### PR TITLE
Feat: 여행기록 추가, 삭제, 수정 기능 추가

### DIFF
--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
             implementation(compose.foundation)
             implementation(compose.material3)
             implementation(compose.ui)
+            implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0") // Use the latest version
         }
     }
 }

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -10,6 +10,8 @@ kotlin {
         namespace = "com.mapmory.shared"
         compileSdk = libs.versions.compileSdk.get().toInt()
         minSdk = libs.versions.minSdk.get().toInt()
+
+        withHostTest {}
     }
     iosArm64()
     iosSimulatorArm64()
@@ -21,6 +23,10 @@ kotlin {
             implementation(compose.material3)
             implementation(compose.ui)
             implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.8.0") // Use the latest version
+        }
+
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
     }
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
@@ -1,10 +1,10 @@
 package com.mapmory.shared.domain
 
 import kotlinx.datetime.LocalDate
-import kotlin.uuid.Uuid
+import kotlin.random.Random
 
 data class TripRecord(
-    val id: Uuid = Uuid.random(),
+    val id: Long = Random.nextLong(from = 1L, until = Long.MAX_VALUE),
     val imageUrl: String,
     val tripRecordTitle: String,
     val tripRecordDescription: String?,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
@@ -1,5 +1,6 @@
 package com.mapmory.shared.domain
 
+import kotlinx.datetime.LocalDate
 import kotlin.uuid.Uuid
 
 data class TripRecord(
@@ -7,5 +8,7 @@ data class TripRecord(
     val imageUrl: String,
     val tripRecordTitle: String,
     val tripRecordDescription: String?,
+    val startTripDate: LocalDate,
+    val endTripDate: LocalDate,
     val location: String,
 )

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
@@ -1,0 +1,11 @@
+package com.mapmory.shared.domain
+
+import kotlin.uuid.Uuid
+
+data class TripRecord(
+    val id: Uuid = Uuid.random(),
+    val imageUrl: String,
+    val tripRecordTitle: String,
+    val tripRecordDescription: String?,
+    val location: String,
+)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
@@ -11,4 +11,10 @@ data class TripRecord(
     val startTripDate: LocalDate,
     val endTripDate: LocalDate,
     val location: String,
-)
+) {
+    init {
+        require(startTripDate <= endTripDate) {
+            "여행 시작일은 종료일보다 늦을 수 없습니다"
+        }
+    }
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
@@ -1,7 +1,6 @@
 package com.mapmory.shared.domain
 
 import kotlinx.datetime.LocalDate
-import kotlin.uuid.Uuid
 
 class TripRecords(
     tripRecords: List<TripRecord> = emptyList(),
@@ -62,6 +61,6 @@ class TripRecords(
         )
     }
 
-    private fun findTripRecordId(id: Uuid): TripRecord? = records.find { it.id == id }
+    private fun findTripRecordId(id: Long): TripRecord? = records.find { it.id == id }
 
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
@@ -42,6 +42,8 @@ class TripRecords(
         editingImage: String?,
         editingTitle: String?,
         editingDescription: String?,
+        editingStartTripDate: LocalDate?,
+        editingEndTripDate: LocalDate?,
         editingLocation: String?,
     ): TripRecords {
         val record = findTripRecordId(editingRecord.id)
@@ -51,6 +53,8 @@ class TripRecords(
             imageUrl = editingImage ?: record.imageUrl,
             tripRecordTitle = editingTitle ?: record.tripRecordTitle,
             tripRecordDescription = editingDescription ?: record.tripRecordDescription,
+            startTripDate = editingStartTripDate ?: record.startTripDate,
+            endTripDate = editingEndTripDate ?: record.endTripDate,
             location = editingLocation ?: record.location,
         )
 

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
@@ -1,5 +1,6 @@
 package com.mapmory.shared.domain
 
+import kotlinx.datetime.LocalDate
 import kotlin.uuid.Uuid
 
 class TripRecords(
@@ -7,7 +8,7 @@ class TripRecords(
 ) {
     private val records: List<TripRecord> = tripRecords.toList()
 
-    val _tripRecords: List<TripRecord>
+    val tripRecords: List<TripRecord>
         get() = records.toList()
 
     fun addTripRecord(
@@ -15,12 +16,16 @@ class TripRecords(
         tripRecordTitle: String,
         tripRecordDescription: String?,
         tripLocation: String,
+        startTripDate: LocalDate,
+        endTripDate: LocalDate,
     ): TripRecords {
         val newRecord = TripRecord(
             imageUrl = imageUri,
             tripRecordTitle = tripRecordTitle,
             tripRecordDescription = tripRecordDescription,
-            location = tripLocation
+            location = tripLocation,
+            startTripDate = startTripDate,
+            endTripDate = endTripDate,
         )
         return TripRecords(records + newRecord)
     }
@@ -28,12 +33,35 @@ class TripRecords(
     fun removeTripRecord(
         deletingRecord: TripRecord
     ): TripRecords {
-        val record = records.find { it.id == deletingRecord.id }
-        if(record == null) return this
+        val record = findTripRecordId(deletingRecord.id) ?: return this
 
         return TripRecords(records.minus(record))
     }
 
-    private fun findTripRecordId(id: Uuid): Uuid? = records.find { it.id == id }?.id
+    fun editTripRecord(
+        editingRecord: TripRecord,
+        editingImage: String?,
+        editingTitle: String?,
+        editingDescription: String?,
+        editingLocation: String?,
+    ): TripRecords {
+        val record = findTripRecordId(editingRecord.id)
+            ?: throw IllegalArgumentException("해당 id를 찾을 수 없습니다")
+
+        val editedRecord = record.copy(
+            imageUrl = editingImage ?: record.imageUrl,
+            tripRecordTitle = editingTitle ?: record.tripRecordTitle,
+            tripRecordDescription = editingDescription ?: record.tripRecordDescription,
+            location = editingLocation ?: record.location,
+        )
+
+        return TripRecords(
+            records.map { currentRecord ->
+                if (currentRecord.id == record.id) editedRecord else currentRecord
+            },
+        )
+    }
+
+    private fun findTripRecordId(id: Uuid): TripRecord? = records.find { it.id == id }
 
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
@@ -1,5 +1,7 @@
 package com.mapmory.shared.domain
 
+import kotlin.uuid.Uuid
+
 class TripRecords(
     tripRecords: List<TripRecord> = emptyList(),
 ) {
@@ -20,6 +22,18 @@ class TripRecords(
             tripRecordDescription = tripRecordDescription,
             location = tripLocation
         )
-        return TripRecords(_tripRecords + newRecord)
+        return TripRecords(records + newRecord)
     }
+
+    fun removeTripRecord(
+        deletingRecord: TripRecord
+    ): TripRecords {
+        val record = records.find { it.id == deletingRecord.id }
+        if(record == null) return this
+
+        return TripRecords(records.minus(record))
+    }
+
+    private fun findTripRecordId(id: Uuid): Uuid? = records.find { it.id == id }?.id
+
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
@@ -1,0 +1,25 @@
+package com.mapmory.shared.domain
+
+class TripRecords(
+    tripRecords: List<TripRecord> = emptyList(),
+) {
+    private val records: List<TripRecord> = tripRecords.toList()
+
+    val _tripRecords: List<TripRecord>
+        get() = records.toList()
+
+    fun addTripRecord(
+        imageUri: String,
+        tripRecordTitle: String,
+        tripRecordDescription: String?,
+        tripLocation: String,
+    ): TripRecords {
+        val newRecord = TripRecord(
+            imageUrl = imageUri,
+            tripRecordTitle = tripRecordTitle,
+            tripRecordDescription = tripRecordDescription,
+            location = tripLocation
+        )
+        return TripRecords(_tripRecords + newRecord)
+    }
+}

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordTest.kt
@@ -1,0 +1,79 @@
+package com.mapmory.shared.domain
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TripRecordTest {
+    @Test
+    fun `시작일과 종료일이 같은 당일 여행을 생성할 수 있다`() {
+        val date = LocalDate(2026, 8, 7)
+
+        val record = createTripRecord(
+            startTripDate = date,
+            endTripDate = date,
+        )
+
+        assertEquals(date, record.startTripDate)
+        assertEquals(date, record.endTripDate)
+    }
+
+    @Test
+    fun `시작일이 종료일보다 늦으면 여행 기록을 생성할 수 없다`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            createTripRecord(
+                startTripDate = LocalDate(2026, 8, 8),
+                endTripDate = LocalDate(2026, 8, 7),
+            )
+        }
+
+        assertEquals("여행 시작일은 종료일보다 늦을 수 없습니다", exception.message)
+    }
+
+    @Test
+    fun `연도 경계를 넘는 여행을 생성할 수 있다`() {
+        val record = createTripRecord(
+            startTripDate = LocalDate(2026, 12, 31),
+            endTripDate = LocalDate(2027, 1, 1),
+        )
+
+        assertTrue(record.startTripDate < record.endTripDate)
+    }
+
+    @Test
+    fun `ID는 Long 타입으로 지정한 값을 유지한다`() {
+        val record = createTripRecord(id = Long.MAX_VALUE)
+
+        assertEquals(Long.MAX_VALUE, record.id)
+    }
+
+    @Test
+    fun `자동 생성된 ID는 양수다`() {
+        val record = TripRecord(
+            imageUrl = "image.jpg",
+            tripRecordTitle = "제주도 여행",
+            tripRecordDescription = "여행 기록",
+            startTripDate = LocalDate(2026, 8, 1),
+            endTripDate = LocalDate(2026, 8, 3),
+            location = "제주도",
+        )
+
+        assertTrue(record.id > 0L)
+    }
+
+    private fun createTripRecord(
+        id: Long = 1L,
+        startTripDate: LocalDate = LocalDate(2026, 8, 1),
+        endTripDate: LocalDate = LocalDate(2026, 8, 3),
+    ): TripRecord = TripRecord(
+        id = id,
+        imageUrl = "image.jpg",
+        tripRecordTitle = "제주도 여행",
+        tripRecordDescription = "여행 기록",
+        startTripDate = startTripDate,
+        endTripDate = endTripDate,
+        location = "제주도",
+    )
+}

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordsTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordsTest.kt
@@ -1,0 +1,181 @@
+package com.mapmory.shared.domain
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+class TripRecordsTest {
+    @Test
+    fun `여행 기록을 추가한다`() {
+        val tripRecords = TripRecords()
+
+        val result = tripRecords.addTripRecord(
+            imageUri = "image.jpg",
+            tripRecordTitle = "제주도 여행",
+            tripRecordDescription = "성산일출봉을 다녀왔다",
+            tripLocation = "제주도",
+            startTripDate = LocalDate(2026, 8, 1),
+            endTripDate = LocalDate(2026, 8, 3),
+        )
+
+        assertEquals(0, tripRecords.tripRecords.size)
+        assertEquals(1, result.tripRecords.size)
+        assertEquals("제주도 여행", result.tripRecords.single().tripRecordTitle)
+    }
+
+    @Test
+    fun `시작일이 종료일보다 늦은 여행 기록은 추가할 수 없다`() {
+        val tripRecords = TripRecords()
+
+        assertFailsWith<IllegalArgumentException> {
+            tripRecords.addTripRecord(
+                imageUri = "image.jpg",
+                tripRecordTitle = "잘못된 여행",
+                tripRecordDescription = null,
+                tripLocation = "제주도",
+                startTripDate = LocalDate(2026, 8, 8),
+                endTripDate = LocalDate(2026, 8, 7),
+            )
+        }
+        assertEquals(emptyList(), tripRecords.tripRecords)
+    }
+
+    @Test
+    fun `여행 기록을 삭제한다`() {
+        val record = createTripRecord()
+        val tripRecords = TripRecords(listOf(record))
+
+        val result = tripRecords.removeTripRecord(record)
+
+        assertEquals(emptyList(), result.tripRecords)
+    }
+
+    @Test
+    fun `존재하지 않는 여행 기록을 삭제하면 기존 객체를 반환한다`() {
+        val tripRecords = TripRecords(listOf(createTripRecord(id = 1L)))
+
+        val result = tripRecords.removeTripRecord(createTripRecord(id = 2L))
+
+        assertSame(tripRecords, result)
+    }
+
+    @Test
+    fun `빈 목록에서 여행 기록을 삭제하면 기존 객체를 반환한다`() {
+        val tripRecords = TripRecords()
+
+        val result = tripRecords.removeTripRecord(createTripRecord())
+
+        assertSame(tripRecords, result)
+    }
+
+    @Test
+    fun `내용이 달라도 ID가 같은 여행 기록을 삭제한다`() {
+        val storedRecord = createTripRecord(id = 1L, title = "저장된 제목")
+        val deletingRecord = createTripRecord(id = 1L, title = "변경된 제목")
+        val tripRecords = TripRecords(listOf(storedRecord))
+
+        val result = tripRecords.removeTripRecord(deletingRecord)
+
+        assertEquals(emptyList(), result.tripRecords)
+    }
+
+    @Test
+    fun `여행 기록의 전달된 필드만 수정한다`() {
+        val record = createTripRecord()
+        val tripRecords = TripRecords(listOf(record))
+
+        val result = tripRecords.editTripRecord(
+            editingRecord = record,
+            editingImage = null,
+            editingTitle = "수정된 제목",
+            editingDescription = null,
+            editingLocation = "부산",
+        )
+
+        val editedRecord = result.tripRecords.single()
+        assertNotSame(tripRecords, result)
+        assertEquals(record.id, editedRecord.id)
+        assertEquals(record.imageUrl, editedRecord.imageUrl)
+        assertEquals("수정된 제목", editedRecord.tripRecordTitle)
+        assertEquals(record.tripRecordDescription, editedRecord.tripRecordDescription)
+        assertEquals("부산", editedRecord.location)
+        assertEquals(record.startTripDate, editedRecord.startTripDate)
+        assertEquals(record.endTripDate, editedRecord.endTripDate)
+    }
+
+    @Test
+    fun `여행 기록을 수정해도 목록 순서는 유지된다`() {
+        val firstRecord = createTripRecord(id = 1L, title = "첫 번째")
+        val secondRecord = createTripRecord(id = 2L, title = "두 번째")
+        val tripRecords = TripRecords(listOf(firstRecord, secondRecord))
+
+        val result = tripRecords.editTripRecord(
+            editingRecord = firstRecord,
+            editingImage = null,
+            editingTitle = "수정된 첫 번째",
+            editingDescription = null,
+            editingLocation = null,
+        )
+
+        assertEquals(listOf(firstRecord.id, secondRecord.id), result.tripRecords.map { it.id })
+        assertEquals("수정된 첫 번째", result.tripRecords.first().tripRecordTitle)
+    }
+
+    @Test
+    fun `수정할 필드가 없으면 기록 내용을 유지한다`() {
+        val record = createTripRecord()
+        val tripRecords = TripRecords(listOf(record))
+
+        val result = tripRecords.editTripRecord(
+            editingRecord = record,
+            editingImage = null,
+            editingTitle = null,
+            editingDescription = null,
+            editingLocation = null,
+        )
+
+        assertEquals(record, result.tripRecords.single())
+        assertEquals(record, tripRecords.tripRecords.single())
+    }
+
+    @Test
+    fun `존재하지 않는 여행 기록을 수정하면 예외가 발생한다`() {
+        val tripRecords = TripRecords(listOf(createTripRecord(id = 1L)))
+
+        assertFailsWith<IllegalArgumentException> {
+            tripRecords.editTripRecord(
+                editingRecord = createTripRecord(id = 2L),
+                editingImage = null,
+                editingTitle = "수정된 제목",
+                editingDescription = null,
+                editingLocation = null,
+            )
+        }
+    }
+
+    @Test
+    fun `생성자에 전달한 목록이 바뀌어도 여행 기록 목록은 바뀌지 않는다`() {
+        val source = mutableListOf(createTripRecord(id = 1L))
+        val tripRecords = TripRecords(source)
+
+        source += createTripRecord(id = 2L)
+
+        assertEquals(listOf(1L), tripRecords.tripRecords.map { it.id })
+    }
+
+    private fun createTripRecord(
+        id: Long = 1L,
+        title: String = "제주도 여행",
+    ): TripRecord = TripRecord(
+        id = id,
+        imageUrl = "image.jpg",
+        tripRecordTitle = title,
+        tripRecordDescription = "여행 기록",
+        startTripDate = LocalDate(2026, 8, 1),
+        endTripDate = LocalDate(2026, 8, 3),
+        location = "제주도",
+    )
+}

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordsTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordsTest.kt
@@ -92,6 +92,8 @@ class TripRecordsTest {
             editingImage = null,
             editingTitle = "수정된 제목",
             editingDescription = null,
+            editingStartTripDate = null,
+            editingEndTripDate = null,
             editingLocation = "부산",
         )
 
@@ -117,6 +119,8 @@ class TripRecordsTest {
             editingImage = null,
             editingTitle = "수정된 첫 번째",
             editingDescription = null,
+            editingStartTripDate = null,
+            editingEndTripDate = null,
             editingLocation = null,
         )
 
@@ -134,10 +138,93 @@ class TripRecordsTest {
             editingImage = null,
             editingTitle = null,
             editingDescription = null,
+            editingStartTripDate = null,
+            editingEndTripDate = null,
             editingLocation = null,
         )
 
         assertEquals(record, result.tripRecords.single())
+        assertEquals(record, tripRecords.tripRecords.single())
+    }
+
+    @Test
+    fun `여행 시작일과 종료일을 함께 수정한다`() {
+        val record = createTripRecord()
+        val tripRecords = TripRecords(listOf(record))
+        val editingStartTripDate = LocalDate(2026, 9, 1)
+        val editingEndTripDate = LocalDate(2026, 9, 5)
+
+        val result = tripRecords.editTripRecord(
+            editingRecord = record,
+            editingImage = null,
+            editingTitle = null,
+            editingDescription = null,
+            editingStartTripDate = editingStartTripDate,
+            editingEndTripDate = editingEndTripDate,
+            editingLocation = null,
+        )
+
+        val editedRecord = result.tripRecords.single()
+        assertEquals(editingStartTripDate, editedRecord.startTripDate)
+        assertEquals(editingEndTripDate, editedRecord.endTripDate)
+    }
+
+    @Test
+    fun `시작일만 수정하면 기존 종료일을 유지한다`() {
+        val record = createTripRecord()
+        val tripRecords = TripRecords(listOf(record))
+        val editingStartTripDate = LocalDate(2026, 8, 2)
+
+        val result = tripRecords.editTripRecord(
+            editingRecord = record,
+            editingImage = null,
+            editingTitle = null,
+            editingDescription = null,
+            editingStartTripDate = editingStartTripDate,
+            editingEndTripDate = null,
+            editingLocation = null,
+        )
+
+        val editedRecord = result.tripRecords.single()
+        assertEquals(editingStartTripDate, editedRecord.startTripDate)
+        assertEquals(record.endTripDate, editedRecord.endTripDate)
+    }
+
+    @Test
+    fun `수정한 시작일이 종료일보다 늦으면 예외가 발생한다`() {
+        val record = createTripRecord()
+        val tripRecords = TripRecords(listOf(record))
+
+        assertFailsWith<IllegalArgumentException> {
+            tripRecords.editTripRecord(
+                editingRecord = record,
+                editingImage = null,
+                editingTitle = null,
+                editingDescription = null,
+                editingStartTripDate = LocalDate(2026, 8, 4),
+                editingEndTripDate = null,
+                editingLocation = null,
+            )
+        }
+        assertEquals(record, tripRecords.tripRecords.single())
+    }
+
+    @Test
+    fun `수정한 종료일이 시작일보다 빠르면 예외가 발생한다`() {
+        val record = createTripRecord()
+        val tripRecords = TripRecords(listOf(record))
+
+        assertFailsWith<IllegalArgumentException> {
+            tripRecords.editTripRecord(
+                editingRecord = record,
+                editingImage = null,
+                editingTitle = null,
+                editingDescription = null,
+                editingStartTripDate = null,
+                editingEndTripDate = LocalDate(2026, 7, 31),
+                editingLocation = null,
+            )
+        }
         assertEquals(record, tripRecords.tripRecords.single())
     }
 
@@ -151,6 +238,8 @@ class TripRecordsTest {
                 editingImage = null,
                 editingTitle = "수정된 제목",
                 editingDescription = null,
+                editingStartTripDate = null,
+                editingEndTripDate = null,
                 editingLocation = null,
             )
         }


### PR DESCRIPTION
### 구현한 기능
- 여행 기록 생성
  - [x] 여행 기록은 id, 제목, 시작/끝 날짜, 설명, 위치를 갖는다
  - [x] 시작 날짜는 끝 날짜보다 나중일 수 없다

- 여행 기록 추가 삭제 수정 기능
  - [x] 여행 기록 추가
    - [x] 시작일이 종료일보다 늦은 여행 기록은 추가할 수 없다
  - [x] 여행 기록 삭제
    - [x] 빈 목록에서 여행 기록을 삭제하면 기존 객체를 반환한다 
    - [x] 존재하지 않는 여행 기록을 삭제하면 기존 객체를 반환한다
  - [x] 여행 기록 수정
    - [x] 여행 기록의 전달된 필드만 수정한다
    - [x] 여행 기록을 수정해도 목록 순서는 유지된다 
    - [x] 수정할 필드가 없으면 기록 내용을 유지한다
    - [x] 존재하지 않는 여행 기록을 수정하면 예외가 발생한다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trip records with titles, dates, locations, images, and optional descriptions.
  * Added validation to prevent trips from ending before they start.
  * Added functionality to create, edit, remove, and list trip records while preserving ordering.

* **Tests**
  * Added coverage for date validation, record management, editing, deletion, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->