### PR TITLE
feat: 대략적인 화면 구현

### DIFF
--- a/client/androidApp/src/main/java/com/mapmory/android/MainActivity.kt
+++ b/client/androidApp/src/main/java/com/mapmory/android/MainActivity.kt
@@ -3,16 +3,13 @@ package com.mapmory.android
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.ui.res.painterResource
 import com.mapmory.shared.MapmoryApp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MapmoryApp(
-                globePainter = { painterResource(R.drawable.globe_hero) },
-            )
+            MapmoryApp()
         }
     }
 }

--- a/client/androidApp/src/main/java/com/mapmory/android/ScreenPreviews.kt
+++ b/client/androidApp/src/main/java/com/mapmory/android/ScreenPreviews.kt
@@ -1,16 +1,10 @@
 package com.mapmory.android
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.mapmory.shared.MapmoryApp
 import com.mapmory.shared.domain.model.Location
@@ -18,6 +12,7 @@ import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.domain.model.TripRecordData
 import com.mapmory.shared.domain.model.TripRecordMedia
 import com.mapmory.shared.domain.model.TripRecordQuery
+import com.mapmory.shared.presentation.triprecord.screen.TripMapArtwork
 import com.mapmory.shared.presentation.triprecord.screen.TripMapScreen
 import com.mapmory.shared.presentation.triprecord.screen.TripRecordDetailScreen
 import com.mapmory.shared.presentation.triprecord.screen.TripRecordEditorScreen
@@ -27,16 +22,14 @@ import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorUiState
 import com.mapmory.shared.presentation.triprecord.state.TripRecordListUiState
 
 @Preview(
-    name = "Mapmory 랜딩",
+    name = "지도",
     showBackground = true,
     widthDp = 412,
     heightDp = 900,
 )
 @Composable
 fun MapmoryAppPreview() {
-    MapmoryApp(
-        globePainter = { painterResource(R.drawable.globe_hero) },
-    )
+    MapmoryApp()
 }
 
 @Preview(
@@ -127,16 +120,7 @@ fun TripRecordEditorScreenPreview() {
 fun TripMapScreenPreview() {
     PreviewTheme {
         TripMapScreen(
-            mapContent = {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(Color(0xFFE6F0E3)),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text("지도 SDK 영역")
-                }
-            },
+            mapContent = { TripMapArtwork() },
             onBackClick = {},
         )
     }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -1,100 +1,229 @@
 package com.mapmory.shared
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.mapmory.shared.domain.model.Location
+import com.mapmory.shared.domain.model.LocationType
+import com.mapmory.shared.domain.model.TripRecordData
+import com.mapmory.shared.domain.model.TripRecordQuery
+import com.mapmory.shared.presentation.triprecord.screen.TripMapArtwork
+import com.mapmory.shared.presentation.triprecord.screen.TripMapScreen
+import com.mapmory.shared.presentation.triprecord.screen.TripProfileScreen
+import com.mapmory.shared.presentation.triprecord.screen.TripRecordDetailScreen
+import com.mapmory.shared.presentation.triprecord.screen.TripRecordEditorScreen
+import com.mapmory.shared.presentation.triprecord.screen.TripRecordListScreen
+import com.mapmory.shared.presentation.triprecord.state.TripRecordDetailUiState
+import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorUiState
+import com.mapmory.shared.presentation.triprecord.state.TripRecordListUiState
+
+private enum class AppDestination {
+    MAP,
+    RECORDS,
+    CREATE,
+    PROFILE,
+    DETAIL,
+}
 
 @Composable
+@Suppress("UNUSED_PARAMETER")
 fun MapmoryApp(
     globePainter: @Composable () -> Painter,
 ) {
-    GlobeLandingScreen(globePainter = globePainter)
-}
-
-@Composable
-private fun GlobeLandingScreen(
-    globePainter: @Composable () -> Painter,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(
-                Brush.verticalGradient(
-                    colors = listOf(
-                        Color(0xFFF8FCFF),
-                        Color(0xFFEAF5FF),
-                    ),
-                ),
-            )
-            .padding(horizontal = 24.dp, vertical = 28.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            text = "MAPMORY",
-            color = Color(0xFF3A78B8),
-            fontSize = 15.sp,
-            fontWeight = FontWeight.Bold,
-            letterSpacing = 3.sp,
+    var destination by remember { mutableStateOf(AppDestination.MAP) }
+    var editorReturnDestination by remember { mutableStateOf(AppDestination.MAP) }
+    var selectedRecordId by remember { mutableStateOf<Long?>(null) }
+    var records by remember { mutableStateOf(emptyList<TripRecordData>()) }
+    var query by remember { mutableStateOf(TripRecordQuery()) }
+    var editorState by remember {
+        mutableStateOf(
+            TripRecordEditorUiState(
+                selectedLocation = appLocations.firstOrNull { it.type == LocationType.DISTRICT },
+            ),
         )
+    }
 
-        Card(
-            shape = RoundedCornerShape(32.dp),
-            colors = CardDefaults.cardColors(containerColor = Color.Transparent),
-            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f)
-                .padding(top = 20.dp)
-                .clip(RoundedCornerShape(32.dp)),
-        ) {
-            Image(
-                painter = globePainter(),
-                contentDescription = "여행 기록을 상징하는 지구본",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize(),
-            )
-        }
+    fun openCreateScreen(returnTo: AppDestination) {
+        editorReturnDestination = returnTo
+        editorState = TripRecordEditorUiState(
+            selectedLocation = appLocations.firstOrNull { it.type == LocationType.DISTRICT },
+        )
+        destination = AppDestination.CREATE
+    }
 
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(top = 28.dp),
-        ) {
-            Text(
-                text = "여행의 순간을\n한 곳에 모아요",
-                style = MaterialTheme.typography.headlineLarge,
-                fontWeight = FontWeight.Bold,
-                textAlign = TextAlign.Center,
-                color = Color(0xFF17324D),
-            )
-            Text(
-                text = "다녀온 곳과 소중한 기억을\nMapmory에 기록해 보세요.",
-                style = MaterialTheme.typography.bodyLarge,
-                textAlign = TextAlign.Center,
-                color = Color(0xFF5F7890),
-                modifier = Modifier.padding(top = 12.dp),
-            )
+    fun openEditScreen(record: TripRecordData) {
+        val location = appLocations.firstOrNull { it.id == record.locationId }
+            ?: appLocations.firstOrNull { it.type == LocationType.DISTRICT }
+        editorReturnDestination = AppDestination.DETAIL
+        editorState = TripRecordEditorUiState(
+            recordId = record.id,
+            selectedLocation = location,
+            title = record.title,
+            content = record.content,
+            startDate = record.startDate.orEmpty(),
+            endDate = record.endDate.orEmpty(),
+        )
+        destination = AppDestination.CREATE
+    }
+
+    fun saveEditor() {
+        val state = editorState
+        val location = state.selectedLocation
+        when {
+            location == null -> editorState = state.copy(errorMessage = "장소를 선택해 주세요.")
+            state.title.isBlank() -> editorState = state.copy(errorMessage = "제목을 입력해 주세요.")
+            else -> {
+                val previousRecord = records.firstOrNull { it.id == state.recordId }
+                val record = TripRecordData(
+                    id = previousRecord?.id ?: ((records.maxOfOrNull(TripRecordData::id) ?: 0L) + 1L),
+                    memberId = 1L,
+                    locationId = location.id,
+                    title = state.title.trim(),
+                    content = state.content.trim(),
+                    startDate = state.startDate.ifBlank { null },
+                    endDate = state.endDate.ifBlank { null },
+                    media = previousRecord?.media.orEmpty(),
+                    createdAt = previousRecord?.createdAt.orEmpty(),
+                    updatedAt = previousRecord?.updatedAt.orEmpty(),
+                )
+                records = if (previousRecord == null) {
+                    records + record
+                } else {
+                    records.map { if (it.id == record.id) record else it }
+                }
+                selectedRecordId = record.id
+                query = TripRecordQuery()
+                destination = if (state.recordId == null) {
+                    AppDestination.RECORDS
+                } else {
+                    AppDestination.DETAIL
+                }
+            }
         }
     }
+
+    val visibleRecords = records.filter { record ->
+        (query.locationId == null || record.locationId == query.locationId) &&
+            (query.keyword.isNullOrBlank() ||
+                record.title.contains(query.keyword.orEmpty(), ignoreCase = true) ||
+                record.content.contains(query.keyword.orEmpty(), ignoreCase = true))
+    }
+    val selectedRecord = records.firstOrNull { it.id == selectedRecordId }
+
+    when (destination) {
+        AppDestination.MAP -> TripMapScreen(
+            mapContent = { TripMapArtwork() },
+            onBackClick = {},
+            onRecordClick = { destination = AppDestination.RECORDS },
+            onCreateClick = { openCreateScreen(AppDestination.MAP) },
+            onProfileClick = { destination = AppDestination.PROFILE },
+        )
+
+        AppDestination.RECORDS -> TripRecordListScreen(
+            uiState = TripRecordListUiState.Success(
+                records = visibleRecords,
+                page = 0,
+                totalPages = 1,
+            ),
+            query = query,
+            locations = appLocations,
+            onKeywordChanged = { keyword ->
+                query = query.copy(keyword = keyword.ifBlank { null }, page = 0)
+            },
+            onLocationChanged = { locationId ->
+                query = query.copy(locationId = locationId, page = 0)
+            },
+            onSearchClick = {},
+            onPreviousPageClick = {},
+            onNextPageClick = {},
+            onCreateClick = { openCreateScreen(AppDestination.RECORDS) },
+            onMapClick = { destination = AppDestination.MAP },
+            onRecordClick = { recordId ->
+                selectedRecordId = recordId
+                destination = AppDestination.DETAIL
+            },
+            onProfileClick = { destination = AppDestination.PROFILE },
+        )
+
+        AppDestination.CREATE -> TripRecordEditorScreen(
+            uiState = editorState,
+            locations = appLocations,
+            onProvinceChanged = {},
+            onLocationSelected = { location ->
+                editorState = editorState.copy(selectedLocation = location, errorMessage = null)
+            },
+            onTitleChanged = { title ->
+                editorState = editorState.copy(title = title, errorMessage = null)
+            },
+            onContentChanged = { content ->
+                editorState = editorState.copy(content = content, errorMessage = null)
+            },
+            onStartDateChanged = { date ->
+                editorState = editorState.copy(startDate = date, errorMessage = null)
+            },
+            onEndDateChanged = { date ->
+                editorState = editorState.copy(endDate = date, errorMessage = null)
+            },
+            onSaveClick = ::saveEditor,
+            onBackClick = { destination = editorReturnDestination },
+            onMapClick = { destination = AppDestination.MAP },
+            onRecordClick = { destination = AppDestination.RECORDS },
+            onProfileClick = { destination = AppDestination.PROFILE },
+        )
+
+        AppDestination.PROFILE -> TripProfileScreen(
+            onMapClick = { destination = AppDestination.MAP },
+            onRecordClick = { destination = AppDestination.RECORDS },
+            onCreateClick = { openCreateScreen(AppDestination.PROFILE) },
+            onProfileClick = { destination = AppDestination.PROFILE },
+        )
+
+        AppDestination.DETAIL -> TripRecordDetailScreen(
+            uiState = selectedRecord?.let(TripRecordDetailUiState::Success)
+                ?: TripRecordDetailUiState.Error("여행 기록을 찾을 수 없습니다."),
+            locations = appLocations,
+            onBackClick = { destination = AppDestination.RECORDS },
+            onEditClick = { selectedRecord?.let(::openEditScreen) },
+            onDeleteClick = {
+                selectedRecordId?.let { recordId ->
+                    records = records.filterNot { it.id == recordId }
+                }
+                destination = AppDestination.RECORDS
+            },
+            onMapClick = { destination = AppDestination.MAP },
+            onRecordClick = { destination = AppDestination.RECORDS },
+            onCreateClick = { openCreateScreen(AppDestination.DETAIL) },
+            onProfileClick = { destination = AppDestination.PROFILE },
+        )
+    }
 }
+
+private val appLocations = listOf(
+    Location(
+        id = 1L,
+        countryId = 1L,
+        parentId = null,
+        regionCode = "11",
+        name = "서울특별시",
+        type = LocationType.PROVINCE,
+    ),
+    Location(
+        id = 2L,
+        countryId = 1L,
+        parentId = 1L,
+        regionCode = "11680",
+        name = "강남구",
+        type = LocationType.DISTRICT,
+    ),
+    Location(
+        id = 3L,
+        countryId = 1L,
+        parentId = 1L,
+        regionCode = "11650",
+        name = "서초구",
+        type = LocationType.DISTRICT,
+    ),
+)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.graphics.painter.Painter
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.domain.model.TripRecordData
@@ -29,10 +28,7 @@ private enum class AppDestination {
 }
 
 @Composable
-@Suppress("UNUSED_PARAMETER")
-fun MapmoryApp(
-    globePainter: @Composable () -> Painter,
-) {
+fun MapmoryApp() {
     var destination by remember { mutableStateOf(AppDestination.MAP) }
     var editorReturnDestination by remember { mutableStateOf(AppDestination.MAP) }
     var selectedRecordId by remember { mutableStateOf<Long?>(null) }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripMapScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripMapScreen.kt
@@ -1,27 +1,116 @@
 package com.mapmory.shared.presentation.triprecord.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.TextButton
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun TripMapScreen(
     mapContent: @Composable () -> Unit,
     onBackClick: () -> Unit,
+    onRecordClick: () -> Unit = onBackClick,
+    onCreateClick: () -> Unit = {},
+    onProfileClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.fillMaxSize()) {
-        mapContent()
-        TextButton(
-            onClick = onBackClick,
-            modifier = Modifier.padding(16.dp),
+    TripRecordBackground(modifier = modifier) {
+        Box(Modifier.fillMaxSize()) {
+            mapContent()
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 10.dp),
+            ) {
+                TripRecordTopBar(
+                    title = "Mapmory",
+                    trailing = {
+                        Text(
+                            text = "나의 여행으로 채우는 지도",
+                            color = TripRecordPalette.muted,
+                            fontSize = 10.sp,
+                        )
+                    },
+                )
+                MapSummaryCard()
+            }
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(end = 18.dp, bottom = 92.dp)
+                    .size(66.dp)
+                    .clip(CircleShape)
+                    .background(TripRecordPalette.accent)
+                    .clickable(onClick = onCreateClick),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text("＋", color = TripRecordPalette.background, fontSize = 39.sp, fontWeight = FontWeight.Light)
+            }
+
+            TripBottomBar(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                selected = TripBottomTab.MAP,
+                onRecordClick = onRecordClick,
+                onCreateClick = onCreateClick,
+                onProfileClick = onProfileClick,
+            )
+        }
+    }
+}
+@Composable
+private fun MapSummaryCard() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = TripRecordPalette.background.copy(alpha = 0.96f),
+                shape = RoundedCornerShape(18.dp),
+            )
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            Text("목록으로")
+            Column {
+                Text("나의 대한민국 지도", color = TripRecordPalette.muted, fontSize = 11.sp)
+                Row(
+                    modifier = Modifier.padding(top = 3.dp),
+                    verticalAlignment = Alignment.Bottom,
+                ) {
+                    Text("2", color = TripRecordPalette.accent, fontSize = 23.sp, fontWeight = FontWeight.Bold)
+                    Text(" / 17", color = TripRecordPalette.text, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+                }
+            }
+            Text(
+                text = "1% 채움",
+                color = TripRecordPalette.accent,
+                fontSize = 11.sp,
+                modifier = Modifier
+                    .background(TripRecordPalette.accentSoft, RoundedCornerShape(50))
+                    .padding(horizontal = 10.dp, vertical = 7.dp),
+            )
         }
     }
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripProfileScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripProfileScreen.kt
@@ -1,0 +1,123 @@
+package com.mapmory.shared.presentation.triprecord.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun TripProfileScreen(
+    onMapClick: () -> Unit,
+    onRecordClick: () -> Unit,
+    onCreateClick: () -> Unit,
+    onProfileClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TripRecordBackground(modifier = modifier) {
+        Column(Modifier.fillMaxSize()) {
+            TripRecordTopBar(
+                title = "Mapmory",
+                trailing = {
+                    Text(
+                        text = "내 정보",
+                        color = TripRecordPalette.muted,
+                        fontSize = 11.sp,
+                    )
+                },
+            )
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 24.dp),
+            ) {
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    text = "내 정보",
+                    color = TripRecordPalette.text,
+                    fontSize = 29.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = "나의 여행 기록을 한눈에 관리해 보세요",
+                    color = TripRecordPalette.muted,
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(top = 7.dp),
+                )
+                Spacer(Modifier.height(24.dp))
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            color = TripRecordPalette.surface,
+                            shape = RoundedCornerShape(20.dp),
+                        )
+                        .padding(20.dp),
+                ) {
+                    Text(
+                        text = "여행자",
+                        color = TripRecordPalette.text,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = "나의 여행을 기록하는 중",
+                        color = TripRecordPalette.muted,
+                        fontSize = 13.sp,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 20.dp),
+                        horizontalArrangement = Arrangement.spacedBy(28.dp),
+                    ) {
+                        ProfileStat(label = "여행 기록", value = "0")
+                        ProfileStat(label = "방문 지역", value = "0")
+                    }
+                }
+            }
+
+            TripBottomBar(
+                selected = TripBottomTab.PROFILE,
+                onMapClick = onMapClick,
+                onRecordClick = onRecordClick,
+                onCreateClick = onCreateClick,
+                onProfileClick = onProfileClick,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileStat(
+    label: String,
+    value: String,
+) {
+    Column {
+        Text(
+            text = value,
+            color = TripRecordPalette.accent,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = label,
+            color = TripRecordPalette.muted,
+            fontSize = 11.sp,
+            modifier = Modifier.padding(top = 3.dp),
+        )
+    }
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDesign.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDesign.kt
@@ -1,0 +1,398 @@
+package com.mapmory.shared.presentation.triprecord.screen
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+internal object TripRecordPalette {
+    val background = Color(0xFF07171B)
+    val surface = Color(0xFF0C2026)
+    val surfaceElevated = Color(0xFF102A32)
+    val line = Color(0xFF1B363E)
+    val text = Color(0xFFE9F4F2)
+    val muted = Color(0xFF81999E)
+    val accent = Color(0xFF19E5A2)
+    val accentSoft = Color(0xFF123E3A)
+    val danger = Color(0xFFFF6264)
+}
+
+@Composable
+internal fun TripRecordTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = darkColorScheme(
+            primary = TripRecordPalette.accent,
+            onPrimary = TripRecordPalette.background,
+            secondary = TripRecordPalette.muted,
+            background = TripRecordPalette.background,
+            onBackground = TripRecordPalette.text,
+            surface = TripRecordPalette.surface,
+            onSurface = TripRecordPalette.text,
+            surfaceVariant = TripRecordPalette.surfaceElevated,
+            onSurfaceVariant = TripRecordPalette.muted,
+            outline = TripRecordPalette.line,
+            error = TripRecordPalette.danger,
+        ),
+        content = content,
+    )
+}
+
+@Composable
+internal fun TripRecordBackground(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    TripRecordTheme {
+        Surface(
+            modifier = modifier.fillMaxSize(),
+            color = TripRecordPalette.background,
+            content = content,
+        )
+    }
+}
+
+@Composable
+internal fun TripRecordTopBar(
+    title: String,
+    onBackClick: (() -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(64.dp)
+            .padding(horizontal = 20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (onBackClick != null) {
+            TripIconButton(
+                label = "←",
+                onClick = onBackClick,
+            )
+            Spacer(Modifier.width(14.dp))
+        } else {
+            Spacer(Modifier.width(4.dp))
+        }
+        Text(
+            text = title,
+            color = TripRecordPalette.text,
+            fontSize = 19.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.weight(1f))
+        trailing?.invoke()
+    }
+}
+
+@Composable
+internal fun TripIconButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .background(TripRecordPalette.surface)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            color = TripRecordPalette.text,
+            fontSize = if (label == "•••") 20.sp else 28.sp,
+            fontWeight = FontWeight.Light,
+        )
+    }
+}
+
+@Composable
+internal fun TripSectionLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        color = TripRecordPalette.muted,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun TripBottomBar(
+    selected: TripBottomTab,
+    onRecordClick: () -> Unit = {},
+    onMapClick: () -> Unit = {},
+    onCreateClick: () -> Unit = {},
+    onProfileClick: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(80.dp)
+            .background(TripRecordPalette.background)
+            .padding(horizontal = 22.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        TripBottomItem(
+            tab = TripBottomTab.MAP,
+            selected = selected == TripBottomTab.MAP,
+            onClick = onMapClick,
+        )
+        TripBottomItem(
+            tab = TripBottomTab.RECORD,
+            selected = selected == TripBottomTab.RECORD,
+            onClick = onRecordClick,
+        )
+        TripBottomItem(
+            tab = TripBottomTab.CREATE,
+            selected = selected == TripBottomTab.CREATE,
+            onClick = onCreateClick,
+        )
+        TripBottomItem(
+            tab = TripBottomTab.PROFILE,
+            selected = selected == TripBottomTab.PROFILE,
+            onClick = onProfileClick,
+        )
+    }
+}
+
+internal enum class TripBottomTab(
+    val icon: String,
+    val label: String,
+) {
+    MAP("⌖", "지도"),
+    RECORD("▤", "기록"),
+    CREATE("＋", "작성"),
+    PROFILE("●", "내 정보"),
+}
+
+@Composable
+private fun TripBottomItem(
+    tab: TripBottomTab,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .width(58.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 5.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = tab.icon,
+            color = if (selected) TripRecordPalette.accent else TripRecordPalette.muted,
+            fontSize = if (tab == TripBottomTab.CREATE) 26.sp else 20.sp,
+            lineHeight = 22.sp,
+        )
+        Text(
+            text = tab.label,
+            color = if (selected) TripRecordPalette.accent else TripRecordPalette.muted,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+internal fun TripPhotoPlaceholder(
+    modifier: Modifier = Modifier,
+    variant: Int = 0,
+) {
+    val skyColors = when (variant % 3) {
+        0 -> listOf(Color(0xFFEEA16C), Color(0xFFE56A66), Color(0xFF305C6B))
+        1 -> listOf(Color(0xFFB5C991), Color(0xFF5A896F), Color(0xFF253E4A))
+        else -> listOf(Color(0xFFB88F85), Color(0xFF596D8E), Color(0xFF203846))
+    }
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(18.dp))
+            .background(Brush.verticalGradient(skyColors)),
+    ) {
+        Canvas(Modifier.fillMaxSize()) {
+            val sun = Offset(size.width * (0.72f - variant.coerceAtMost(2) * 0.12f), size.height * 0.28f)
+            drawCircle(
+                color = Color(0xFFFFE8AB),
+                radius = size.minDimension * 0.09f,
+                center = sun,
+            )
+
+            val backHill = Path().apply {
+                moveTo(0f, size.height * 0.68f)
+                lineTo(size.width * 0.2f, size.height * 0.47f)
+                lineTo(size.width * 0.37f, size.height * 0.65f)
+                lineTo(size.width * 0.58f, size.height * 0.42f)
+                lineTo(size.width, size.height * 0.67f)
+                lineTo(size.width, size.height)
+                lineTo(0f, size.height)
+                close()
+            }
+            drawPath(backHill, color = Color(0xFF456A62))
+
+            val frontHill = Path().apply {
+                moveTo(0f, size.height * 0.82f)
+                lineTo(size.width * 0.32f, size.height * 0.64f)
+                lineTo(size.width * 0.53f, size.height * 0.76f)
+                lineTo(size.width * 0.77f, size.height * 0.55f)
+                lineTo(size.width, size.height * 0.72f)
+                lineTo(size.width, size.height)
+                lineTo(0f, size.height)
+                close()
+            }
+            drawPath(frontHill, color = Color(0xFF1B3C43))
+            drawLine(
+                color = Color.White.copy(alpha = 0.28f),
+                start = Offset(size.width * 0.08f, size.height * 0.8f),
+                end = Offset(size.width * 0.88f, size.height * 0.73f),
+                strokeWidth = size.minDimension * 0.012f,
+            )
+        }
+    }
+}
+
+@Composable
+fun TripMapArtwork(
+    modifier: Modifier = Modifier,
+) {
+    Canvas(
+        modifier = modifier
+            .fillMaxSize()
+            .background(TripRecordPalette.background),
+    ) {
+        val scaleX = size.width / 320f
+        val scaleY = size.height / 500f
+        fun point(x: Float, y: Float) = Offset(x * scaleX, y * scaleY)
+
+        val peninsula = Path().apply {
+            moveTo(point(188f, 42f))
+            lineTo(point(218f, 58f))
+            lineTo(point(224f, 91f))
+            lineTo(point(246f, 119f))
+            lineTo(point(235f, 147f))
+            lineTo(point(252f, 179f))
+            lineTo(point(237f, 213f))
+            lineTo(point(221f, 236f))
+            lineTo(point(226f, 274f))
+            lineTo(point(205f, 296f))
+            lineTo(point(190f, 329f))
+            lineTo(point(164f, 338f))
+            lineTo(point(143f, 319f))
+            lineTo(point(119f, 325f))
+            lineTo(point(105f, 300f))
+            lineTo(point(82f, 288f))
+            lineTo(point(66f, 259f))
+            lineTo(point(73f, 225f))
+            lineTo(point(89f, 201f))
+            lineTo(point(95f, 164f))
+            lineTo(point(119f, 145f))
+            lineTo(point(135f, 113f))
+            lineTo(point(161f, 96f))
+            lineTo(point(164f, 64f))
+            close()
+        }
+        drawPath(peninsula, color = Color(0xFF112B32), style = Fill)
+        drawPath(
+            peninsula,
+            color = Color(0xFF254049),
+            style = Stroke(width = size.minDimension * 0.008f),
+        )
+
+        val highlightedSouth = Path().apply {
+            moveTo(point(75f, 228f))
+            lineTo(point(91f, 208f))
+            lineTo(point(110f, 217f))
+            lineTo(point(126f, 203f))
+            lineTo(point(145f, 220f))
+            lineTo(point(161f, 246f))
+            lineTo(point(153f, 274f))
+            lineTo(point(133f, 285f))
+            lineTo(point(112f, 274f))
+            lineTo(point(93f, 282f))
+            lineTo(point(79f, 263f))
+            close()
+        }
+        drawPath(highlightedSouth, color = Color(0xFFB8F2D1), style = Fill)
+        drawPath(
+            highlightedSouth,
+            color = Color(0xFF9FE8BF),
+            style = Stroke(width = size.minDimension * 0.006f),
+        )
+
+        val provinceLines = listOf(
+            listOf(164f to 64f, 170f to 116f, 154f to 160f, 145f to 220f),
+            listOf(119f to 145f, 153f to 160f, 191f to 151f, 235f to 147f),
+            listOf(89f to 201f, 126f to 203f, 161f to 193f, 221f to 182f),
+            listOf(66f to 259f, 112f to 274f, 153f to 274f, 190f to 246f),
+            listOf(135f to 113f, 145f to 160f, 126f to 203f, 133f to 285f),
+        )
+        provinceLines.forEach { line ->
+            val path = Path().apply {
+                line.forEachIndexed { index, (x, y) ->
+                    if (index == 0) moveTo(point(x, y)) else lineTo(point(x, y))
+                }
+            }
+            drawPath(
+                path,
+                color = Color(0xFF1C353D),
+                style = Stroke(width = size.minDimension * 0.004f),
+            )
+        }
+
+        drawOval(
+            color = Color(0xFF74E7B2),
+            topLeft = point(109f, 360f),
+            size = androidx.compose.ui.geometry.Size(38f * scaleX, 15f * scaleY),
+        )
+        drawOval(
+            color = Color(0xFF1C353D),
+            topLeft = point(80f, 184f),
+            size = androidx.compose.ui.geometry.Size(7f * scaleX, 4f * scaleY),
+        )
+    }
+}
+
+private fun Path.moveTo(point: Offset) {
+    moveTo(point.x, point.y)
+}
+
+private fun Path.lineTo(point: Offset) {
+    lineTo(point.x, point.y)
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
@@ -1,12 +1,18 @@
 package com.mapmory.shared.presentation.triprecord.screen
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -14,8 +20,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.presentation.triprecord.state.TripRecordDetailUiState
 
@@ -26,53 +35,130 @@ fun TripRecordDetailScreen(
     onBackClick: () -> Unit,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
+    onMapClick: () -> Unit = {},
+    onRecordClick: () -> Unit = {},
+    onCreateClick: () -> Unit = {},
+    onProfileClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        TextButton(onClick = onBackClick) {
-            Text("목록으로")
-        }
+    TripRecordBackground(modifier = modifier) {
+        Column(Modifier.fillMaxSize()) {
+            Box(Modifier.weight(1f)) {
+                when (uiState) {
+                    TripRecordDetailUiState.Idle,
+                    TripRecordDetailUiState.Loading,
+                    TripRecordDetailUiState.Deleting,
+                    -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(color = TripRecordPalette.accent)
+                    }
 
-        when (uiState) {
-            TripRecordDetailUiState.Idle,
-            TripRecordDetailUiState.Loading,
-            TripRecordDetailUiState.Deleting,
-            -> CircularProgressIndicator()
+                    is TripRecordDetailUiState.Error -> Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(24.dp),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(uiState.message, color = TripRecordPalette.danger)
+                        TextButton(onClick = onBackClick) { Text("목록으로") }
+                    }
 
-            is TripRecordDetailUiState.Error -> Text(
-                text = uiState.message,
-                color = MaterialTheme.colorScheme.error,
-            )
+                    is TripRecordDetailUiState.Success -> {
+                        val record = uiState.record
+                        val location = locations.firstOrNull { it.id == record.locationId }
+                        Column(Modifier.fillMaxSize()) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .weight(1f),
+                            ) {
+                                TripPhotoPlaceholder(
+                                    modifier = Modifier.fillMaxSize(),
+                                    variant = record.id.toInt() + 1,
+                                )
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 18.dp, vertical = 20.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                ) {
+                                    TripIconButton(label = "←", onClick = onBackClick)
+                                    TripIconButton(label = "•••", onClick = {})
+                                }
+                            }
 
-            is TripRecordDetailUiState.Success -> {
-                val record = uiState.record
-                Text(record.title, style = MaterialTheme.typography.headlineMedium)
-                locations.firstOrNull { it.id == record.locationId }?.let { location ->
-                    Text(location.name, style = MaterialTheme.typography.titleMedium)
-                }
-                Text(record.content, style = MaterialTheme.typography.bodyLarge)
-                record.startDate?.let { startDate ->
-                    Text(if (record.endDate == null) startDate else "$startDate ~ ${record.endDate}")
-                }
-                if (record.media.isNotEmpty()) {
-                    Text("사진 ${record.media.size}장")
-                }
-                Text("작성일: ${record.createdAt}", style = MaterialTheme.typography.bodySmall)
-                Text("수정일: ${record.updatedAt}", style = MaterialTheme.typography.bodySmall)
-                TextButton(onClick = onEditClick) {
-                    Text("수정")
-                }
-                TextButton(onClick = { showDeleteDialog = true }) {
-                    Text("삭제", color = MaterialTheme.colorScheme.error)
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(
+                                        color = TripRecordPalette.surface,
+                                        shape = RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp),
+                                    )
+                                    .padding(horizontal = 24.dp, vertical = 24.dp),
+                            ) {
+                                Text(
+                                    text = record.title,
+                                    color = TripRecordPalette.text,
+                                    fontSize = 26.sp,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                                Text(
+                                    text = record.content,
+                                    color = TripRecordPalette.muted,
+                                    fontSize = 14.sp,
+                                    modifier = Modifier.padding(top = 8.dp),
+                                )
+                                Column(
+                                    modifier = Modifier.padding(top = 17.dp),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                                ) {
+                                    Text(
+                                        text = "대한민국 · ${location?.name ?: "여행지"}",
+                                        color = TripRecordPalette.accent,
+                                        fontSize = 11.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                    )
+                                    record.startDate?.let { date ->
+                                        Text(
+                                            text = date.replace('-', '.'),
+                                            color = TripRecordPalette.muted,
+                                            fontSize = 11.sp,
+                                        )
+                                    }
+                                }
+                                Spacer(Modifier.height(21.dp))
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                ) {
+                                    Text(
+                                        text = if (record.media.isEmpty()) "여행 기록" else "사진 ${record.media.size}장",
+                                        color = TripRecordPalette.muted,
+                                        fontSize = 12.sp,
+                                    )
+                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        TextButton(onClick = onEditClick) { Text("수정") }
+                                        TextButton(onClick = { showDeleteDialog = true }) {
+                                            Text("삭제", color = TripRecordPalette.danger)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
+
+            TripBottomBar(
+                selected = TripBottomTab.RECORD,
+                onMapClick = onMapClick,
+                onRecordClick = onRecordClick,
+                onCreateClick = onCreateClick,
+                onProfileClick = onProfileClick,
+            )
         }
     }
 
@@ -88,13 +174,11 @@ fun TripRecordDetailScreen(
                         onDeleteClick()
                     },
                 ) {
-                    Text("삭제", color = MaterialTheme.colorScheme.error)
+                    Text("삭제", color = TripRecordPalette.danger)
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showDeleteDialog = false }) {
-                    Text("취소")
-                }
+                TextButton(onClick = { showDeleteDialog = false }) { Text("취소") }
             },
         )
     }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -1,13 +1,21 @@
 package com.mapmory.shared.presentation.triprecord.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -17,7 +25,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorUiState
@@ -34,98 +44,202 @@ fun TripRecordEditorScreen(
     onEndDateChanged: (String) -> Unit,
     onSaveClick: () -> Unit,
     onBackClick: () -> Unit,
+    onMapClick: () -> Unit = {},
+    onRecordClick: () -> Unit = {},
+    onProfileClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val provinces = locations.filter { it.type == LocationType.PROVINCE }
-    var selectedProvinceId by remember {
-        mutableStateOf(uiState.selectedLocation?.parentId)
+    var selectedProvinceId by remember(uiState.selectedLocation?.parentId) {
+        mutableStateOf(uiState.selectedLocation?.parentId ?: provinces.firstOrNull()?.id)
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        TextButton(onClick = onBackClick) {
-            Text("목록으로")
-        }
-        Text(
-            text = if (uiState.recordId == null) "여행 기록 작성" else "여행 기록 수정",
-            style = MaterialTheme.typography.headlineMedium,
-        )
-        Text("시·도 선택", style = MaterialTheme.typography.titleMedium)
-        provinces.forEach { province ->
-            OutlinedButton(
-                onClick = {
-                    if (selectedProvinceId != province.id) onProvinceChanged()
-                    selectedProvinceId = province.id
-                },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(
-                    if (selectedProvinceId == province.id) "✓ ${province.name}" else province.name,
-                )
-            }
-        }
-        selectedProvinceId?.let { provinceId ->
-            Text("시·군·구 선택", style = MaterialTheme.typography.titleMedium)
-            locations
-                .filter { it.type == LocationType.DISTRICT && it.parentId == provinceId }
-                .forEach { district ->
-                    OutlinedButton(
-                        onClick = { onLocationSelected(district) },
-                        modifier = Modifier.fillMaxWidth(),
+    TripRecordBackground(modifier = modifier) {
+        Column(Modifier.fillMaxSize()) {
+            TripRecordTopBar(
+                title = if (uiState.recordId == null) "새 기록 작성" else "기록 수정",
+                onBackClick = onBackClick,
+                trailing = {
+                    TextButton(
+                        onClick = onSaveClick,
+                        enabled = !uiState.isSaving,
                     ) {
                         Text(
-                            if (uiState.selectedLocation?.id == district.id) {
-                                "✓ ${district.name}"
-                            } else {
-                                district.name
-                            },
+                            text = if (uiState.isSaving) "저장 중" else "완료",
+                            color = if (uiState.isSaving) TripRecordPalette.muted else TripRecordPalette.accent,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                },
+            )
+
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 10.dp),
+                verticalArrangement = Arrangement.spacedBy(18.dp),
+            ) {
+                item {
+                    EditorSectionLabel("제목")
+                    OutlinedTextField(
+                        value = uiState.title,
+                        onValueChange = onTitleChanged,
+                        placeholder = { Text("여행의 제목을 입력해 주세요") },
+                        singleLine = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                    )
+                }
+
+                item {
+                    EditorSectionLabel("여행 사진")
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(top = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        TripPhotoPlaceholder(Modifier.size(112.dp, 84.dp), variant = 0)
+                        TripPhotoPlaceholder(Modifier.size(112.dp, 84.dp), variant = 1)
+                        TripPhotoPlaceholder(Modifier.size(112.dp, 84.dp), variant = 2)
+                        Column(
+                            modifier = Modifier
+                                .size(84.dp)
+                                .background(TripRecordPalette.surface, RoundedCornerShape(16.dp)),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+                        ) {
+                            Text("＋", color = TripRecordPalette.accent, fontSize = 28.sp)
+                            Text("사진 추가", color = TripRecordPalette.muted, fontSize = 10.sp)
+                        }
+                    }
+                }
+
+                item {
+                    EditorSectionLabel("장소")
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(top = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        provinces.forEach { province ->
+                            EditorChoiceChip(
+                                text = province.name,
+                                selected = selectedProvinceId == province.id,
+                                onClick = {
+                                    selectedProvinceId = province.id
+                                    onProvinceChanged()
+                                },
+                            )
+                        }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(top = 9.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        locations
+                            .filter { it.type == LocationType.DISTRICT && it.parentId == selectedProvinceId }
+                            .forEach { district ->
+                                EditorChoiceChip(
+                                    text = district.name,
+                                    selected = uiState.selectedLocation?.id == district.id,
+                                    onClick = { onLocationSelected(district) },
+                                )
+                            }
+                    }
+                }
+
+                item {
+                    EditorSectionLabel("여행 날짜")
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        OutlinedTextField(
+                            value = uiState.startDate,
+                            onValueChange = onStartDateChanged,
+                            placeholder = { Text("YYYY.MM.DD") },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f),
+                        )
+                        OutlinedTextField(
+                            value = uiState.endDate,
+                            onValueChange = onEndDateChanged,
+                            placeholder = { Text("종료일") },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f),
                         )
                     }
                 }
-        }
-        OutlinedTextField(
-            value = uiState.title,
-            onValueChange = onTitleChanged,
-            label = { Text("제목") },
-            modifier = Modifier.fillMaxWidth(),
-        )
-        OutlinedTextField(
-            value = uiState.content,
-            onValueChange = onContentChanged,
-            label = { Text("내용") },
-            modifier = Modifier.fillMaxWidth(),
-        )
-        OutlinedTextField(
-            value = uiState.startDate,
-            onValueChange = onStartDateChanged,
-            label = { Text("시작일 (YYYY-MM-DD)") },
-            modifier = Modifier.fillMaxWidth(),
-        )
-        OutlinedTextField(
-            value = uiState.endDate,
-            onValueChange = onEndDateChanged,
-            label = { Text("종료일 (YYYY-MM-DD)") },
-            modifier = Modifier.fillMaxWidth(),
-        )
-        uiState.errorMessage?.let { message ->
-            Text(message, color = MaterialTheme.colorScheme.error)
-        }
-        Button(
-            onClick = onSaveClick,
-            enabled = !uiState.isSaving,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(
-                when {
-                    uiState.isSaving -> "저장 중..."
-                    uiState.recordId == null -> "저장"
-                    else -> "수정"
-                },
+
+                item {
+                    EditorSectionLabel("기록")
+                    OutlinedTextField(
+                        value = uiState.content,
+                        onValueChange = onContentChanged,
+                        placeholder = { Text("여행에서 느낀 점을 기록해 보세요") },
+                        minLines = 4,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                    )
+                }
+
+                uiState.errorMessage?.let { message ->
+                    item {
+                        Text(message, color = TripRecordPalette.danger, fontSize = 12.sp)
+                    }
+                }
+
+                item { Spacer(Modifier.height(18.dp)) }
+            }
+
+            TripBottomBar(
+                selected = TripBottomTab.CREATE,
+                onMapClick = onMapClick,
+                onRecordClick = onRecordClick,
+                onProfileClick = onProfileClick,
             )
         }
     }
+}
+@Composable
+private fun EditorSectionLabel(text: String) {
+    Text(
+        text = text,
+        color = TripRecordPalette.muted,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+    )
+}
+
+@Composable
+private fun EditorChoiceChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = text,
+        color = if (selected) TripRecordPalette.background else TripRecordPalette.muted,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .background(
+                color = if (selected) TripRecordPalette.accent else TripRecordPalette.surface,
+                shape = RoundedCornerShape(50),
+            )
+            .padding(horizontal = 13.dp, vertical = 9.dp),
+    )
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordListScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordListScreen.kt
@@ -1,25 +1,29 @@
 package com.mapmory.shared.presentation.triprecord.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.domain.model.TripRecordData
@@ -39,94 +43,159 @@ fun TripRecordListScreen(
     onCreateClick: () -> Unit,
     onMapClick: () -> Unit,
     onRecordClick: (Long) -> Unit,
+    onProfileClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Text(
-            text = "여행 기록",
-            style = MaterialTheme.typography.headlineMedium,
-        )
-        Button(onClick = onCreateClick) {
-            Text("기록 작성")
-        }
-        OutlinedButton(onClick = onMapClick) {
-            Text("지도 보기")
-        }
-        OutlinedTextField(
-            value = query.keyword.orEmpty(),
-            onValueChange = onKeywordChanged,
-            label = { Text("제목·내용 검색") },
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Row(
-            modifier = Modifier.horizontalScroll(rememberScrollState()),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            OutlinedButton(onClick = { onLocationChanged(null) }) {
-                Text(if (query.locationId == null) "✓ 전체" else "전체")
-            }
-            locations.filter { it.type == LocationType.DISTRICT }.forEach { location ->
-                OutlinedButton(onClick = { onLocationChanged(location.id) }) {
-                    Text(if (query.locationId == location.id) "✓ ${location.name}" else location.name)
-                }
-            }
-        }
-        Button(onClick = onSearchClick) {
-            Text("검색")
-        }
-
-        when (uiState) {
-            TripRecordListUiState.Idle,
-            TripRecordListUiState.Loading,
-            -> CircularProgressIndicator()
-
-            is TripRecordListUiState.Error -> Text(uiState.message)
-
-            is TripRecordListUiState.Success -> {
-                if (uiState.records.isEmpty()) {
+    TripRecordBackground(modifier = modifier) {
+        Column(Modifier.fillMaxSize()) {
+            TripRecordTopBar(
+                title = "Mapmory",
+                trailing = {
                     Text(
-                        if (query.keyword == null && query.locationId == null) {
-                            "아직 작성한 여행 기록이 없어요."
+                        text = "나의 여행 기록",
+                        color = TripRecordPalette.muted,
+                        fontSize = 11.sp,
+                    )
+                },
+            )
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 24.dp),
+            ) {
+                Spacer(Modifier.height(18.dp))
+                Text(
+                    text = "나의 여행기록",
+                    color = TripRecordPalette.text,
+                    fontSize = 29.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = "여행의 순간을 다시 꺼내보세요",
+                    color = TripRecordPalette.muted,
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(top = 7.dp),
+                )
+                Spacer(Modifier.height(20.dp))
+                LocationFilters(
+                    query = query,
+                    locations = locations,
+                    onLocationChanged = onLocationChanged,
+                    onSearchClick = onSearchClick,
+                )
+                Spacer(Modifier.height(16.dp))
+
+                when (uiState) {
+                    TripRecordListUiState.Idle,
+                    TripRecordListUiState.Loading,
+                    -> CircularProgressIndicator(
+                        color = TripRecordPalette.accent,
+                        modifier = Modifier.padding(top = 20.dp),
+                    )
+
+                    is TripRecordListUiState.Error -> Text(
+                        text = uiState.message,
+                        color = TripRecordPalette.danger,
+                        modifier = Modifier.padding(top = 20.dp),
+                    )
+
+                    is TripRecordListUiState.Success -> {
+                        if (uiState.records.isEmpty()) {
+                            EmptyTripRecords(
+                                hasFilter = query.keyword != null || query.locationId != null,
+                                modifier = Modifier.weight(1f),
+                            )
                         } else {
-                            "조건에 맞는 여행 기록이 없어요."
-                        },
-                    )
-                } else {
-                    TripRecordList(
-                        records = uiState.records,
-                        locations = locations,
-                        onRecordClick = onRecordClick,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-                if (uiState.totalPages > 1) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Button(
-                            onClick = onPreviousPageClick,
-                            enabled = uiState.page > 0,
-                        ) {
-                            Text("이전")
+                            TripRecordList(
+                                records = uiState.records,
+                                locations = locations,
+                                onRecordClick = onRecordClick,
+                                modifier = Modifier.weight(1f),
+                            )
                         }
-                        Text("${uiState.page + 1} / ${uiState.totalPages}")
-                        Button(
-                            onClick = onNextPageClick,
-                            enabled = uiState.page + 1 < uiState.totalPages,
-                        ) {
-                            Text("다음")
+                        if (uiState.totalPages > 1) {
+                            PageControls(
+                                page = uiState.page,
+                                totalPages = uiState.totalPages,
+                                onPreviousPageClick = onPreviousPageClick,
+                                onNextPageClick = onNextPageClick,
+                            )
                         }
                     }
                 }
             }
+
+            TripBottomBar(
+                selected = TripBottomTab.RECORD,
+                onMapClick = onMapClick,
+                onCreateClick = onCreateClick,
+                onProfileClick = onProfileClick,
+            )
         }
     }
+}
+
+@Composable
+private fun LocationFilters(
+    query: TripRecordQuery,
+    locations: List<Location>,
+    onLocationChanged: (Long?) -> Unit,
+    onSearchClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        TripFilterChip(
+            text = "전체",
+            selected = query.locationId == null,
+            onClick = {
+                onLocationChanged(null)
+                onSearchClick()
+            },
+        )
+        locations
+            .filter { it.type == LocationType.DISTRICT }
+            .take(5)
+            .forEach { location ->
+                TripFilterChip(
+                    text = location.name,
+                    selected = query.locationId == location.id,
+                    onClick = {
+                        onLocationChanged(location.id)
+                        onSearchClick()
+                    },
+                )
+            }
+    }
+}
+
+@Composable
+private fun TripFilterChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = text,
+        color = if (selected) TripRecordPalette.background else TripRecordPalette.muted,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .then(
+                Modifier
+                    .padding(horizontal = 14.dp, vertical = 9.dp)
+                    .background(
+                        color = if (selected) TripRecordPalette.accent else TripRecordPalette.surface,
+                        shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+                    ),
+            )
+            .padding(horizontal = 2.dp),
+    )
 }
 
 @Composable
@@ -137,28 +206,131 @@ private fun TripRecordList(
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = 18.dp),
     ) {
         items(records, key = TripRecordData::id) { record ->
-            Card(
+            TripRecordCard(
+                record = record,
+                location = locations.firstOrNull { it.id == record.locationId },
                 onClick = { onRecordClick(record.id) },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text(record.title, style = MaterialTheme.typography.titleMedium)
-                    locations.firstOrNull { it.id == record.locationId }?.let { location ->
-                        Text(location.name, style = MaterialTheme.typography.bodySmall)
-                    }
-                    Text(record.content, style = MaterialTheme.typography.bodyMedium)
-                    record.startDate?.let { startDate ->
+            )
+        }
+    }
+}
+
+@Composable
+private fun TripRecordCard(
+    record: TripRecordData,
+    location: Location?,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(18.dp),
+        colors = CardDefaults.cardColors(containerColor = TripRecordPalette.surface),
+    ) {
+        Column {
+            TripPhotoPlaceholder(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(222.dp),
+                variant = record.id.toInt(),
+            )
+            Column(Modifier.padding(18.dp)) {
+                Text(
+                    text = record.title,
+                    color = TripRecordPalette.text,
+                    fontSize = 21.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = record.content,
+                    color = TripRecordPalette.muted,
+                    fontSize = 13.sp,
+                    maxLines = 2,
+                    modifier = Modifier.padding(top = 7.dp),
+                )
+                Column(
+                    modifier = Modifier.padding(top = 15.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "대한민국 · ${location?.name ?: "여행지"}",
+                        color = TripRecordPalette.accent,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    record.startDate?.let { date ->
                         Text(
-                            text = if (record.endDate == null) startDate else "$startDate ~ ${record.endDate}",
-                            style = MaterialTheme.typography.bodySmall,
+                            text = date.replace('-', '.'),
+                            color = TripRecordPalette.muted,
+                            fontSize = 11.sp,
                         )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun EmptyTripRecords(
+    hasFilter: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = if (hasFilter) "조건에 맞는 여행 기록이 없어요." else "아직 작성한 여행 기록이 없어요.",
+            color = TripRecordPalette.text,
+            fontSize = 17.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = "새로운 여행의 순간을 기록해 보세요.",
+            color = TripRecordPalette.muted,
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun PageControls(
+    page: Int,
+    totalPages: Int,
+    onPreviousPageClick: () -> Unit,
+    onNextPageClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = "‹ 이전",
+            color = if (page > 0) TripRecordPalette.accent else TripRecordPalette.muted.copy(alpha = 0.45f),
+            modifier = Modifier.clickable(enabled = page > 0, onClick = onPreviousPageClick),
+        )
+        Text(
+            text = "${page + 1} / $totalPages",
+            color = Color.White,
+            fontSize = 12.sp,
+        )
+        Text(
+            text = "다음 ›",
+            color = if (page + 1 < totalPages) TripRecordPalette.accent else TripRecordPalette.muted.copy(alpha = 0.45f),
+            modifier = Modifier.clickable(
+                enabled = page + 1 < totalPages,
+                onClick = onNextPageClick,
+            ),
+        )
     }
 }

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/MainViewController.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/MainViewController.kt
@@ -1,12 +1,7 @@
 package com.mapmory.shared
 
 import androidx.compose.ui.window.ComposeUIViewController
-import mapmoryclient.shared.generated.resources.Res
-import mapmoryclient.shared.generated.resources.globe_hero
-import org.jetbrains.compose.resources.painterResource
 
 fun MainViewController() = ComposeUIViewController {
-    MapmoryApp(
-        globePainter = { painterResource(Res.drawable.globe_hero) },
-    )
+    MapmoryApp()
 }


### PR DESCRIPTION
 ## 작업 내용

  - TripMapScreen을 Android/iOS 공통 메인 화면으로 변경
  - 하단 네비게이션 연결
      - 지도
      - 여행 기록 목록
      - 기록 작성
      - 내 정보
  - 지도 + 버튼을 기록 작성 화면으로 연결
  - 여행 기록 목록에서 상세 화면으로 이동
  - 상세 화면에서 수정·삭제 동작 연결
  - 작성 화면에서 기록 생성·수정 후 화면 이동 연결
  - TripProfileScreen 추가
  - Android/iOS 진입점에서 기존 globePainter 의존성 제거

  ## 구현 방식
  - MapmoryApp에서 현재 화면 상태를 관리하는 간단한 네비게이션 구성
  - 공통 Compose 화면을 사용해 Android/iOS 화면 흐름 통일
  - 기록 생성·수정·삭제는 현재 화면 연결 확인을 위한 로컬 상태 기반으로 처리