### PR TITLE
feat: Room 기반 사진 메타데이터 로컬 인덱스 추가

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.compose.multiplatform) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ minSdk = "28"
 ktor = "3.5.1"
 androidxCompose = "1.11.4"
 navigationCompose = "2.9.2"
+ksp = "2.3.10"
+room = "2.8.4"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -16,6 +18,7 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 [libraries]
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
@@ -27,3 +30,5 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidxCompose" }
 jetbrains-androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
 }
 
 kotlin {
@@ -41,6 +42,7 @@ kotlin {
 
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.androidx.room.runtime)
             implementation("androidx.activity:activity-compose:1.11.0")
             implementation("androidx.exifinterface:exifinterface:1.4.1")
         }
@@ -58,4 +60,12 @@ kotlin {
             implementation(libs.ktor.client.mock)
         }
     }
+}
+
+ksp {
+    arg("room.generateKotlin", "true")
+}
+
+dependencies {
+    add("kspAndroid", libs.androidx.room.compiler)
 }

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/local/photo/PhotoMetadataDao.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/local/photo/PhotoMetadataDao.kt
@@ -1,0 +1,48 @@
+package com.mapmory.shared.data.local.photo
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+
+@Dao
+interface PhotoMetadataDao {
+    @Query("SELECT * FROM photo_metadata")
+    suspend fun getAll(): List<PhotoMetadataEntity>
+
+    @Query(
+        """
+        SELECT * FROM photo_metadata
+        WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+        ORDER BY capturedAtMillis DESC
+        """,
+    )
+    suspend fun getLocatedPhotos(): List<PhotoMetadataEntity>
+
+    @Query(
+        """
+        SELECT * FROM photo_metadata
+        WHERE capturedAtMillis BETWEEN :fromMillis AND :toMillis
+        ORDER BY capturedAtMillis DESC
+        """,
+    )
+    suspend fun getPhotosCapturedBetween(
+        fromMillis: Long,
+        toMillis: Long,
+    ): List<PhotoMetadataEntity>
+
+    @Upsert
+    suspend fun upsertAll(photos: List<PhotoMetadataEntity>)
+
+    @Query("DELETE FROM photo_metadata WHERE scanId != :currentScanId")
+    suspend fun deleteNotSeenIn(currentScanId: Long)
+
+    @Transaction
+    suspend fun replaceSnapshot(
+        photos: List<PhotoMetadataEntity>,
+        scanId: Long,
+    ) {
+        upsertAll(photos)
+        deleteNotSeenIn(scanId)
+    }
+}

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/local/photo/PhotoMetadataDatabase.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/local/photo/PhotoMetadataDatabase.kt
@@ -1,0 +1,28 @@
+package com.mapmory.shared.data.local.photo
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [PhotoMetadataEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class PhotoMetadataDatabase : RoomDatabase() {
+    abstract fun photoMetadataDao(): PhotoMetadataDao
+
+    companion object {
+        @Volatile
+        private var instance: PhotoMetadataDatabase? = null
+
+        fun getInstance(context: Context): PhotoMetadataDatabase = instance ?: synchronized(this) {
+            instance ?: Room.databaseBuilder(
+                context.applicationContext,
+                PhotoMetadataDatabase::class.java,
+                "mapmory-photo-metadata.db",
+            ).build().also { instance = it }
+        }
+    }
+}

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/local/photo/PhotoMetadataEntity.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/local/photo/PhotoMetadataEntity.kt
@@ -1,0 +1,24 @@
+package com.mapmory.shared.data.local.photo
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * 갤러리 사진을 빠르게 찾기 위한 로컬 인덱스다.
+ * 사진 원본은 저장하지 않고 MediaStore에서 다시 읽을 수 있는 정보만 보관한다.
+ */
+@Entity(tableName = "photo_metadata")
+data class PhotoMetadataEntity(
+    @PrimaryKey val mediaId: Long,
+    val contentUri: String,
+    val displayName: String,
+    val capturedAtMillis: Long?,
+    val modifiedAtSeconds: Long,
+    val latitude: Double?,
+    val longitude: Double?,
+    val mimeType: String?,
+    val sizeBytes: Long,
+    val width: Int,
+    val height: Int,
+    val scanId: Long,
+)


### PR DESCRIPTION
## 관련 이슈

Closes #82

## 작업 내용

- Room 2.8.4와 KSP 설정을 추가했습니다.
- 사진 메타데이터 Entity와 DAO를 추가했습니다.
- 기존 Android 사진 추천 흐름에 Room 인덱스를 연결했습니다.
- MediaStore의 수정 시각이 같은 사진은 기존 위치 메타데이터를 재사용합니다.
- 새 사진과 수정된 사진만 EXIF 위치를 다시 읽습니다.
- 최신 스캔에서 사라진 사진의 메타데이터를 정리합니다.
- 추천 사진 로딩 시 이미 조회한 메타데이터를 재사용해 중복 조회를 줄였습니다.

## 저장 정책

- 저장: MediaStore ID·URI·파일명·촬영/수정 시각·위치·MIME 타입·크기·해상도·스캔 ID
- 저장하지 않음: 사진 원본 바이트·Presigned URL

## 제외 범위

- 백그라운드 자동 동기화
- 사진 원본 저장
- iOS 로컬 저장소
- 여행 기록 초안 캐시

## 검증

- `./gradlew :shared:compileAndroidMain`
- `./gradlew :shared:testAndroidHostTest :shared:jvmTest :androidApp:compileDebugKotlin`
- `git diff --check`