### PR TITLE
refactor(auth): Auth 응답 ApiResponse 통일·잔여 X-Member-Id 제거·깨진 테스트 수리

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/auth/AuthController.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/AuthController.java
@@ -5,6 +5,7 @@ import com.mapmory.backend.auth.dto.LoginResponse;
 import com.mapmory.backend.auth.dto.LogoutRequest;
 import com.mapmory.backend.auth.dto.RefreshRequest;
 import com.mapmory.backend.auth.dto.TokenResponse;
+import com.mapmory.backend.common.dto.ApiResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,15 +24,13 @@ public class AuthController {
     }
 
     @PostMapping("/login/kakao")
-    public ResponseEntity<LoginResponse> loginWithKakao(@Valid @RequestBody KakaoLoginRequest request) {
-        LoginResponse response = authService.loginWithKakao(request.kakaoAccessToken());
-        return ResponseEntity.ok(response);
+    public ApiResponse<LoginResponse> loginWithKakao(@Valid @RequestBody KakaoLoginRequest request) {
+        return ApiResponse.from(authService.loginWithKakao(request.kakaoAccessToken()));
     }
 
     @PostMapping("/token/refresh")
-    public ResponseEntity<TokenResponse> refresh(@Valid @RequestBody RefreshRequest request) {
-        TokenResponse response = authService.refresh(request.refreshToken());
-        return ResponseEntity.ok(response);
+    public ApiResponse<TokenResponse> refresh(@Valid @RequestBody RefreshRequest request) {
+        return ApiResponse.from(authService.refresh(request.refreshToken()));
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.travelrecord.mapsummary.controller;
 
+import com.mapmory.backend.auth.security.LoginMemberId;
 import com.mapmory.backend.common.dto.ApiResponse;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
@@ -8,7 +9,6 @@ import java.util.List;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,19 +24,13 @@ public class RegionMapSummaryController {
     }
 
     @GetMapping("/roots")
-    public ApiResponse<List<RegionMapSummaryResponse>> getRootSummaries(
-            @RequestHeader("X-Member-Id")
-            @Positive(message = "회원 ID는 양수여야 합니다.")
-            Long memberId
-    ) {
+    public ApiResponse<List<RegionMapSummaryResponse>> getRootSummaries(@LoginMemberId Long memberId) {
         return ApiResponse.from(regionMapSummaryService.getSummaries(memberId, null));
     }
 
     @GetMapping("/{regionId}/children")
     public ApiResponse<List<RegionMapSummaryResponse>> getChildSummaries(
-            @RequestHeader("X-Member-Id")
-            @Positive(message = "회원 ID는 양수여야 합니다.")
-            Long memberId,
+            @LoginMemberId Long memberId,
             @PathVariable
             @Positive(message = "지역 ID는 양수여야 합니다.")
             Long regionId

--- a/backend/src/test/java/com/mapmory/backend/auth/KakaoLoginIntegrationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/auth/KakaoLoginIntegrationTest.java
@@ -47,8 +47,8 @@ class KakaoLoginIntegrationTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(REQUEST_BODY))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").isNotEmpty())
-                .andExpect(jsonPath("$.isNewMember").value(true));
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.isNewMember").value(true));
 
         assertThat(memberRepository.findByProviderAndProviderId(AuthProvider.KAKAO, "100001"))
                 .isPresent();
@@ -63,13 +63,13 @@ class KakaoLoginIntegrationTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(REQUEST_BODY))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isNewMember").value(true));
+                .andExpect(jsonPath("$.data.isNewMember").value(true));
 
         mockMvc.perform(post("/api/v1/auth/login/kakao")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(REQUEST_BODY))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isNewMember").value(false));
+                .andExpect(jsonPath("$.data.isNewMember").value(false));
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/auth/RefreshTokenIntegrationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/auth/RefreshTokenIntegrationTest.java
@@ -49,8 +49,8 @@ class RefreshTokenIntegrationTest extends IntegrationTest {
 
         mockMvc.perform(refreshRequest(refreshToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").isNotEmpty())
-                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
 
         // 회전된(폐기된) 이전 refresh 재사용 → 401
         mockMvc.perform(refreshRequest(refreshToken))
@@ -91,7 +91,7 @@ class RefreshTokenIntegrationTest extends IntegrationTest {
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
-        return JsonPath.read(responseBody, "$.refreshToken");
+        return JsonPath.read(responseBody, "$.data.refreshToken");
     }
 
     private MockHttpServletRequestBuilder refreshRequest(String refreshToken) {

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
@@ -6,7 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.mapmory.backend.common.ProblemDetailFactory;
+import com.mapmory.backend.IntegrationTest;
+import com.mapmory.backend.auth.jwt.JwtProvider;
 import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.exception.MemberErrorCode;
 import com.mapmory.backend.region.RegionType;
@@ -19,21 +20,27 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(RegionMapSummaryController.class)
-@Import(ProblemDetailFactory.class)
+@AutoConfigureMockMvc
 @DisplayName("Region 지도 요약 API")
-class RegionMapSummaryControllerTest {
+class RegionMapSummaryControllerTest extends IntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private JwtProvider jwtProvider;
+
     @MockitoBean
     private RegionMapSummaryService regionMapSummaryService;
+
+    private String bearer(Long memberId) {
+        return "Bearer " + jwtProvider.issueAccessToken(memberId);
+    }
 
     @Nested
     @DisplayName("GET /api/v1/travel-records/map-summary/regions/roots")
@@ -54,7 +61,7 @@ class RegionMapSummaryControllerTest {
             ));
 
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/roots")
-                            .header("X-Member-Id", 10L))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(10L)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data[0].regionId").value(1))
                     .andExpect(jsonPath("$.data[0].code").value("KR"))
@@ -67,31 +74,11 @@ class RegionMapSummaryControllerTest {
         }
 
         @Test
-        @DisplayName("회원 ID가 양수가 아니면 400을 반환한다")
-        void rejectsNonPositiveMemberId() throws Exception {
-            mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/roots")
-                            .header("X-Member-Id", 0L))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
-        }
-
-        @Test
-        @DisplayName("회원 ID 헤더가 없으면 400을 반환한다")
-        void rejectsMissingMemberId() throws Exception {
+        @DisplayName("토큰 없이 요청하면 401을 반환한다")
+        void rejectsUnauthenticatedRequest() throws Exception {
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/roots"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
-                    .andExpect(jsonPath("$.errors[0].field").value("X-Member-Id"));
-        }
-
-        @Test
-        @DisplayName("회원 ID가 숫자 형식이 아니면 400을 반환한다")
-        void rejectsMalformedMemberId() throws Exception {
-            mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/roots")
-                            .header("X-Member-Id", "member"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
-                    .andExpect(jsonPath("$.errors[0].field").value("X-Member-Id"));
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("INVALID_ACCESS_TOKEN"));
         }
 
         @Test
@@ -101,7 +88,7 @@ class RegionMapSummaryControllerTest {
                     .thenThrow(new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/roots")
-                            .header("X-Member-Id", 999L))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(999L)))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("MEMBER_NOT_FOUND"));
         }
@@ -126,7 +113,7 @@ class RegionMapSummaryControllerTest {
             ));
 
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/1/children")
-                            .header("X-Member-Id", 10L))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(10L)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data[0].regionId").value(15))
                     .andExpect(jsonPath("$.data[0].code").value("49"))
@@ -141,7 +128,7 @@ class RegionMapSummaryControllerTest {
         @DisplayName("지역 ID가 양수가 아니면 400을 반환한다")
         void rejectsNonPositiveRegionId() throws Exception {
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/0/children")
-                            .header("X-Member-Id", 10L))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(10L)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
         }
@@ -153,7 +140,7 @@ class RegionMapSummaryControllerTest {
                     .thenThrow(new BusinessException(RegionErrorCode.REGION_NOT_FOUND));
 
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/999/children")
-                            .header("X-Member-Id", 10L))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(10L)))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("REGION_NOT_FOUND"));
         }


### PR DESCRIPTION
## 작업 내용
main 인증 마무리 정리 3가지:
1. **Auth API 응답을 공통 `ApiResponse`(`{ "data": ... }`)로 통일** — api.md 공통 규칙 준수
2. **`RegionMapSummaryController`의 `X-Member-Id` 임시 인증 제거** → `@LoginMemberId` (main의 마지막 잔존)
3. **main에서 깨져 있는 `RegionMapSummaryControllerTest` 수리** — 시큐리티 도입(#70) 후
   @WebMvcTest 슬라이스가 auth 빈(JwtAuthenticationFilter 등)을 끌어와 컨텍스트 로딩이 실패하던 것을
   Bearer 토큰 기반 통합 테스트로 재작성. **현재 main CI 실패의 원인이므로 이 PR로 복구됩니다.**

> 참고: 원래 이 브랜치는 #71/#73 코드의 main 반영(구 PR #85)이 목적이었으나, PR #87로 해당 코드가
> 이미 반영되어 rebase 후 위 정리 작업만 남았습니다.

## 변경 파일 (5개)
- `AuthController` — 로그인·재발급 응답 `ApiResponse.from(...)` 래핑 (로그아웃 204 유지)
- `RegionMapSummaryController` — `@RequestHeader("X-Member-Id")` + `@Positive` → `@LoginMemberId`
  (토큰 유래 id라 양수 검증 불필요)
- `KakaoLoginIntegrationTest` / `RefreshTokenIntegrationTest` — jsonPath `$.data.*` 갱신
- `RegionMapSummaryControllerTest` — 통합 테스트로 재작성, 헤더 검증 3건은 "토큰 없으면 401"로 대체

## 완료 조건
- [x] 로그인·재발급 응답이 `{ "data": ... }` 형식
- [x] `X-Member-Id` 사용처 0건
- [x] 전체 테스트 통과 (main에서 깨져 있던 테스트 포함)

## 참고 자료
- Closes #79
- 관련: #87(카카오·refresh main 반영), ADR 0009~0011

## 클라이언트(안드/iOS) 영향
- 로그인/재발급 응답이 `data`로 감싸집니다:
  `{ "data": { "accessToken": ..., "refreshToken": ..., "isNewMember": ... } }`
- 지도 요약 API는 `X-Member-Id` 대신 `Authorization: Bearer {accessToken}` 필요
