### PR TITLE
[feat] android/ios 사진 미디어 및 갤러리 접근 권한 제공

### DIFF
--- a/client/androidApp/src/main/AndroidManifest.xml
+++ b/client/androidApp/src/main/AndroidManifest.xml
@@ -1,4 +1,26 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <!-- Android 12L (API 32) 이하의 전체 갤러리 읽기 -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
+    <!-- Android 9 (API 28)에서 촬영한 사진을 공유 갤러리에 저장 -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+
+    <!-- Android 13 (API 33) 이상의 전체 사진 읽기 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
+    <!-- Android 14 (API 34) 이상의 선택한 사진 접근 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+
+    <uses-feature
+        android:name="android.hardware.camera.any"
+        android:required="false" />
+
     <application
         android:label="Mapmory"
         android:theme="@style/Theme.Mapmory">

--- a/client/androidApp/src/main/java/com/mapmory/android/MainActivity.kt
+++ b/client/androidApp/src/main/java/com/mapmory/android/MainActivity.kt
@@ -3,11 +3,46 @@ package com.mapmory.android
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import com.mapmory.android.permission.GalleryAccess
+import com.mapmory.android.permission.currentGalleryAccess
+import com.mapmory.android.permission.hasCameraPermission
+import com.mapmory.android.permission.rememberMediaPermissionRequesters
+import com.mapmory.shared.GalleryPermissionState
 import com.mapmory.shared.MapmoryApp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent { MapmoryApp() }
+        setContent {
+            val context = LocalContext.current
+            var isCameraPermissionGranted by remember {
+                mutableStateOf(context.hasCameraPermission())
+            }
+            var galleryAccess by remember {
+                mutableStateOf(context.currentGalleryAccess())
+            }
+            val permissionRequesters = rememberMediaPermissionRequesters(
+                onCameraPermissionResult = { isCameraPermissionGranted = it },
+                onGalleryPermissionResult = { galleryAccess = it },
+            )
+
+            MapmoryApp(
+                isCameraPermissionGranted = isCameraPermissionGranted,
+                galleryPermissionState = galleryAccess.toPermissionState(),
+                onRequestCameraPermission = permissionRequesters.requestCamera,
+                onRequestGalleryPermission = permissionRequesters.requestGallery,
+            )
+        }
     }
+}
+
+private fun GalleryAccess.toPermissionState(): GalleryPermissionState = when (this) {
+    GalleryAccess.FULL -> GalleryPermissionState.FULL
+    GalleryAccess.PARTIAL -> GalleryPermissionState.PARTIAL
+    GalleryAccess.DENIED -> GalleryPermissionState.DENIED
 }

--- a/client/androidApp/src/main/java/com/mapmory/android/permission/MediaPermissionManager.kt
+++ b/client/androidApp/src/main/java/com/mapmory/android/permission/MediaPermissionManager.kt
@@ -1,0 +1,88 @@
+package com.mapmory.android.permission
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+enum class GalleryAccess {
+    FULL,
+    PARTIAL,
+    DENIED,
+}
+
+data class MediaPermissionRequesters(
+    val requestCamera: () -> Unit,
+    val requestGallery: () -> Unit,
+)
+
+@Composable
+fun rememberMediaPermissionRequesters(
+    onCameraPermissionResult: (Boolean) -> Unit,
+    onGalleryPermissionResult: (GalleryAccess) -> Unit,
+): MediaPermissionRequesters {
+    val context = LocalContext.current
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = onCameraPermissionResult,
+    )
+    val galleryPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+    ) {
+        onGalleryPermissionResult(context.currentGalleryAccess())
+    }
+
+    return remember(cameraPermissionLauncher, galleryPermissionLauncher) {
+        MediaPermissionRequesters(
+            requestCamera = {
+                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+            },
+            requestGallery = {
+                galleryPermissionLauncher.launch(requiredGalleryPermissions())
+            },
+        )
+    }
+}
+
+fun Context.hasCameraPermission(): Boolean = hasPermission(Manifest.permission.CAMERA)
+
+fun Context.currentGalleryAccess(): GalleryAccess = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+        hasPermission(Manifest.permission.READ_MEDIA_IMAGES) -> GalleryAccess.FULL
+
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+        hasPermission(Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED) -> GalleryAccess.PARTIAL
+
+    Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2 &&
+        hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE) -> GalleryAccess.FULL
+
+    else -> GalleryAccess.DENIED
+}
+
+private fun requiredGalleryPermissions(): Array<String> = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> arrayOf(
+        Manifest.permission.READ_MEDIA_IMAGES,
+        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+    )
+
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> arrayOf(
+        Manifest.permission.READ_MEDIA_IMAGES,
+    )
+
+    Build.VERSION.SDK_INT <= Build.VERSION_CODES.P -> arrayOf(
+        Manifest.permission.READ_EXTERNAL_STORAGE,
+        Manifest.permission.WRITE_EXTERNAL_STORAGE,
+    )
+
+    else -> arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+}
+
+private fun Context.hasPermission(permission: String): Boolean =
+    ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED

--- a/client/iosApp/Info.plist
+++ b/client/iosApp/Info.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>Mapmory</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+    <string>여행 기록에 첨부할 사진을 촬영하기 위해 카메라를 사용합니다.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>여행 기록에 첨부할 사진을 찾기 위해 사진 보관함에 접근합니다.</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>촬영한 여행 사진을 사진 보관함에 저장하기 위해 접근합니다.</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/client/iosApp/Mapmory.xcodeproj/project.pbxproj
+++ b/client/iosApp/Mapmory.xcodeproj/project.pbxproj
@@ -1,0 +1,271 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000000000000000000001 /* MapmoryApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000001 /* MapmoryApp.swift */; };
+		A10000000000000000000002 /* MediaPermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* MediaPermissionManager.swift */; };
+		A10000000000000000000003 /* MediaPermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000005 /* MediaPermissionView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A20000000000000000000001 /* MapmoryApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapmoryApp.swift; sourceTree = "<group>"; };
+		A20000000000000000000002 /* MediaPermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPermissionManager.swift; sourceTree = "<group>"; };
+		A20000000000000000000003 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A20000000000000000000004 /* Mapmory.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mapmory.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A20000000000000000000005 /* MediaPermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPermissionView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A30000000000000000000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A40000000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000001 /* MapmoryApp.swift */,
+				A20000000000000000000002 /* MediaPermissionManager.swift */,
+				A20000000000000000000005 /* MediaPermissionView.swift */,
+				A20000000000000000000003 /* Info.plist */,
+				A40000000000000000000002 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A40000000000000000000002 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A20000000000000000000004 /* Mapmory.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A50000000000000000000001 /* Mapmory */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A90000000000000000000002 /* Build configuration list for PBXNativeTarget "Mapmory" */;
+			buildPhases = (
+				A60000000000000000000001 /* Compile Kotlin Framework */,
+				A70000000000000000000001 /* Sources */,
+				A30000000000000000000001 /* Frameworks */,
+				A80000000000000000000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Mapmory;
+			productName = Mapmory;
+			productReference = A20000000000000000000004 /* Mapmory.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A50000000000000000000002 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2660;
+				LastUpgradeCheck = 2660;
+				TargetAttributes = {
+					A50000000000000000000001 = {
+						CreatedOnToolsVersion = 26.6;
+					};
+				};
+			};
+			buildConfigurationList = A90000000000000000000001 /* Build configuration list for PBXProject "Mapmory" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A40000000000000000000001;
+			productRefGroup = A40000000000000000000002 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A50000000000000000000001 /* Mapmory */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A80000000000000000000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A60000000000000000000001 /* Compile Kotlin Framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Compile Kotlin Framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n    echo \"Skipping Gradle framework build because the IDE already built it\"\n    exit 0\nfi\ncd \"$SRCROOT/..\"\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A70000000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000001 /* MapmoryApp.swift in Sources */,
+				A10000000000000000000002 /* MediaPermissionManager.swift in Sources */,
+				A10000000000000000000003 /* MediaPermissionView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		B10000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B10000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		B20000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					Shared,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapmory.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B20000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					Shared,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapmory.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A90000000000000000000001 /* Build configuration list for PBXProject "Mapmory" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B10000000000000000000001 /* Debug */,
+				B10000000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A90000000000000000000002 /* Build configuration list for PBXNativeTarget "Mapmory" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B20000000000000000000001 /* Debug */,
+				B20000000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A50000000000000000000002 /* Project object */;
+}

--- a/client/iosApp/Mapmory.xcodeproj/xcshareddata/xcschemes/Mapmory.xcscheme
+++ b/client/iosApp/Mapmory.xcodeproj/xcshareddata/xcschemes/Mapmory.xcscheme
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A50000000000000000000001"
+               BuildableName = "Mapmory.app"
+               BlueprintName = "Mapmory"
+               ReferencedContainer = "container:Mapmory.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A50000000000000000000001"
+            BuildableName = "Mapmory.app"
+            BlueprintName = "Mapmory"
+            ReferencedContainer = "container:Mapmory.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A50000000000000000000001"
+            BuildableName = "Mapmory.app"
+            BlueprintName = "Mapmory"
+            ReferencedContainer = "container:Mapmory.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/client/iosApp/MapmoryApp.swift
+++ b/client/iosApp/MapmoryApp.swift
@@ -1,0 +1,30 @@
+import Shared
+import SwiftUI
+
+@main
+struct MapmoryApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ZStack(alignment: .bottom) {
+                ComposeView()
+                    .ignoresSafeArea()
+
+                MediaPermissionView()
+                    .padding()
+            }
+        }
+    }
+}
+
+private struct ComposeView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        let viewController = MainViewControllerKt.MainViewController()
+        viewController.view.backgroundColor = .systemBackground
+        return viewController
+    }
+
+    func updateUIViewController(
+        _ uiViewController: UIViewController,
+        context: Context
+    ) {}
+}

--- a/client/iosApp/MediaPermissionManager.swift
+++ b/client/iosApp/MediaPermissionManager.swift
@@ -1,0 +1,87 @@
+import AVFoundation
+import Photos
+
+enum MediaPermissionStatus: Equatable {
+    case notDetermined
+    case authorized
+    case limited
+    case denied
+    case restricted
+}
+
+enum MediaPermissionManager {
+    static func cameraStatus() -> MediaPermissionStatus {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .notDetermined:
+            return .notDetermined
+        case .authorized:
+            return .authorized
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        @unknown default:
+            return .denied
+        }
+    }
+
+    static func requestCameraAccess() async -> MediaPermissionStatus {
+        guard cameraStatus() == .notDetermined else {
+            return cameraStatus()
+        }
+
+        let granted = await AVCaptureDevice.requestAccess(for: .video)
+        return granted ? .authorized : .denied
+    }
+
+    static func photoLibraryStatus(
+        for accessLevel: PHAccessLevel = .readWrite
+    ) -> MediaPermissionStatus {
+        mapPhotoLibraryStatus(
+            PHPhotoLibrary.authorizationStatus(for: accessLevel)
+        )
+    }
+
+    static func requestPhotoLibraryAccess() async -> MediaPermissionStatus {
+        await requestPhotoLibraryAccess(for: .readWrite)
+    }
+
+    static func requestPhotoLibraryAddAccess() async -> MediaPermissionStatus {
+        await requestPhotoLibraryAccess(for: .addOnly)
+    }
+
+    private static func requestPhotoLibraryAccess(
+        for accessLevel: PHAccessLevel
+    ) async -> MediaPermissionStatus {
+        let currentStatus = photoLibraryStatus(for: accessLevel)
+        guard currentStatus == .notDetermined else {
+            return currentStatus
+        }
+
+        let status = await withCheckedContinuation { continuation in
+            PHPhotoLibrary.requestAuthorization(for: accessLevel) { status in
+                continuation.resume(returning: status)
+            }
+        }
+        return mapPhotoLibraryStatus(status)
+    }
+
+    private static func mapPhotoLibraryStatus(
+        _ status: PHAuthorizationStatus
+    ) -> MediaPermissionStatus {
+        switch status {
+        case .notDetermined:
+            return .notDetermined
+        case .authorized:
+            return .authorized
+        case .limited:
+            return .limited
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        @unknown default:
+            return .denied
+        }
+    }
+}

--- a/client/iosApp/MediaPermissionView.swift
+++ b/client/iosApp/MediaPermissionView.swift
@@ -14,19 +14,19 @@ final class MediaPermissionViewModel: ObservableObject {
     }
 
     func requestCamera() async {
-        guard cameraStatus == .notDetermined else { return }
+        guard cameraStatus == .notDetermined, !isRequestingCamera else { return }
 
         isRequestingCamera = true
+        defer { isRequestingCamera = false }
         cameraStatus = await MediaPermissionManager.requestCameraAccess()
-        isRequestingCamera = false
     }
 
     func requestPhotoLibrary() async {
-        guard photoLibraryStatus == .notDetermined else { return }
+        guard photoLibraryStatus == .notDetermined, !isRequestingPhotoLibrary else { return }
 
         isRequestingPhotoLibrary = true
+        defer { isRequestingPhotoLibrary = false }
         photoLibraryStatus = await MediaPermissionManager.requestPhotoLibraryAccess()
-        isRequestingPhotoLibrary = false
     }
 }
 

--- a/client/iosApp/MediaPermissionView.swift
+++ b/client/iosApp/MediaPermissionView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+import UIKit
+
+@MainActor
+final class MediaPermissionViewModel: ObservableObject {
+    @Published private(set) var cameraStatus = MediaPermissionManager.cameraStatus()
+    @Published private(set) var photoLibraryStatus = MediaPermissionManager.photoLibraryStatus()
+    @Published private(set) var isRequestingCamera = false
+    @Published private(set) var isRequestingPhotoLibrary = false
+
+    func refresh() {
+        cameraStatus = MediaPermissionManager.cameraStatus()
+        photoLibraryStatus = MediaPermissionManager.photoLibraryStatus()
+    }
+
+    func requestCamera() async {
+        guard cameraStatus == .notDetermined else { return }
+
+        isRequestingCamera = true
+        cameraStatus = await MediaPermissionManager.requestCameraAccess()
+        isRequestingCamera = false
+    }
+
+    func requestPhotoLibrary() async {
+        guard photoLibraryStatus == .notDetermined else { return }
+
+        isRequestingPhotoLibrary = true
+        photoLibraryStatus = await MediaPermissionManager.requestPhotoLibraryAccess()
+        isRequestingPhotoLibrary = false
+    }
+}
+
+struct MediaPermissionView: View {
+    @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
+    @StateObject private var viewModel = MediaPermissionViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("사진 접근 권한")
+                .font(.headline)
+
+            permissionRow(
+                title: "카메라",
+                status: viewModel.cameraStatus,
+                isRequesting: viewModel.isRequestingCamera
+            ) {
+                handleCameraAction()
+            }
+
+            permissionRow(
+                title: "사진 보관함",
+                status: viewModel.photoLibraryStatus,
+                isRequesting: viewModel.isRequestingPhotoLibrary
+            ) {
+                handlePhotoLibraryAction()
+            }
+
+            if viewModel.photoLibraryStatus == .limited {
+                Text("일부 사진만 허용되어 있습니다. 전체 갤러리 탐색이 필요하면 설정에서 ‘전체 접근’을 선택해 주세요.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(20)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20))
+        .shadow(radius: 8)
+        .onChange(of: scenePhase) { phase in
+            if phase == .active {
+                viewModel.refresh()
+            }
+        }
+    }
+
+    private func permissionRow(
+        title: String,
+        status: MediaPermissionStatus,
+        isRequesting: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.body.weight(.semibold))
+                Text(status.description)
+                    .font(.caption)
+                    .foregroundStyle(status.tintColor)
+            }
+
+            Spacer()
+
+            Button(status.actionTitle, action: action)
+                .buttonStyle(.borderedProminent)
+                .disabled(status == .authorized || status == .restricted || isRequesting)
+        }
+    }
+
+    private func handleCameraAction() {
+        if viewModel.cameraStatus == .notDetermined {
+            Task { await viewModel.requestCamera() }
+        } else {
+            openSettings()
+        }
+    }
+
+    private func handlePhotoLibraryAction() {
+        if viewModel.photoLibraryStatus == .notDetermined {
+            Task { await viewModel.requestPhotoLibrary() }
+        } else {
+            openSettings()
+        }
+    }
+
+    private func openSettings() {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        openURL(settingsURL)
+    }
+}
+
+private extension MediaPermissionStatus {
+    var description: String {
+        switch self {
+        case .notDetermined:
+            return "요청 전"
+        case .authorized:
+            return "허용됨"
+        case .limited:
+            return "일부 사진만 허용됨"
+        case .denied:
+            return "거부됨"
+        case .restricted:
+            return "기기 정책으로 제한됨"
+        }
+    }
+
+    var actionTitle: String {
+        switch self {
+        case .notDetermined:
+            return "권한 요청"
+        case .authorized:
+            return "허용됨"
+        case .limited, .denied:
+            return "설정 열기"
+        case .restricted:
+            return "제한됨"
+        }
+    }
+
+    var tintColor: Color {
+        switch self {
+        case .authorized:
+            return .green
+        case .limited:
+            return .orange
+        case .notDetermined:
+            return .secondary
+        case .denied, .restricted:
+            return .red
+        }
+    }
+}

--- a/client/iosApp/README.md
+++ b/client/iosApp/README.md
@@ -4,9 +4,21 @@
 
 ## 초기 설정
 
-1. Xcode 26.4 계열 설치
+1. Xcode 26.4 이상 설치
 2. iOS Deployment Target 16.0 설정
-3. Gradle로 `shared`의 iOS framework 생성
-4. Xcode에서 Simulator와 실제 기기 빌드
+3. Xcode에서 `Mapmory.xcodeproj`를 열기
+4. 실제 기기 빌드 시 Signing Team과 Bundle Identifier 설정
+5. `Mapmory` scheme으로 Simulator 또는 실제 기기 빌드
 
-Xcode 프로젝트 파일은 팀의 Apple Developer Bundle ID와 서명 팀이 정해진 뒤 추가합니다.
+## 미디어 권한
+
+- 카메라: `NSCameraUsageDescription`
+- 전체 사진 보관함 읽기/쓰기: `NSPhotoLibraryUsageDescription`
+- 사진 보관함에 추가만 하기: `NSPhotoLibraryAddUsageDescription`
+
+권한은 앱 실행 시 자동으로 요청하지 않고, 사용자가 카메라나 갤러리 기능을 선택한 시점에
+`MediaPermissionManager`를 통해 요청한다. `.limited`는 사용자가 일부 사진만 허용한 상태이므로 전체 허용과
+구분해야 한다.
+
+Xcode의 Build Phase가 Gradle `:shared:embedAndSignAppleFrameworkForXcode` 작업을 실행해 공통 Compose UI를
+`Shared.framework`로 연결한다.

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -13,8 +13,15 @@ kotlin {
 
         withHostTest {}
     }
-    iosArm64()
-    iosSimulatorArm64()
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "Shared"
+            isStatic = true
+        }
+    }
 
     sourceSets {
         commonMain.dependencies {

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -1,9 +1,18 @@
 package com.mapmory.shared
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 
 @Composable
 fun MapmoryApp() {
-    Text("Mapmory")
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("Mapmory")
+    }
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -1,18 +1,61 @@
 package com.mapmory.shared
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
-fun MapmoryApp() {
-    Box(
+fun MapmoryApp(
+    isCameraPermissionGranted: Boolean? = null,
+    galleryPermissionState: GalleryPermissionState? = null,
+    onRequestCameraPermission: (() -> Unit)? = null,
+    onRequestGalleryPermission: (() -> Unit)? = null,
+) {
+    Column(
         modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
     ) {
         Text("Mapmory")
+
+        if (onRequestCameraPermission != null) {
+            Spacer(Modifier.height(16.dp))
+            Button(
+                onClick = onRequestCameraPermission,
+                enabled = isCameraPermissionGranted != true,
+            ) {
+                Text(if (isCameraPermissionGranted == true) "카메라 허용됨" else "카메라 권한 요청")
+            }
+        }
+
+        if (onRequestGalleryPermission != null) {
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = onRequestGalleryPermission,
+                enabled = galleryPermissionState != GalleryPermissionState.FULL,
+            ) {
+                Text(galleryPermissionState.galleryButtonText())
+            }
+        }
     }
+}
+
+enum class GalleryPermissionState {
+    FULL,
+    PARTIAL,
+    DENIED,
+}
+
+private fun GalleryPermissionState?.galleryButtonText(): String = when (this) {
+    GalleryPermissionState.FULL -> "갤러리 허용됨"
+    GalleryPermissionState.PARTIAL -> "사진 추가 선택"
+    GalleryPermissionState.DENIED, null -> "갤러리 권한 요청"
 }

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/MainViewController.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/MainViewController.kt
@@ -1,0 +1,7 @@
+package com.mapmory.shared
+
+import androidx.compose.ui.window.ComposeUIViewController
+
+fun MainViewController() = ComposeUIViewController {
+    MapmoryApp()
+}


### PR DESCRIPTION
## 구현한 기능
### Android 미디어 권한

  - 카메라 권한 추가
  - Android 버전에 따른 갤러리 권한 분기
      - Android 12L 이하: 저장소 읽기 권한
      - Android 13 이상: 사진 읽기 권한
      - Android 14 이상: 선택한 사진 접근 권한

  - 전체 접근, 일부 접근, 거부 상태 구분
  - 카메라가 없는 기기에서도 설치할 수 있도록 카메라 기능을 선택 사항
    으로 설정

  ### iOS 앱 실행 환경

  - Compose Multiplatform 공통 UI를 실행하는 Xcode 프로젝트 구성
  - iOS Device 및 Apple Silicon Simulator 타깃 추가
  - Shared.framework 자동 빌드·연결
  - SwiftUI에서 ComposeUIViewController를 표시하도록 앱 진입점 구성
  - Compose iOS 실행에 필요한 Info.plist 설정 추가

  ### iOS 미디어 권한

  - 카메라 접근 권한 선언 및 요청
  - 사진 보관함 읽기·쓰기 권한 선언 및 요청
  - 사진 보관함 추가 전용 권한 설명 추가
  - 권한 상태 구분pb

  - 권한 상태와 요청 버튼을 표시하는 화면 추가
  - 거부 또는 일부 허용 상태에서 시스템 설정으로 이동하는 기능 추가
  - 앱이 다시 활성화될 때 변경된 권한 상태 갱신
  - 중복 권한 요청 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initial iOS app support with shared Compose content.
  * Added camera and photo-library permission handling on iOS and Android.
  * Added guidance for limited photo-library access and links to system settings.
  * Added Android support for version-specific media permissions and optional camera hardware.
* **Documentation**
  * Updated iOS setup instructions, signing requirements, permissions, and build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->