### PR TITLE
feat(travelrecord): 여행 일지 삭제 API 구현

### DIFF
--- a/api.md
+++ b/api.md
@@ -368,7 +368,22 @@ Region 관련 오류는 생성 API와 동일하게 처리한다.
 
 ### 여행 기록 삭제
 
-`DELETE /api/v1/travel-records/{travelRecordId}`: 기록을 삭제한다. 연결된 `record_media` 행은 CASCADE 삭제한다. S3 객체 삭제는 별도 처리한다.
+`DELETE /api/v1/travel-records/{travelRecordId}`
+
+현재 회원이 소유한 여행 기록을 삭제한다. 기록이 없거나 다른 회원의 기록이면 존재 여부를 숨기기 위해 동일하게 `404 TRAVEL_RECORD_NOT_FOUND`를 반환한다.
+
+연결된 `record_media` 행은 DB의 `ON DELETE CASCADE`로 함께 삭제한다. S3 실제 객체 삭제는 후속 작업으로 처리한다.
+
+#### Response `204 No Content`
+
+응답 본문은 없다.
+
+#### 오류 응답
+
+| 상태 | `code` | 조건 |
+| --- | --- | --- |
+| `400` | `VALIDATION_ERROR` | 회원 ID 또는 여행 기록 ID가 양의 정수가 아님 |
+| `404` | `TRAVEL_RECORD_NOT_FOUND` | 기록이 없거나 현재 회원의 기록이 아님 |
 
 ## 5. 지역별 여행 기록 통계 API
 

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -89,5 +90,15 @@ public class TravelRecordController {
         );
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
+    }
+
+    @DeleteMapping("/travel-records/{travelRecordId}")
+    public ResponseEntity<Void> delete(
+            @RequestHeader("X-Member-Id") @Positive Long memberId,
+            @PathVariable @Positive Long travelRecordId
+    ) {
+        travelRecordService.delete(memberId, travelRecordId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -118,6 +118,14 @@ public class TravelRecordService {
         return TravelRecordDetailResponse.from(travelRecord, updatedMedia);
     }
 
+    @Transactional
+    public void delete(Long memberId, Long travelRecordId) {
+        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, memberId)
+                .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
+
+        travelRecordRepository.delete(travelRecord);
+    }
+
     @Transactional(readOnly = true)
     public Page<TravelRecord> findAll(Long memberId, String countryCode, String provinceCode, String districtCode, int page, int size) {
         validateRegionCodeFormat(countryCode, provinceCode, districtCode);

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -177,6 +178,17 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.data.region.district.code").value("50110"))
                 .andExpect(jsonPath("$.data.objectKeys[0]")
                         .value("travel-records/10/b.jpg"));
+    }
+
+    @Test
+    void 여행_일지를_삭제한다() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(travelRecordController).build();
+
+        mockMvc.perform(delete("/api/v1/travel-records/101")
+                        .header("X-Member-Id", 10L))
+                .andExpect(status().isNoContent());
+
+        verify(travelRecordService).delete(10L, 101L);
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
@@ -136,4 +136,39 @@ class TravelRecordRepositoryTest {
                 .extracting(RecordMedia::getObjectKey)
                 .containsExactly("mapmory/detail/a.jpg");
     }
+
+    @Test
+    void 여행_일지를_삭제하면_연결된_미디어도_삭제한다() {
+        Member member = memberRepository.save(Member.of("삭제 테스트 회원", UUID.randomUUID()));
+        Region country = regionRepository.save(
+                Region.of(null, null, "XD", "삭제 테스트 국가", RegionType.COUNTRY)
+        );
+        TravelRecord travelRecord = travelRecordRepository.save(
+                TravelRecord.of(
+                        member,
+                        country,
+                        "삭제할 기록",
+                        "본문",
+                        LocalDate.of(2026, 8, 16),
+                        null
+                )
+        );
+        RecordMedia recordMedia = recordMediaRepository.save(
+                RecordMedia.of(travelRecord, "mapmory/delete/a.jpg", null, 0)
+        );
+        entityManager.flush();
+        entityManager.clear();
+
+        Long travelRecordId = travelRecord.getId();
+        Long recordMediaId = recordMedia.getId();
+        TravelRecord foundTravelRecord = travelRecordRepository.findById(travelRecordId)
+                .orElseThrow();
+
+        travelRecordRepository.delete(foundTravelRecord);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(travelRecordRepository.findById(travelRecordId)).isEmpty();
+        assertThat(recordMediaRepository.findById(recordMediaId)).isEmpty();
+    }
 }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -403,6 +403,26 @@ class TravelRecordServiceTest {
         assertError(() -> travelRecordService.findAll(10L, null, null, null, 0, 20), "MEMBER_NOT_FOUND");
     }
 
+    @Test
+    void 소유한_여행_일지를_삭제한다() {
+        TravelRecord travelRecord = mock(TravelRecord.class);
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.of(travelRecord));
+
+        travelRecordService.delete(10L, 101L);
+
+        verify(travelRecordRepository).delete(travelRecord);
+    }
+
+    @Test
+    void 없거나_다른_회원의_여행_일지_삭제를_거부한다() {
+        when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
+                .thenReturn(Optional.empty());
+
+        assertError(() -> travelRecordService.delete(10L, 101L), "TRAVEL_RECORD_NOT_FOUND");
+        verify(travelRecordRepository, never()).delete(any(TravelRecord.class));
+    }
+
     private Region region(Long id) {
         Region region = mock(Region.class);
         when(region.getId()).thenReturn(id);


### PR DESCRIPTION
## 작업 내용

현재 회원이 소유한 여행 일지를 삭제하는 API를 구현했습니다.

- `DELETE /api/v1/travel-records/{travelRecordId}`
- 여행 일지 ID와 회원 ID를 함께 조회하여 소유권 검사
- 기록이 없거나 다른 회원의 기록이면 `TRAVEL_RECORD_NOT_FOUND` 반환
- 삭제 성공 시 `204 No Content` 반환
- 여행 일지 삭제 시 연결된 `record_media` 행을 DB CASCADE로 삭제
- API 명세 최신화

S3 실제 객체 삭제는 후속 작업입니다.

## 검증

```text
./gradlew test
BUILD SUCCESSFUL
```

- Controller의 204 응답 및 서비스 위임 테스트
- Service의 소유권 기반 삭제 및 예외 테스트
- MySQL Testcontainers 기반 `record_media` CASCADE 삭제 테스트

## PR 의존성

이 PR은 여행 일지 수정 API PR #75를 기반으로 하는 스택 PR입니다. #75 머지 후 base를 `main`으로 변경합니다.

## 관련 이슈

Closes #21
