### PR TITLE
feat(travelrecord): 여행 일지 등록 api 구현

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/member/MemberRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.mapmory.backend.member;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
@@ -1,0 +1,6 @@
+package com.mapmory.backend.recordmedia;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordMediaRepository extends JpaRepository<RecordMedia, Long> {
+}

--- a/backend/src/main/java/com/mapmory/backend/region/RegionRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/region/RegionRepository.java
@@ -1,0 +1,18 @@
+package com.mapmory.backend.region;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+
+    Optional<Region> findByParentIsNullAndRegionTypeAndRegionCode(
+            RegionType regionType,
+            String regionCode
+    );
+
+    Optional<Region> findByParentIdAndRegionTypeAndRegionCode(
+            Long parentId,
+            RegionType regionType,
+            String regionCode
+    );
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
@@ -69,4 +69,7 @@ public class TravelRecord extends BaseEntity {
         return new TravelRecord(member, region, title, content, startDate, endDate);
     }
 
+    public Long getId() {
+        return id;
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -1,0 +1,33 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
+import com.mapmory.backend.travelrecord.dto.CreateTravelRecordResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1")
+public class TravelRecordController {
+
+    private TravelRecordService travelRecordService;
+
+    public TravelRecordController(TravelRecordService travelRecordService) {
+        this.travelRecordService = travelRecordService;
+    }
+
+    @PostMapping("/travel-records")
+    public ResponseEntity<CreateTravelRecordResponse> create(@RequestHeader("X-Member-Id") Long memberId,
+                                                             @Valid @RequestBody TravelRecordRequest travelRecordRequest
+    ) {
+        TravelRecord travelRecord = travelRecordService.create(memberId, travelRecordRequest);
+        CreateTravelRecordResponse response = CreateTravelRecordResponse.from(travelRecord);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordRepository.java
@@ -1,0 +1,6 @@
+package com.mapmory.backend.travelrecord;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TravelRecordRepository extends JpaRepository<TravelRecord, Long> {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -1,0 +1,95 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.recordmedia.RecordMediaRepository;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionRepository;
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TravelRecordService {
+
+    private final TravelRecordRepository travelRecordRepository;
+    private final RegionRepository regionRepository;
+    private final MemberRepository memberRepository;
+    private final RecordMediaRepository recordMediaRepository;
+
+    public TravelRecordService(
+            TravelRecordRepository travelRecordRepository,
+            MemberRepository memberRepository,
+            RegionRepository regionRepository,
+            RecordMediaRepository recordMediaRepository
+    ) {
+        this.travelRecordRepository = travelRecordRepository;
+        this.memberRepository = memberRepository;
+        this.regionRepository = regionRepository;
+        this.recordMediaRepository = recordMediaRepository;
+    }
+
+    public TravelRecord create(Long memberId, TravelRecordRequest request) {
+        Member member = memberRepository.getReferenceById(memberId);
+        Region region = resolveRegion(request);
+
+        TravelRecord travelRecord = TravelRecord.of(
+                member,
+                region,
+                request.title(),
+                request.content(),
+                request.startDate(),
+                request.endDate()
+        );
+
+        TravelRecord savedTravelRecord = travelRecordRepository.save(travelRecord);
+
+        List<String> objectKeys = request.objectKeys() == null
+                ? List.of()
+                : request.objectKeys();
+
+        for (int index = 0; index < objectKeys.size(); index++) {
+            RecordMedia recordMedia = RecordMedia.of(
+                    savedTravelRecord,
+                    objectKeys.get(index),
+                    null,
+                    index
+            );
+
+            recordMediaRepository.save(recordMedia);
+        }
+
+        return savedTravelRecord;
+    }
+
+    private Region resolveRegion(TravelRecordRequest request) {
+        // countryCode → provinceCode → districtCode로 Region 탐색
+
+        // 국가 조건 : parentId가 없어야 함 + RegionType = COUNTRY + countryCode
+        Region country = regionRepository.findByParentIsNullAndRegionTypeAndRegionCode(
+                RegionType.COUNTRY,
+                request.countryCode()
+        ).orElseThrow();
+
+        if (request.provinceCode() == null && request.districtCode() == null) {
+            return country;
+        }
+
+        // 중간 지역 조건 : parentId = country_id + RegionType = PROVINCE + provinceCode
+        Region province = regionRepository.findByParentIdAndRegionTypeAndRegionCode(
+                country.getId(),
+                RegionType.PROVINCE,
+                request.provinceCode()
+        ).orElseThrow();
+
+        // 세부 지역 조건 : parentId = province_id + RegionType = DISTRICT + districtCode
+        return regionRepository
+                .findByParentIdAndRegionTypeAndRegionCode(
+                province.getId(),
+                RegionType.DISTRICT,
+                request.districtCode()
+        ).orElseThrow();
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/CreateTravelRecordResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/CreateTravelRecordResponse.java
@@ -1,0 +1,11 @@
+package com.mapmory.backend.travelrecord.dto;
+
+import com.mapmory.backend.travelrecord.TravelRecord;
+
+public record CreateTravelRecordResponse(
+        Long id
+) {
+    public static CreateTravelRecordResponse from(TravelRecord travelRecord) {
+        return new CreateTravelRecordResponse(travelRecord.getId());
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
@@ -1,0 +1,20 @@
+package com.mapmory.backend.travelrecord.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+
+public record TravelRecordRequest(
+        @NotNull
+        String countryCode,
+        String provinceCode,
+        String districtCode,
+        @NotNull
+        String title,
+        String content,
+        @NotNull
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> objectKeys
+) {
+}

--- a/backend/src/main/resources/db/migration/V11__insert_temporary_members.sql
+++ b/backend/src/main/resources/db/migration/V11__insert_temporary_members.sql
@@ -1,0 +1,5 @@
+-- 개발·테스트용 임시 회원
+INSERT INTO member (uuid, name) VALUES
+    ('2c853e88-97fb-4a42-852b-4dfc159c85ac', '도우너'),
+    ('774c091b-d920-4642-a3d8-b1548aa1f36c', '티온'),
+    ('bd88b2eb-8e69-42e6-b755-f62044569bd1', '달수');

--- a/backend/src/test/java/com/mapmory/backend/common/SpringMvcProblemDetailTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/SpringMvcProblemDetailTest.java
@@ -14,7 +14,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@WebMvcTest(properties = "spring.mvc.problemdetails.enabled=true")
+@WebMvcTest(
+        controllers = SpringMvcProblemDetailTest.MethodRestrictedController.class,
+        properties = "spring.mvc.problemdetails.enabled=true"
+)
 @Import({ProblemDetailFactory.class, SpringMvcProblemDetailTest.MethodRestrictedController.class})
 class SpringMvcProblemDetailTest {
 

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -1,0 +1,60 @@
+package com.mapmory.backend.travelrecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.travelrecord.dto.CreateTravelRecordResponse;
+import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TravelRecordControllerTest {
+
+    @Mock
+    private TravelRecordService travelRecordService;
+
+    @InjectMocks
+    private TravelRecordController travelRecordController;
+
+    @Test
+    void createsTravelRecord() {
+        TravelRecordRequest request = new TravelRecordRequest(
+                "JP",
+                null,
+                null,
+                "일본 여행",
+                "",
+                LocalDate.of(2026, 8, 11),
+                null,
+                List.of()
+        );
+        TravelRecord travelRecord = TravelRecord.of(
+                null,
+                null,
+                request.title(),
+                request.content(),
+                request.startDate(),
+                request.endDate()
+        );
+        ReflectionTestUtils.setField(travelRecord, "id", 1L);
+
+        when(travelRecordService.create(10L, request)).thenReturn(travelRecord);
+
+        ResponseEntity<CreateTravelRecordResponse> response =
+                travelRecordController.create(10L, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isEqualTo(new CreateTravelRecordResponse(1L));
+        verify(travelRecordService).create(10L, request);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.mapmory.backend.travelrecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mapmory.backend.IntegrationTest;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionRepository;
+import com.mapmory.backend.region.RegionType;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+class TravelRecordRepositoryTest extends IntegrationTest {
+
+    @Autowired
+    private TravelRecordRepository travelRecordRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @Transactional
+    void savesTravelRecord() {
+        Member member = memberRepository.save(Member.of("테스터", UUID.randomUUID()));
+        Region testCountry = regionRepository.save(
+                Region.of(null, null, "ZZ", "테스트 국가", RegionType.COUNTRY)
+        );
+
+        TravelRecord travelRecord = travelRecordRepository.save(
+                TravelRecord.of(
+                        member,
+                        testCountry,
+                        "테스트 여행",
+                        "",
+                        LocalDate.of(2026, 8, 11),
+                        null
+                )
+        );
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(travelRecord.getId()).isNotNull();
+        assertThat(travelRecordRepository.findById(travelRecord.getId())).isPresent();
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -1,0 +1,72 @@
+package com.mapmory.backend.travelrecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionRepository;
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TravelRecordServiceTest {
+
+    @Mock
+    private TravelRecordRepository travelRecordRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @InjectMocks
+    private TravelRecordService travelRecordService;
+
+    @Test
+    void createsCountryTravelRecord() {
+        Member member = mock(Member.class);
+        Region japan = mock(Region.class);
+        TravelRecordRequest request = new TravelRecordRequest(
+                "JP",
+                null,
+                null,
+                "일본 여행",
+                "",
+                LocalDate.of(2026, 8, 11),
+                null,
+                List.of()
+        );
+
+        when(memberRepository.getReferenceById(10L)).thenReturn(member);
+        when(regionRepository.findByParentIsNullAndRegionTypeAndRegionCode(
+                RegionType.COUNTRY,
+                "JP"
+        )).thenReturn(Optional.of(japan));
+        when(travelRecordRepository.save(any(TravelRecord.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        TravelRecord result = travelRecordService.create(10L, request);
+
+        assertThat(result).isNotNull();
+        verify(memberRepository).getReferenceById(10L);
+        verify(regionRepository).findByParentIsNullAndRegionTypeAndRegionCode(
+                RegionType.COUNTRY,
+                "JP"
+        );
+        verify(travelRecordRepository).save(any(TravelRecord.class));
+    }
+}


### PR DESCRIPTION
## 작업 내용

여행 기록 생성 기능의 기본 골격을 추가했습니다.

- `TravelRecordController`, `TravelRecordService`, `TravelRecordRepository` 추가
- 국가 → 시도 → 시군구 코드 경로를 이용한 `Region` 조회
- 회원과 최종 Region을 연결한 여행 기록 기본 저장
- 생성된 여행 기록 ID 반환
- Controller·Service·Repository 테스트 추가
- 새 Controller 추가로 영향을 받은 MVC 슬라이스 테스트 범위 조정

## 검증

```text
./gradlew test
```

## 이번 PR에서 제외
- 대한민국 기록의 DISTRICT 필수 규칙 검증
- 날짜 범위 검증
- Object Key 검증
- record_media 저장
- 도메인 예외 응답 정리
## 관련 이슈
Related to #11 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to create travel records with titles, content, dates, location details, and associated media.
  - Travel locations can be selected using country, province, and district information with hierarchical validation.
  - Successful creation returns the newly created travel record ID.
  - Required fields are validated before submission, while media attachments remain optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->