### PR TITLE
feat(travelrecord): 여행 일지 수정 API 구현

### DIFF
--- a/api.md
+++ b/api.md
@@ -368,7 +368,22 @@ Region 관련 오류는 생성 API와 동일하게 처리한다.
 
 ### 여행 기록 삭제
 
-`DELETE /api/v1/travel-records/{travelRecordId}`: 기록을 삭제한다. 연결된 `record_media` 행은 CASCADE 삭제한다. S3 객체 삭제는 별도 처리한다.
+`DELETE /api/v1/travel-records/{travelRecordId}`
+
+현재 회원이 소유한 여행 기록을 삭제한다. 기록이 없거나 다른 회원의 기록이면 존재 여부를 숨기기 위해 동일하게 `404 TRAVEL_RECORD_NOT_FOUND`를 반환한다.
+
+연결된 `record_media` 행은 DB의 `ON DELETE CASCADE`로 함께 삭제한다. S3 실제 객체 삭제는 후속 작업으로 처리한다.
+
+#### Response `204 No Content`
+
+응답 본문은 없다.
+
+#### 오류 응답
+
+| 상태 | `code` | 조건 |
+| --- | --- | --- |
+| `400` | `VALIDATION_ERROR` | 회원 ID 또는 여행 기록 ID가 양의 정수가 아님 |
+| `404` | `TRAVEL_RECORD_NOT_FOUND` | 기록이 없거나 현재 회원의 기록이 아님 |
 
 ## 5. 지역별 여행 기록 통계 API
 

--- a/api.md
+++ b/api.md
@@ -340,10 +340,35 @@ GET /api/v1/travel-records?countryCode=KR&provinceCode=49&districtCode=50110
 
 `objectKeys`는 `record_media.sort_order` 오름차순으로 반환하며 미디어가 없으면 빈 배열이다. 국가 단위 기록은 `province`와 `district`가 `null`이다. Presigned GET URL 변환은 S3 조회 연동 시 추가한다.
 
-### 여행 기록 수정 및 삭제
+### 여행 기록 수정
 
-- `PUT /api/v1/travel-records/{travelRecordId}`: 생성과 같은 요청 본문으로 전체 수정한다.
-- `DELETE /api/v1/travel-records/{travelRecordId}`: 기록을 삭제한다. 연결된 `record_media` 행은 CASCADE 삭제한다. S3 객체 삭제는 별도 처리한다.
+`PUT /api/v1/travel-records/{travelRecordId}`
+
+현재 회원이 소유한 여행 기록을 생성 요청과 같은 본문으로 전체 수정한다. `objectKeys`는 수정 후 유지할 전체 미디어 목록이며 배열 순서가 노출 순서가 된다.
+
+- 기존 Object Key가 요청에도 있으면 미디어를 유지하고 순서만 변경한다.
+- 요청에서 빠진 기존 Object Key는 `record_media` 연결을 삭제한다.
+- 새 Object Key는 미디어로 추가한다.
+- `objectKeys`가 `null`이거나 빈 배열이면 모든 미디어 연결을 삭제한다.
+- S3 실제 객체 삭제와 Presigned URL 변환은 후속 작업으로 처리한다.
+
+#### Response `200 OK`
+
+수정된 여행 기록을 상세 조회와 같은 응답 구조로 반환한다.
+
+#### 오류 응답
+
+| 상태 | `code` | 조건 |
+| --- | --- | --- |
+| `400` | `VALIDATION_ERROR` | 회원 ID, 여행 기록 ID 또는 요청 본문이 올바르지 않음 |
+| `400` | `INVALID_OBJECT_KEY` | Object Key가 중복되거나 다른 기록에서 사용 중임 |
+| `404` | `TRAVEL_RECORD_NOT_FOUND` | 기록이 없거나 현재 회원의 기록이 아님 |
+
+Region 관련 오류는 생성 API와 동일하게 처리한다.
+
+### 여행 기록 삭제
+
+`DELETE /api/v1/travel-records/{travelRecordId}`: 기록을 삭제한다. 연결된 `record_media` 행은 CASCADE 삭제한다. S3 객체 삭제는 별도 처리한다.
 
 ## 5. 지역별 여행 기록 통계 API
 

--- a/backend/docs/travel-record-storage-and-query.md
+++ b/backend/docs/travel-record-storage-and-query.md
@@ -261,7 +261,31 @@ Repository에서 `travelRecordId`와 `memberId`를 함께 조건으로 사용한
 
 국가 단위 기록은 `province`와 `district`가 `null`이다. 현재는 S3 객체 키만 제공하며, Presigned GET URL 변환은 S3 연동 시 추가한다.
 
-## 9. 현재 후속 작업
+## 9. 여행 기록 수정
+
+수정 API는 현재 회원이 소유한 기록을 생성 요청과 같은 본문으로 전체 수정한다.
+
+```http
+PUT /api/v1/travel-records/{travelRecordId}
+X-Member-Id: 10
+```
+
+Service는 `travelRecordId`와 `memberId`로 소유권을 확인한 후 새 Region 경로를 조회한다. 기록이 없거나 다른 회원의 기록이면 모두 `404 TRAVEL_RECORD_NOT_FOUND`를 반환한다.
+
+미디어는 전체 삭제 후 재생성하지 않고 기존 목록과 요청의 `objectKeys`를 비교한다.
+
+| 구분 | 처리 |
+| --- | --- |
+| 기존과 요청에 모두 존재 | 기존 미디어를 유지하고 `sort_order` 변경 |
+| 기존에만 존재 | `record_media` 삭제 |
+| 요청에만 존재 | 새 `record_media` 생성 |
+| 요청이 `null` 또는 빈 배열 | 기존 미디어 전체 삭제 |
+
+중복 Object Key 또는 다른 여행 기록에서 이미 사용 중인 Object Key는 `400 INVALID_OBJECT_KEY`로 거부한다. Object Key의 회원 소유권과 S3 업로드 완료 여부 검증은 후속 작업이다.
+
+수정 성공 시 변경된 여행 기록을 상세 조회와 같은 응답 구조로 반환한다. 기록과 미디어 변경은 하나의 트랜잭션에서 처리하므로 중간에 실패하면 전체 변경이 롤백된다.
+
+## 10. 현재 후속 작업
 
 | 항목 | 상태 |
 | --- | --- |
@@ -269,6 +293,7 @@ Repository에서 `travelRecordId`와 `memberId`를 함께 조건으로 사용한
 | 전체·국가·시도·시군구 목록 조회 | 구현 |
 | 생성·목록 페이징 테스트 | 구현 |
 | 여행 기록 상세 조회 및 소유권 검사 | 구현 |
+| 여행 기록 전체 수정 및 미디어 동기화 | 구현 |
 | 목록 썸네일 URL 생성 | 미구현, 현재 `null` |
 | 상세 조회 Object Key의 Presigned GET URL 변환 | 미구현 |
 | 키워드 검색 | 미구현 |
@@ -277,7 +302,7 @@ Repository에서 `travelRecordId`와 `memberId`를 함께 조건으로 사용한
 | Region 미존재 도메인 예외 | 미구현 |
 | 성공 응답 `data` 래퍼 | 구현 |
 
-## 10. 관련 문서
+## 11. 관련 문서
 
 - [API 명세](../../api.md)
 - [ERD](erd.md)

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMedia.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMedia.java
@@ -52,6 +52,10 @@ public class RecordMedia {
         return new RecordMedia(travelRecord, objectKey, thumbKey, sortOrder);
     }
 
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
     public Long getId() {
         return id;
     }

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
@@ -1,9 +1,12 @@
 package com.mapmory.backend.recordmedia;
 
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecordMediaRepository extends JpaRepository<RecordMedia, Long> {
 
     List<RecordMedia> findByTravelRecordIdOrderBySortOrderAsc(Long travelRecordId);
+
+    List<RecordMedia> findByObjectKeyIn(Collection<String> objectKeys);
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
@@ -69,6 +69,20 @@ public class TravelRecord extends BaseEntity {
         return new TravelRecord(member, region, title, content, startDate, endDate);
     }
 
+    public void update(
+            Region region,
+            String title,
+            String content,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        this.region = region;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
     public Long getId() {
         return id;
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -89,5 +90,15 @@ public class TravelRecordController {
         );
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
+    }
+
+    @DeleteMapping("/travel-records/{travelRecordId}")
+    public ResponseEntity<Void> delete(
+            @RequestHeader("X-Member-Id") @Positive Long memberId,
+            @PathVariable @Positive Long travelRecordId
+    ) {
+        travelRecordService.delete(memberId, travelRecordId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -71,6 +72,21 @@ public class TravelRecordController {
             @PathVariable @Positive Long travelRecordId
     ) {
         TravelRecordDetailResponse response = travelRecordService.findById(memberId, travelRecordId);
+
+        return ResponseEntity.ok(TravelRecordResponse.of(response));
+    }
+
+    @PutMapping("/travel-records/{travelRecordId}")
+    public ResponseEntity<TravelRecordResponse<TravelRecordDetailResponse>> update(
+            @RequestHeader("X-Member-Id") @Positive Long memberId,
+            @PathVariable @Positive Long travelRecordId,
+            @Valid @RequestBody TravelRecordRequest travelRecordRequest
+    ) {
+        TravelRecordDetailResponse response = travelRecordService.update(
+                memberId,
+                travelRecordId,
+                travelRecordRequest
+        );
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordErrorCode.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordErrorCode.java
@@ -34,6 +34,12 @@ public enum TravelRecordErrorCode implements ErrorCode {
             "TRAVEL_RECORD_NOT_FOUND",
             "여행 일지를 찾을 수 없습니다.",
             "요청한 여행 일지가 없거나 조회할 권한이 없습니다."
+    ),
+    INVALID_OBJECT_KEY(
+            ErrorKind.INVALID_INPUT,
+            "INVALID_OBJECT_KEY",
+            "Object Key가 올바르지 않습니다.",
+            "중복되거나 다른 여행 일지에서 사용 중인 Object Key가 포함되어 있습니다."
     );
 
     private final ErrorKind kind;

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -118,6 +118,14 @@ public class TravelRecordService {
         return TravelRecordDetailResponse.from(travelRecord, updatedMedia);
     }
 
+    @Transactional
+    public void delete(Long memberId, Long travelRecordId) {
+        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, memberId)
+                .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
+
+        travelRecordRepository.delete(travelRecord);
+    }
+
     @Transactional(readOnly = true)
     public Page<TravelRecord> findAll(Long memberId, String countryCode, String provinceCode, String districtCode, int page, int size) {
         validateRegionCodeFormat(countryCode, provinceCode, districtCode);

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -9,7 +9,13 @@ import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -80,6 +86,36 @@ public class TravelRecordService {
                 .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
 
         return TravelRecordDetailResponse.from(travelRecord, recordMedia);
+    }
+
+    @Transactional
+    public TravelRecordDetailResponse update(
+            Long memberId,
+            Long travelRecordId,
+            TravelRecordRequest request
+    ) {
+        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, memberId)
+                .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
+        List<String> objectKeys = request.objectKeys() == null ? List.of() : request.objectKeys();
+        validateUniqueObjectKeys(objectKeys);
+
+        Region region = resolveRegion(request);
+        List<RecordMedia> existingMedia = recordMediaRepository
+                .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
+        validateObjectKeysAreAvailable(objectKeys, existingMedia);
+
+        travelRecord.update(
+                region,
+                request.title(),
+                request.content(),
+                request.startDate(),
+                request.endDate()
+        );
+        List<RecordMedia> updatedMedia = synchronizeMedia(travelRecord, existingMedia, objectKeys);
+
+        travelRecordRepository.flush();
+
+        return TravelRecordDetailResponse.from(travelRecord, updatedMedia);
     }
 
     @Transactional(readOnly = true)
@@ -185,5 +221,54 @@ public class TravelRecordService {
 
         Region province = regionResolver.findProvince(country, request.provinceCode());
         return regionResolver.findDistrict(province, request.districtCode());
+    }
+
+    private void validateUniqueObjectKeys(List<String> objectKeys) {
+        if (new HashSet<>(objectKeys).size() != objectKeys.size()) {
+            throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
+        }
+    }
+
+    private void validateObjectKeysAreAvailable(
+            List<String> objectKeys,
+            List<RecordMedia> existingMedia
+    ) {
+        Set<String> existingObjectKeys = existingMedia.stream()
+                .map(RecordMedia::getObjectKey)
+                .collect(Collectors.toSet());
+        List<String> newObjectKeys = objectKeys.stream()
+                .filter(objectKey -> !existingObjectKeys.contains(objectKey))
+                .toList();
+
+        if (!newObjectKeys.isEmpty()
+                && !recordMediaRepository.findByObjectKeyIn(newObjectKeys).isEmpty()) {
+            throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
+        }
+    }
+
+    private List<RecordMedia> synchronizeMedia(
+            TravelRecord travelRecord,
+            List<RecordMedia> existingMedia,
+            List<String> objectKeys
+    ) {
+        Map<String, RecordMedia> existingMediaByObjectKey = new HashMap<>();
+        for (RecordMedia recordMedia : existingMedia) {
+            existingMediaByObjectKey.put(recordMedia.getObjectKey(), recordMedia);
+        }
+
+        List<RecordMedia> updatedMedia = new ArrayList<>();
+        for (int index = 0; index < objectKeys.size(); index++) {
+            String objectKey = objectKeys.get(index);
+            RecordMedia recordMedia = existingMediaByObjectKey.remove(objectKey);
+            if (recordMedia == null) {
+                recordMedia = RecordMedia.of(travelRecord, objectKey, null, index);
+            } else {
+                recordMedia.updateSortOrder(index);
+            }
+            updatedMedia.add(recordMedia);
+        }
+
+        recordMediaRepository.deleteAll(existingMediaByObjectKey.values());
+        return recordMediaRepository.saveAll(updatedMedia);
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -177,6 +178,17 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.data.region.district.code").value("50110"))
                 .andExpect(jsonPath("$.data.objectKeys[0]")
                         .value("travel-records/10/b.jpg"));
+    }
+
+    @Test
+    void 여행_일지를_삭제한다() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(travelRecordController).build();
+
+        mockMvc.perform(delete("/api/v1/travel-records/101")
+                        .header("X-Member-Id", 10L))
+                .andExpect(status().isNoContent());
+
+        verify(travelRecordService).delete(10L, 101L);
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -26,8 +26,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.http.MediaType;
 
 @ExtendWith(MockitoExtension.class)
 class TravelRecordControllerTest {
@@ -128,6 +130,53 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.data.region.district.code").value("50110"))
                 .andExpect(jsonPath("$.data.objectKeys[0]")
                         .value("mapmory/travel-records/a.jpg"));
+    }
+
+    @Test
+    void updatesTravelRecord() throws Exception {
+        TravelRecordDetailResponse detail = new TravelRecordDetailResponse(
+                101L,
+                "수정된 제주 여행",
+                "수정된 본문",
+                new RegionDetailResponse(
+                        new RegionItemResponse("KR", "대한민국"),
+                        new RegionItemResponse("49", "제주특별자치도"),
+                        new RegionItemResponse("50110", "제주시")
+                ),
+                LocalDate.of(2026, 8, 11),
+                LocalDate.of(2026, 8, 13),
+                List.of("travel-records/10/b.jpg"),
+                null,
+                null
+        );
+        when(travelRecordService.update(
+                org.mockito.ArgumentMatchers.eq(10L),
+                org.mockito.ArgumentMatchers.eq(101L),
+                org.mockito.ArgumentMatchers.any(TravelRecordRequest.class)
+        )).thenReturn(detail);
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(travelRecordController).build();
+
+        mockMvc.perform(put("/api/v1/travel-records/101")
+                        .header("X-Member-Id", 10L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "countryCode": "KR",
+                                  "provinceCode": "49",
+                                  "districtCode": "50110",
+                                  "title": "수정된 제주 여행",
+                                  "content": "수정된 본문",
+                                  "startDate": "2026-08-11",
+                                  "endDate": "2026-08-13",
+                                  "objectKeys": ["travel-records/10/b.jpg"]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(101L))
+                .andExpect(jsonPath("$.data.title").value("수정된 제주 여행"))
+                .andExpect(jsonPath("$.data.region.district.code").value("50110"))
+                .andExpect(jsonPath("$.data.objectKeys[0]")
+                        .value("travel-records/10/b.jpg"));
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -41,7 +41,7 @@ class TravelRecordControllerTest {
     private TravelRecordController travelRecordController;
 
     @Test
-    void createsTravelRecord() {
+    void 여행_일지를_생성한다() {
         TravelRecordRequest request = new TravelRecordRequest(
                 "JP",
                 null,
@@ -75,7 +75,7 @@ class TravelRecordControllerTest {
     }
 
     @Test
-    void findsTravelRecordDetail() {
+    void 여행_일지_상세_조회를_서비스에_위임한다() {
         TravelRecordDetailResponse detail = new TravelRecordDetailResponse(
                 101L,
                 "제주 여행",
@@ -102,7 +102,7 @@ class TravelRecordControllerTest {
     }
 
     @Test
-    void respondsWithTravelRecordDetail() throws Exception {
+    void 여행_일지_상세_HTTP_응답을_반환한다() throws Exception {
         TravelRecordDetailResponse detail = new TravelRecordDetailResponse(
                 101L,
                 "제주 여행",
@@ -133,7 +133,7 @@ class TravelRecordControllerTest {
     }
 
     @Test
-    void updatesTravelRecord() throws Exception {
+    void 여행_일지를_수정한다() throws Exception {
         TravelRecordDetailResponse detail = new TravelRecordDetailResponse(
                 101L,
                 "수정된 제주 여행",
@@ -180,7 +180,7 @@ class TravelRecordControllerTest {
     }
 
     @Test
-    void rejectsRequestWithoutMemberIdHeader() throws Exception {
+    void 회원_ID_헤더가_없으면_요청을_거부한다() throws Exception {
         MockMvc mockMvc = MockMvcBuilders.standaloneSetup(travelRecordController)
                 .setControllerAdvice(new ValidationExceptionHandler(new ProblemDetailFactory()))
                 .build();

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
@@ -41,7 +41,7 @@ class TravelRecordRepositoryTest {
     private EntityManager entityManager;
 
     @Test
-    void savesTravelRecord() {
+    void 여행_일지를_저장한다() {
         Member member = memberRepository.save(Member.of("테스터", UUID.randomUUID()));
         Region testCountry = regionRepository.save(
                 Region.of(null, null, "ZZ", "테스트 국가", RegionType.COUNTRY)
@@ -66,7 +66,7 @@ class TravelRecordRepositoryTest {
     }
 
     @Test
-    void findsTravelRecordsByMemberWithPagination() {
+    void 회원의_여행_일지를_페이지로_조회한다() {
         Member member = memberRepository.save(
                 Member.of("테스터", UUID.randomUUID())
         );
@@ -101,7 +101,7 @@ class TravelRecordRepositoryTest {
     }
 
     @Test
-    void findsOwnedTravelRecordAndMediaInSortOrder() {
+    void 소유한_일지와_정렬된_미디어를_조회한다() {
         Member owner = memberRepository.save(Member.of("작성자", UUID.randomUUID()));
         Member otherMember = memberRepository.save(Member.of("다른 회원", UUID.randomUUID()));
         Region country = regionRepository.save(

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
@@ -136,4 +136,39 @@ class TravelRecordRepositoryTest {
                 .extracting(RecordMedia::getObjectKey)
                 .containsExactly("mapmory/detail/a.jpg");
     }
+
+    @Test
+    void 여행_일지를_삭제하면_연결된_미디어도_삭제한다() {
+        Member member = memberRepository.save(Member.of("삭제 테스트 회원", UUID.randomUUID()));
+        Region country = regionRepository.save(
+                Region.of(null, null, "XD", "삭제 테스트 국가", RegionType.COUNTRY)
+        );
+        TravelRecord travelRecord = travelRecordRepository.save(
+                TravelRecord.of(
+                        member,
+                        country,
+                        "삭제할 기록",
+                        "본문",
+                        LocalDate.of(2026, 8, 16),
+                        null
+                )
+        );
+        RecordMedia recordMedia = recordMediaRepository.save(
+                RecordMedia.of(travelRecord, "mapmory/delete/a.jpg", null, 0)
+        );
+        entityManager.flush();
+        entityManager.clear();
+
+        Long travelRecordId = travelRecord.getId();
+        Long recordMediaId = recordMedia.getId();
+        TravelRecord foundTravelRecord = travelRecordRepository.findById(travelRecordId)
+                .orElseThrow();
+
+        travelRecordRepository.delete(foundTravelRecord);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(travelRecordRepository.findById(travelRecordId)).isEmpty();
+        assertThat(recordMediaRepository.findById(recordMediaId)).isEmpty();
+    }
 }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
@@ -130,5 +130,10 @@ class TravelRecordRepositoryTest {
         assertThat(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(travelRecord.getId()))
                 .extracting(RecordMedia::getObjectKey)
                 .containsExactly("mapmory/detail/a.jpg", "mapmory/detail/b.jpg");
+        assertThat(recordMediaRepository.findByObjectKeyIn(
+                java.util.List.of("mapmory/detail/a.jpg")
+        ))
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly("mapmory/detail/a.jpg");
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -3,6 +3,7 @@ package com.mapmory.backend.travelrecord;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -146,6 +147,180 @@ class TravelRecordServiceTest {
                 .thenReturn(Optional.empty());
 
         assertError(() -> travelRecordService.findById(10L, 101L), "TRAVEL_RECORD_NOT_FOUND");
+        verify(recordMediaRepository, never()).findByTravelRecordIdOrderBySortOrderAsc(101L);
+    }
+
+    @Test
+    void updatesTravelRecordAndSynchronizesMedia() {
+        Region country = Region.of(null, null, "KR", "대한민국", RegionType.COUNTRY);
+        Region province = Region.of(country, country, "49", "제주특별자치도", RegionType.PROVINCE);
+        Region district = Region.of(province, country, "50110", "제주시", RegionType.DISTRICT);
+        TravelRecord travelRecord = TravelRecord.of(
+                mock(Member.class),
+                country,
+                "기존 제목",
+                "기존 본문",
+                LocalDate.of(2026, 8, 1),
+                null
+        );
+        ReflectionTestUtils.setField(travelRecord, "id", 101L);
+        RecordMedia mediaA = RecordMedia.of(travelRecord, "travel-records/10/a.jpg", null, 0);
+        RecordMedia mediaB = RecordMedia.of(travelRecord, "travel-records/10/b.jpg", null, 1);
+        TravelRecordRequest request = new TravelRecordRequest(
+                "KR",
+                "49",
+                "50110",
+                "수정된 제목",
+                "수정된 본문",
+                LocalDate.of(2026, 8, 11),
+                LocalDate.of(2026, 8, 13),
+                List.of("travel-records/10/b.jpg", "travel-records/10/c.jpg")
+        );
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.of(travelRecord));
+        when(regionResolver.findCountry("KR")).thenReturn(country);
+        when(regionResolver.findProvince(country, "49")).thenReturn(province);
+        when(regionResolver.findDistrict(province, "50110")).thenReturn(district);
+        when(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(101L))
+                .thenReturn(List.of(mediaA, mediaB));
+        when(recordMediaRepository.findByObjectKeyIn(List.of("travel-records/10/c.jpg")))
+                .thenReturn(List.of());
+        when(recordMediaRepository.saveAll(anyList()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        TravelRecordDetailResponse result = travelRecordService.update(10L, 101L, request);
+
+        assertThat(result.title()).isEqualTo("수정된 제목");
+        assertThat(result.content()).isEqualTo("수정된 본문");
+        assertThat(result.region().district().code()).isEqualTo("50110");
+        assertThat(result.objectKeys()).containsExactly(
+                "travel-records/10/b.jpg",
+                "travel-records/10/c.jpg"
+        );
+        assertThat(mediaB.getSortOrder()).isZero();
+        verify(recordMediaRepository).deleteAll(org.mockito.ArgumentMatchers.argThat(records -> {
+            java.util.Iterator<? extends RecordMedia> iterator = records.iterator();
+            return iterator.hasNext()
+                    && iterator.next() == mediaA
+                    && !iterator.hasNext();
+        }));
+    }
+
+    @Test
+    void rejectsDuplicateObjectKeysWhenUpdating() {
+        TravelRecord travelRecord = mock(TravelRecord.class);
+        TravelRecordRequest request = new TravelRecordRequest(
+                "JP",
+                null,
+                null,
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null,
+                List.of("travel-records/10/a.jpg", "travel-records/10/a.jpg")
+        );
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.of(travelRecord));
+
+        assertError(() -> travelRecordService.update(10L, 101L, request), "INVALID_OBJECT_KEY");
+        verify(regionResolver, never()).findCountry("JP");
+    }
+
+    @Test
+    void rejectsObjectKeyAlreadyUsedByAnotherTravelRecord() {
+        Region japan = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
+        TravelRecord travelRecord = TravelRecord.of(
+                mock(Member.class),
+                japan,
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
+        TravelRecordRequest request = new TravelRecordRequest(
+                "JP",
+                null,
+                null,
+                "수정된 일본 여행",
+                "수정된 본문",
+                LocalDate.of(2026, 8, 12),
+                null,
+                List.of("travel-records/20/used.jpg")
+        );
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.of(travelRecord));
+        when(regionResolver.findCountry("JP")).thenReturn(japan);
+        when(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(101L))
+                .thenReturn(List.of());
+        when(recordMediaRepository.findByObjectKeyIn(List.of("travel-records/20/used.jpg")))
+                .thenReturn(List.of(mock(RecordMedia.class)));
+
+        assertError(() -> travelRecordService.update(10L, 101L, request), "INVALID_OBJECT_KEY");
+        assertThat(travelRecord.getTitle()).isEqualTo("일본 여행");
+        verify(recordMediaRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void removesAllMediaWhenObjectKeysAreNull() {
+        Region japan = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
+        TravelRecord travelRecord = TravelRecord.of(
+                mock(Member.class),
+                japan,
+                "기존 제목",
+                "기존 본문",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
+        RecordMedia existingMedia = RecordMedia.of(
+                travelRecord,
+                "travel-records/10/a.jpg",
+                null,
+                0
+        );
+        TravelRecordRequest request = new TravelRecordRequest(
+                "JP",
+                null,
+                null,
+                "수정된 제목",
+                "수정된 본문",
+                LocalDate.of(2026, 8, 12),
+                null,
+                null
+        );
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.of(travelRecord));
+        when(regionResolver.findCountry("JP")).thenReturn(japan);
+        when(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(101L))
+                .thenReturn(List.of(existingMedia));
+        when(recordMediaRepository.saveAll(anyList()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        TravelRecordDetailResponse result = travelRecordService.update(10L, 101L, request);
+
+        assertThat(result.objectKeys()).isEmpty();
+        verify(recordMediaRepository).deleteAll(org.mockito.ArgumentMatchers.argThat(records ->
+                records.iterator().hasNext()
+        ));
+        verify(recordMediaRepository, never()).findByObjectKeyIn(anyList());
+    }
+
+    @Test
+    void rejectsUpdatingMissingOrOtherMembersTravelRecord() {
+        TravelRecordRequest request = new TravelRecordRequest(
+                "JP",
+                null,
+                null,
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null,
+                List.of()
+        );
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.empty());
+
+        assertError(() -> travelRecordService.update(10L, 101L, request), "TRAVEL_RECORD_NOT_FOUND");
+        verify(regionResolver, never()).findCountry("JP");
         verify(recordMediaRepository, never()).findByTravelRecordIdOrderBySortOrderAsc(101L);
     }
 

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -403,6 +403,26 @@ class TravelRecordServiceTest {
         assertError(() -> travelRecordService.findAll(10L, null, null, null, 0, 20), "MEMBER_NOT_FOUND");
     }
 
+    @Test
+    void 소유한_여행_일지를_삭제한다() {
+        TravelRecord travelRecord = mock(TravelRecord.class);
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.of(travelRecord));
+
+        travelRecordService.delete(10L, 101L);
+
+        verify(travelRecordRepository).delete(travelRecord);
+    }
+
+    @Test
+    void 없거나_다른_회원의_여행_일지_삭제를_거부한다() {
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.empty());
+
+        assertError(() -> travelRecordService.delete(10L, 101L), "TRAVEL_RECORD_NOT_FOUND");
+        verify(travelRecordRepository, never()).delete(any(TravelRecord.class));
+    }
+
     private Region region(Long id) {
         Region region = mock(Region.class);
         when(region.getId()).thenReturn(id);

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -61,7 +61,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void createsCountryTravelRecord() {
+    void 국가_단위_여행_일지를_생성한다() {
         Member member = mock(Member.class);
         Region japan = mock(Region.class);
         TravelRecordRequest request = new TravelRecordRequest(
@@ -81,7 +81,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void findsTravelRecordDetailWithRegionHierarchyAndOrderedObjectKeys() {
+    void 지역_계층과_정렬된_Object_Key를_포함한_일지_상세를_조회한다() {
         Region country = Region.of(null, null, "KR", "대한민국", RegionType.COUNTRY);
         Region province = Region.of(country, country, "49", "제주특별자치도", RegionType.PROVINCE);
         Region district = Region.of(province, country, "50110", "제주시", RegionType.DISTRICT);
@@ -117,7 +117,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void returnsEmptyObjectKeysForTravelRecordWithoutMedia() {
+    void 미디어가_없는_일지는_빈_Object_Key_목록을_반환한다() {
         Region japan = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
         TravelRecord travelRecord = TravelRecord.of(
                 mock(Member.class),
@@ -142,7 +142,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void rejectsMissingOrOtherMembersTravelRecord() {
+    void 없거나_다른_회원의_일지_상세_조회를_거부한다() {
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.empty());
 
@@ -151,7 +151,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void updatesTravelRecordAndSynchronizesMedia() {
+    void 여행_일지를_수정하고_미디어를_동기화한다() {
         Region country = Region.of(null, null, "KR", "대한민국", RegionType.COUNTRY);
         Region province = Region.of(country, country, "49", "제주특별자치도", RegionType.PROVINCE);
         Region district = Region.of(province, country, "50110", "제주시", RegionType.DISTRICT);
@@ -207,7 +207,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void rejectsDuplicateObjectKeysWhenUpdating() {
+    void 수정_요청의_중복_Object_Key를_거부한다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
         TravelRecordRequest request = new TravelRecordRequest(
                 "JP",
@@ -227,7 +227,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void rejectsObjectKeyAlreadyUsedByAnotherTravelRecord() {
+    void 다른_일지에서_사용_중인_Object_Key를_거부한다() {
         Region japan = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
         TravelRecord travelRecord = TravelRecord.of(
                 mock(Member.class),
@@ -261,7 +261,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void removesAllMediaWhenObjectKeysAreNull() {
+    void Object_Key가_null이면_모든_미디어를_삭제한다() {
         Region japan = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
         TravelRecord travelRecord = TravelRecord.of(
                 mock(Member.class),
@@ -305,7 +305,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void rejectsUpdatingMissingOrOtherMembersTravelRecord() {
+    void 없거나_다른_회원의_일지_수정을_거부한다() {
         TravelRecordRequest request = new TravelRecordRequest(
                 "JP",
                 null,
@@ -325,7 +325,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void findsRecordsWithoutRegionFilter() {
+    void 지역_필터_없이_일지_목록을_조회한다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberId(eq(10L), any(Pageable.class))).thenReturn(expected);
@@ -339,7 +339,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void findsRecordsByCountry() {
+    void 국가로_일지_목록을_조회한다() {
         Region korea = region(1L);
         Page<TravelRecord> expected = Page.empty();
         when(regionResolver.findCountry("KR")).thenReturn(korea);
@@ -350,7 +350,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void findsRecordsByProvince() {
+    void 시도로_일지_목록을_조회한다() {
         Region korea = mock(Region.class);
         Region jeju = region(2L);
         Page<TravelRecord> expected = Page.empty();
@@ -363,7 +363,7 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void findsRecordsByDistrict() {
+    void 시군구로_일지_목록을_조회한다() {
         Region korea = mock(Region.class);
         Region jeju = mock(Region.class);
         Region jejuCity = region(3L);
@@ -378,26 +378,26 @@ class TravelRecordServiceTest {
     }
 
     @Test
-    void rejectsInvalidRegionFilterCombination() {
+    void 잘못된_지역_필터_조합을_거부한다() {
         assertError(() -> travelRecordService.findAll(10L, null, "49", null, 0, 20), "REGION_REQUIRED");
         assertError(() -> travelRecordService.findAll(10L, "KR", null, "50110", 0, 20), "REGION_REQUIRED");
     }
 
     @Test
-    void rejectsInvalidRegionCodeFormat() {
+    void 잘못된_지역_코드_형식을_거부한다() {
         assertError(() -> travelRecordService.findAll(10L, "kr", null, null, 0, 20), "VALIDATION_ERROR");
         assertError(() -> travelRecordService.findAll(10L, "KR", " ", null, 0, 20), "VALIDATION_ERROR");
     }
 
     @Test
-    void rejectsInvalidPagination() {
+    void 잘못된_페이지네이션을_거부한다() {
         assertError(() -> travelRecordService.findAll(10L, null, null, null, -1, 20), "VALIDATION_ERROR");
         assertError(() -> travelRecordService.findAll(10L, null, null, null, 0, 0), "VALIDATION_ERROR");
         assertError(() -> travelRecordService.findAll(10L, null, null, null, 0, 101), "VALIDATION_ERROR");
     }
 
     @Test
-    void rejectsNonexistentMember() {
+    void 존재하지_않는_회원을_거부한다() {
         when(memberRepository.existsById(10L)).thenReturn(false);
 
         assertError(() -> travelRecordService.findAll(10L, null, null, null, 0, 20), "MEMBER_NOT_FOUND");


### PR DESCRIPTION
## 작업 내용

현재 회원이 소유한 여행 일지를 전체 수정하는 API를 구현했습니다.

- `PUT /api/v1/travel-records/{travelRecordId}`
- 여행 일지 ID와 회원 ID를 함께 조회하여 소유권 검사
- Region, 제목, 본문, 여행 날짜 전체 수정
- 기존 미디어와 요청 `objectKeys`를 비교해 유지·추가·삭제
- 요청 배열 순서에 맞게 `sortOrder` 갱신
- 중복되거나 다른 기록에서 사용 중인 Object Key를 `INVALID_OBJECT_KEY`로 거부
- 수정 결과를 상세 조회 응답 구조로 반환
- 여행 기록 테스트 메서드명을 한국어로 정리
- API 명세와 여행 기록 저장·조회 문서 갱신

## 미디어 동기화

전체 삭제 후 재생성하지 않고 기존 미디어를 재사용합니다.

- 기존과 요청에 모두 존재: 유지하고 순서 변경
- 기존에만 존재: DB 연결 삭제
- 요청에만 존재: 새 미디어 생성
- `null` 또는 빈 배열: 모든 미디어 연결 삭제

S3 실제 객체 삭제, Object Key의 회원 소유권 및 업로드 완료 검증은 후속 작업입니다.

## 검증

```text
./gradlew test
BUILD SUCCESSFUL
```

- Controller 수정 응답 계약 테스트
- Service 본문·Region·미디어 동기화 및 예외 테스트
- MySQL Testcontainers 기반 Repository 쿼리 테스트

## PR 의존성

이 PR은 여행 일지 상세 조회 PR #74를 기반으로 하는 스택 PR입니다. #74 머지 후 base를 `main`으로 변경합니다.

## 관련 이슈

Closes #20
