### PR TITLE
refactor(auth): 인증 회원을 Member 엔티티로 주입

### DIFF
--- a/backend/docs/adr/0009-authentication-with-spring-security-and-jwt.md
+++ b/backend/docs/adr/0009-authentication-with-spring-security-and-jwt.md
@@ -20,7 +20,7 @@
 ### Spring Security를 도입하고 우리 서비스의 JWT(access token)를 직접 발급·검증한다
 
 - access token은 HS256으로 서명한 JWT다. 페이로드의 `sub`에 memberId를 담는다.
-- 서명·만료만으로 검증하므로 매 요청에 DB 조회가 필요 없다(무상태).
+- 토큰 자체의 서명·만료 검증에는 DB 조회가 필요 없다.
 - 발급/검증 로직은 `JwtProvider`에 모으고, 키·만료는 `jwt.*` 설정으로 주입한다.
   (`jwt.secret`은 프로파일별: local은 개발용, prod는 환경변수)
 
@@ -29,11 +29,13 @@
 서버는 `HttpSession`을 만들지 않는다. 매 요청마다 필터가 토큰을 검증해
 `SecurityContext`를 새로 구성한다. 다중 기기·수평 확장에 유리하다.
 
-### 인증은 필터에서, memberId 주입은 ArgumentResolver로 한다
+### 인증은 필터에서, Member 주입은 ArgumentResolver로 한다
 
 - `JwtAuthenticationFilter`가 `Authorization: Bearer` 토큰을 검증해
   `SecurityContext`에 memberId를 등록한다.
-- 컨트롤러는 `@LoginMemberId`로 인증된 memberId를 주입받는다. (`X-Member-Id` 헤더 제거)
+- `LoginMemberArgumentResolver`는 `SecurityContext`의 memberId로 회원을 조회하고,
+  컨트롤러는 `@LoginMember`로 인증된 `Member`를 주입받는다. (`X-Member-Id` 헤더 제거)
+- `@LoginMember`가 선언된 요청은 현재 회원의 존재를 확인하기 위해 DB를 한 번 조회한다.
 
 ### 필터 단계의 인증·인가 실패도 Problem Details로 응답한다
 
@@ -70,5 +72,6 @@ redirect 기반 `oauth2-client` 자동화 이득은 받지 않는다. 그러나 
 ### 비용과 주의점
 
 - Spring Security의 러닝 커브와, 필터 계층 예외를 별도 처리기로 다뤄야 하는 점.
+- `@LoginMember`가 선언된 요청마다 회원 조회가 한 번 발생한다.
 - `ErrorKind`가 추가되면 웹 계층의 HTTP 상태 매핑도 함께 추가해야 한다.
 - refresh token 전략은 별도 결정으로 다룬다(후속).

--- a/backend/src/main/java/com/mapmory/backend/auth/security/LoginMember.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/security/LoginMember.java
@@ -6,9 +6,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 인증된 요청의 memberId를 컨트롤러 파라미터로 주입한다.
+ * 인증된 요청의 Member를 컨트롤러 파라미터로 주입한다.
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface LoginMemberId {
+public @interface LoginMember {
 }

--- a/backend/src/main/java/com/mapmory/backend/auth/security/LoginMemberArgumentResolver.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/security/LoginMemberArgumentResolver.java
@@ -2,6 +2,9 @@ package com.mapmory.backend.auth.security;
 
 import com.mapmory.backend.auth.exception.AuthErrorCode;
 import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.member.exception.MemberErrorCode;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -12,18 +15,24 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 /**
- * {@link LoginMemberId}가 붙은 Long 파라미터에 SecurityContext의 memberId를 주입한다.
+ * {@link LoginMember}가 붙은 Member 파라미터에 인증된 회원을 주입한다.
  *
  * 인증 정보가 없거나 형식이 예상과 다르면 인증 오류로 처리한다.
  * (보호된 엔드포인트라면 시큐리티 단계에서 이미 걸러지지만, 방어적으로 확인한다.)
  */
 @Component
-public class LoginMemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
+
+    public LoginMemberArgumentResolver(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(LoginMemberId.class)
-                && parameter.getParameterType().equals(Long.class);
+        return parameter.hasParameterAnnotation(LoginMember.class)
+                && parameter.getParameterType().equals(Member.class);
     }
 
     @Override
@@ -37,6 +46,7 @@ public class LoginMemberIdArgumentResolver implements HandlerMethodArgumentResol
         if (authentication == null || !(authentication.getPrincipal() instanceof Long memberId)) {
             throw new BusinessException(AuthErrorCode.INVALID_ACCESS_TOKEN);
         }
-        return memberId;
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/auth/security/WebMvcConfig.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/security/WebMvcConfig.java
@@ -8,14 +8,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private final LoginMemberIdArgumentResolver loginMemberIdArgumentResolver;
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
-    public WebMvcConfig(LoginMemberIdArgumentResolver loginMemberIdArgumentResolver) {
-        this.loginMemberIdArgumentResolver = loginMemberIdArgumentResolver;
+    public WebMvcConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(loginMemberIdArgumentResolver);
+        resolvers.add(loginMemberArgumentResolver);
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -1,6 +1,7 @@
 package com.mapmory.backend.travelrecord;
 
-import com.mapmory.backend.auth.security.LoginMemberId;
+import com.mapmory.backend.auth.security.LoginMember;
+import com.mapmory.backend.member.Member;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecord.dto.CreateTravelRecordResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
@@ -35,10 +36,10 @@ public class TravelRecordController {
 
     @PostMapping("/travel-records")
     public ResponseEntity<TravelRecordResponse<CreateTravelRecordResponse>> create(
-            @LoginMemberId Long memberId,
+            @LoginMember Member member,
             @Valid @RequestBody TravelRecordRequest travelRecordRequest
     ) {
-        TravelRecord travelRecord = travelRecordService.create(memberId, travelRecordRequest);
+        TravelRecord travelRecord = travelRecordService.create(member, travelRecordRequest);
         CreateTravelRecordResponse response = CreateTravelRecordResponse.from(travelRecord);
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -47,7 +48,7 @@ public class TravelRecordController {
 
     @GetMapping("/travel-records")
     public ResponseEntity<TravelRecordResponse<TravelRecordListResponse>> findAll(
-            @LoginMemberId Long memberId,
+            @LoginMember Member member,
             @RequestParam(required = false) String countryCode,
             @RequestParam(required = false) String provinceCode,
             @RequestParam(required = false) String districtCode,
@@ -55,7 +56,7 @@ public class TravelRecordController {
             @RequestParam(defaultValue = "20") int size
     ) {
         Page<TravelRecord> travelRecords = travelRecordService.findAll(
-                memberId,
+                member,
                 countryCode,
                 provinceCode,
                 districtCode,
@@ -69,22 +70,22 @@ public class TravelRecordController {
 
     @GetMapping("/travel-records/{travelRecordId}")
     public ResponseEntity<TravelRecordResponse<TravelRecordDetailResponse>> findById(
-            @LoginMemberId Long memberId,
+            @LoginMember Member member,
             @PathVariable @Positive Long travelRecordId
     ) {
-        TravelRecordDetailResponse response = travelRecordService.findById(memberId, travelRecordId);
+        TravelRecordDetailResponse response = travelRecordService.findById(member, travelRecordId);
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }
 
     @PutMapping("/travel-records/{travelRecordId}")
     public ResponseEntity<TravelRecordResponse<TravelRecordDetailResponse>> update(
-            @LoginMemberId Long memberId,
+            @LoginMember Member member,
             @PathVariable @Positive Long travelRecordId,
             @Valid @RequestBody TravelRecordRequest travelRecordRequest
     ) {
         TravelRecordDetailResponse response = travelRecordService.update(
-                memberId,
+                member,
                 travelRecordId,
                 travelRecordRequest
         );
@@ -94,10 +95,10 @@ public class TravelRecordController {
 
     @DeleteMapping("/travel-records/{travelRecordId}")
     public ResponseEntity<Void> delete(
-            @LoginMemberId Long memberId,
+            @LoginMember Member member,
             @PathVariable @Positive Long travelRecordId
     ) {
-        travelRecordService.delete(memberId, travelRecordId);
+        travelRecordService.delete(member, travelRecordId);
 
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordErrorCode.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordErrorCode.java
@@ -23,12 +23,6 @@ public enum TravelRecordErrorCode implements ErrorCode {
             "요청 값이 올바르지 않습니다.",
             "페이지 번호 또는 페이지 크기가 올바르지 않습니다."
     ),
-    MEMBER_NOT_FOUND(
-            ErrorKind.NOT_FOUND,
-            "MEMBER_NOT_FOUND",
-            "회원을 찾을 수 없습니다.",
-            "요청한 회원 ID에 해당하는 회원이 없습니다."
-    ),
     TRAVEL_RECORD_NOT_FOUND(
             ErrorKind.NOT_FOUND,
             "TRAVEL_RECORD_NOT_FOUND",

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -1,7 +1,6 @@
 package com.mapmory.backend.travelrecord;
 
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.member.MemberRepository;
 import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
@@ -30,25 +29,20 @@ public class TravelRecordService {
 
     private final TravelRecordRepository travelRecordRepository;
     private final RegionResolver regionResolver;
-    private final MemberRepository memberRepository;
     private final RecordMediaRepository recordMediaRepository;
 
     public TravelRecordService(
             TravelRecordRepository travelRecordRepository,
-            MemberRepository memberRepository,
             RegionResolver regionResolver,
             RecordMediaRepository recordMediaRepository
     ) {
         this.travelRecordRepository = travelRecordRepository;
-        this.memberRepository = memberRepository;
         this.regionResolver = regionResolver;
         this.recordMediaRepository = recordMediaRepository;
     }
 
     @Transactional
-    public TravelRecord create(Long memberId, TravelRecordRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.MEMBER_NOT_FOUND));
+    public TravelRecord create(Member member, TravelRecordRequest request) {
         Region region = regionResolver.resolve(
                 request.countryCode(),
                 request.provinceCode(),
@@ -84,8 +78,8 @@ public class TravelRecordService {
     }
 
     @Transactional(readOnly = true)
-    public TravelRecordDetailResponse findById(Long memberId, Long travelRecordId) {
-        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, memberId)
+    public TravelRecordDetailResponse findById(Member member, Long travelRecordId) {
+        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
         List<RecordMedia> recordMedia = recordMediaRepository
                 .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
@@ -95,11 +89,11 @@ public class TravelRecordService {
 
     @Transactional
     public TravelRecordDetailResponse update(
-            Long memberId,
+            Member member,
             Long travelRecordId,
             TravelRecordRequest request
     ) {
-        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, memberId)
+        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
         List<String> objectKeys = request.objectKeys() == null ? List.of() : request.objectKeys();
         validateUniqueObjectKeys(objectKeys);
@@ -124,19 +118,19 @@ public class TravelRecordService {
     }
 
     @Transactional
-    public void delete(Long memberId, Long travelRecordId) {
-        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, memberId)
+    public void delete(Member member, Long travelRecordId) {
+        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
 
         travelRecordRepository.delete(travelRecord);
     }
 
     @Transactional(readOnly = true)
-    public Page<TravelRecord> findAll(Long memberId, String countryCode, String provinceCode, String districtCode, int page, int size) {
+    public Page<TravelRecord> findAll(Member member, String countryCode, String provinceCode, String districtCode, int page, int size) {
         validateRegionCodeFormat(countryCode, provinceCode, districtCode);
         validateRegionFilterHierarchy(countryCode, provinceCode, districtCode);
         validatePagination(page, size);
-        validateMemberExists(memberId);
+        Long memberId = member.getId();
         Pageable pageable = createPageable(page, size);
 
         if (countryCode == null) {
@@ -204,12 +198,6 @@ public class TravelRecordService {
                     TravelRecordErrorCode.INVALID_PAGINATION,
                     "page는 0 이상이고 size는 1 이상 %d 이하여야 합니다.".formatted(MAX_PAGE_SIZE)
             );
-        }
-    }
-
-    private void validateMemberExists(Long memberId) {
-        if (!memberRepository.existsById(memberId)) {
-            throw new BusinessException(TravelRecordErrorCode.MEMBER_NOT_FOUND);
         }
     }
 

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
@@ -1,7 +1,8 @@
 package com.mapmory.backend.travelrecord.mapsummary.controller;
 
-import com.mapmory.backend.auth.security.LoginMemberId;
+import com.mapmory.backend.auth.security.LoginMember;
 import com.mapmory.backend.common.dto.ApiResponse;
+import com.mapmory.backend.member.Member;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
 import jakarta.validation.constraints.Positive;
@@ -24,17 +25,17 @@ public class RegionMapSummaryController {
     }
 
     @GetMapping("/roots")
-    public ApiResponse<List<RegionMapSummaryResponse>> getRootSummaries(@LoginMemberId Long memberId) {
-        return ApiResponse.from(regionMapSummaryService.getSummaries(memberId, null));
+    public ApiResponse<List<RegionMapSummaryResponse>> getRootSummaries(@LoginMember Member member) {
+        return ApiResponse.from(regionMapSummaryService.getSummaries(member, null));
     }
 
     @GetMapping("/{regionId}/children")
     public ApiResponse<List<RegionMapSummaryResponse>> getChildSummaries(
-            @LoginMemberId Long memberId,
+            @LoginMember Member member,
             @PathVariable
             @Positive(message = "지역 ID는 양수여야 합니다.")
             Long regionId
     ) {
-        return ApiResponse.from(regionMapSummaryService.getSummaries(memberId, regionId));
+        return ApiResponse.from(regionMapSummaryService.getSummaries(member, regionId));
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
@@ -1,8 +1,7 @@
 package com.mapmory.backend.travelrecord.mapsummary.service;
 
 import com.mapmory.backend.common.exception.BusinessException;
-import com.mapmory.backend.member.exception.MemberErrorCode;
-import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
@@ -15,36 +14,26 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class RegionMapSummaryService {
 
-    private final MemberRepository memberRepository;
     private final RegionRepository regionRepository;
     private final RegionMapSummaryRepository regionMapSummaryRepository;
     private final LevelPolicy levelPolicy;
 
     public RegionMapSummaryService(
-            MemberRepository memberRepository,
             RegionRepository regionRepository,
             RegionMapSummaryRepository regionMapSummaryRepository,
             LevelPolicy levelPolicy
     ) {
-        this.memberRepository = memberRepository;
         this.regionRepository = regionRepository;
         this.regionMapSummaryRepository = regionMapSummaryRepository;
         this.levelPolicy = levelPolicy;
     }
 
     @Transactional(readOnly = true)
-    public List<RegionMapSummaryResponse> getSummaries(Long memberId, Long parentRegionId) {
-        validateMember(memberId);
+    public List<RegionMapSummaryResponse> getSummaries(Member member, Long parentRegionId) {
         validateParentRegion(parentRegionId);
-        return regionMapSummaryRepository.findRegionMapSummaries(memberId, parentRegionId).stream()
+        return regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId).stream()
                 .map(result -> RegionMapSummaryResponse.from(result, levelPolicy))
                 .toList();
-    }
-
-    private void validateMember(Long memberId) {
-        if (!memberRepository.existsById(memberId)) {
-            throw new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND);
-        }
     }
 
     private void validateParentRegion(Long parentRegionId) {

--- a/backend/src/test/java/com/mapmory/backend/auth/security/LoginMemberArgumentResolverTest.java
+++ b/backend/src/test/java/com/mapmory/backend/auth/security/LoginMemberArgumentResolverTest.java
@@ -1,0 +1,87 @@
+package com.mapmory.backend.auth.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.auth.exception.AuthErrorCode;
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.member.exception.MemberErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class LoginMemberArgumentResolverTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MethodParameter methodParameter;
+
+    @InjectMocks
+    private LoginMemberArgumentResolver resolver;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void LoginMember가_붙은_Member_파라미터를_지원한다() {
+        when(methodParameter.hasParameterAnnotation(LoginMember.class)).thenReturn(true);
+        doReturn(Member.class).when(methodParameter).getParameterType();
+
+        assertThat(resolver.supportsParameter(methodParameter)).isTrue();
+    }
+
+    @Test
+    void SecurityContext의_memberId로_Member를_조회한다() {
+        Member member = Member.of("테스터", java.util.UUID.randomUUID());
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(10L, null, List.of())
+        );
+        when(memberRepository.findById(10L)).thenReturn(Optional.of(member));
+
+        Object resolved = resolver.resolveArgument(null, null, null, null);
+
+        assertThat(resolved).isSameAs(member);
+    }
+
+    @Test
+    void 인증_정보가_올바르지_않으면_인증_오류를_반환한다() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("invalid", null, List.of())
+        );
+
+        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+                .isInstanceOfSatisfying(BusinessException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.INVALID_ACCESS_TOKEN));
+        verifyNoInteractions(memberRepository);
+    }
+
+    @Test
+    void 인증된_회원을_찾을_수_없으면_MEMBER_NOT_FOUND를_반환한다() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(999L, null, List.of())
+        );
+        when(memberRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> resolver.resolveArgument(null, null, null, null))
+                .isInstanceOfSatisfying(BusinessException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/auth/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/auth/security/SecurityIntegrationTest.java
@@ -9,7 +9,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.mapmory.backend.IntegrationTest;
 import com.mapmory.backend.auth.jwt.JwtProperties;
 import com.mapmory.backend.auth.jwt.JwtProvider;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
 import java.time.Duration;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +34,9 @@ class SecurityIntegrationTest extends IntegrationTest {
     @Autowired
     private JwtProvider jwtProvider;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @Value("${jwt.secret}")
     private String secret;
 
@@ -43,12 +49,13 @@ class SecurityIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    void 유효한_토큰이면_보호된_API에_접근하고_memberId가_주입된다() throws Exception {
-        String token = jwtProvider.issueAccessToken(7L);
+    void 유효한_토큰이면_보호된_API에_접근하고_Member가_주입된다() throws Exception {
+        Member member = memberRepository.save(Member.of("인증 테스트 회원", UUID.randomUUID()));
+        String token = jwtProvider.issueAccessToken(member.getId());
 
         mockMvc.perform(get("/test/secured").header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(content().string("7"));
+                .andExpect(content().string(member.getId().toString()));
     }
 
     @Test
@@ -89,8 +96,8 @@ class SecurityIntegrationTest extends IntegrationTest {
     static class SecuredTestController {
 
         @GetMapping("/test/secured")
-        Long secured(@LoginMemberId Long memberId) {
-            return memberId;
+        Long secured(@LoginMember Member member) {
+            return member.getId();
         }
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -9,7 +9,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.mapmory.backend.auth.security.LoginMemberId;
+import com.mapmory.backend.auth.security.LoginMember;
+import com.mapmory.backend.member.Member;
 import com.mapmory.backend.travelrecord.dto.CreateTravelRecordResponse;
 import com.mapmory.backend.travelrecord.dto.RegionDetailResponse;
 import com.mapmory.backend.travelrecord.dto.RegionItemResponse;
@@ -18,6 +19,7 @@ import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecord.dto.TravelRecordResponse;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -40,6 +42,11 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 class TravelRecordControllerTest {
 
     private static final long MEMBER_ID = 10L;
+    private static final Member MEMBER = Member.of("테스터", UUID.randomUUID());
+
+    static {
+        ReflectionTestUtils.setField(MEMBER, "id", MEMBER_ID);
+    }
 
     @Mock
     private TravelRecordService travelRecordService;
@@ -47,14 +54,14 @@ class TravelRecordControllerTest {
     @InjectMocks
     private TravelRecordController travelRecordController;
 
-    // @LoginMemberId를 고정 memberId로 해석하는 리졸버. standalone MockMvc에서 HTTP·JSON 레이어만
+    // @LoginMember를 고정 Member로 해석하는 리졸버. standalone MockMvc에서 HTTP·JSON 레이어만
     // 검증하고, 실제 인증(401 등)은 SecurityIntegrationTest가 담당한다.
     private MockMvc mockMvcWithLoginMember() {
         return MockMvcBuilders.standaloneSetup(travelRecordController)
                 .setCustomArgumentResolvers(new HandlerMethodArgumentResolver() {
                     @Override
                     public boolean supportsParameter(MethodParameter parameter) {
-                        return parameter.hasParameterAnnotation(LoginMemberId.class);
+                        return parameter.hasParameterAnnotation(LoginMember.class);
                     }
 
                     @Override
@@ -64,7 +71,7 @@ class TravelRecordControllerTest {
                             NativeWebRequest webRequest,
                             WebDataBinderFactory binderFactory
                     ) {
-                        return MEMBER_ID;
+                        return MEMBER;
                     }
                 })
                 .build();
@@ -92,37 +99,37 @@ class TravelRecordControllerTest {
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
 
-        when(travelRecordService.create(MEMBER_ID, request)).thenReturn(travelRecord);
+        when(travelRecordService.create(MEMBER, request)).thenReturn(travelRecord);
 
         ResponseEntity<TravelRecordResponse<CreateTravelRecordResponse>> response =
-                travelRecordController.create(MEMBER_ID, request);
+                travelRecordController.create(MEMBER, request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(response.getBody()).isEqualTo(
                 TravelRecordResponse.of(new CreateTravelRecordResponse(1L))
         );
-        verify(travelRecordService).create(MEMBER_ID, request);
+        verify(travelRecordService).create(MEMBER, request);
     }
 
     @Test
     void 여행_일지_상세_조회를_서비스에_위임한다() {
         TravelRecordDetailResponse detail = detail("제주 여행", "제주시를 걸었다.",
                 List.of("mapmory/travel-records/a.jpg"));
-        when(travelRecordService.findById(MEMBER_ID, 101L)).thenReturn(detail);
+        when(travelRecordService.findById(MEMBER, 101L)).thenReturn(detail);
 
         ResponseEntity<TravelRecordResponse<TravelRecordDetailResponse>> response =
-                travelRecordController.findById(MEMBER_ID, 101L);
+                travelRecordController.findById(MEMBER, 101L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(TravelRecordResponse.of(detail));
-        verify(travelRecordService).findById(MEMBER_ID, 101L);
+        verify(travelRecordService).findById(MEMBER, 101L);
     }
 
     @Test
     void 여행_일지_상세_HTTP_응답을_반환한다() throws Exception {
         TravelRecordDetailResponse detail = detail("제주 여행", "제주시를 걸었다.",
                 List.of("mapmory/travel-records/a.jpg"));
-        when(travelRecordService.findById(MEMBER_ID, 101L)).thenReturn(detail);
+        when(travelRecordService.findById(MEMBER, 101L)).thenReturn(detail);
 
         mockMvcWithLoginMember().perform(get("/api/v1/travel-records/101"))
                 .andExpect(status().isOk())
@@ -139,7 +146,7 @@ class TravelRecordControllerTest {
         TravelRecordDetailResponse detail = detail("수정된 제주 여행", "수정된 본문",
                 List.of("travel-records/10/b.jpg"));
         when(travelRecordService.update(
-                ArgumentMatchers.eq(MEMBER_ID),
+                ArgumentMatchers.eq(MEMBER),
                 ArgumentMatchers.eq(101L),
                 ArgumentMatchers.any(TravelRecordRequest.class)
         )).thenReturn(detail);
@@ -171,7 +178,7 @@ class TravelRecordControllerTest {
         mockMvcWithLoginMember().perform(delete("/api/v1/travel-records/101"))
                 .andExpect(status().isNoContent());
 
-        verify(travelRecordService).delete(MEMBER_ID, 101L);
+        verify(travelRecordService).delete(MEMBER, 101L);
     }
 
     private TravelRecordDetailResponse detail(String title, String content, List<String> objectKeys) {

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 
 import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.member.MemberRepository;
 import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
 import com.mapmory.backend.region.Region;
@@ -44,9 +43,6 @@ class TravelRecordServiceTest {
     private TravelRecordRepository travelRecordRepository;
 
     @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
     private RegionResolver regionResolver;
 
     @Mock
@@ -55,25 +51,26 @@ class TravelRecordServiceTest {
     @InjectMocks
     private TravelRecordService travelRecordService;
 
+    private Member member;
+
     @BeforeEach
     void setUp() {
-        lenient().when(memberRepository.existsById(10L)).thenReturn(true);
+        member = mock(Member.class);
+        lenient().when(member.getId()).thenReturn(10L);
     }
 
     @Test
     void 국가_단위_여행_일지를_생성한다() {
-        Member member = mock(Member.class);
         Region japan = mock(Region.class);
         TravelRecordRequest request = new TravelRecordRequest(
                 "JP", null, null, "일본 여행", "", LocalDate.of(2026, 8, 11), null, List.of()
         );
 
-        when(memberRepository.findById(10L)).thenReturn(Optional.of(member));
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(10L, request);
+        TravelRecord result = travelRecordService.create(member, request);
 
         assertThat(result).isNotNull();
         verify(regionResolver).resolve("JP", null, null);
@@ -103,7 +100,7 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(101L))
                 .thenReturn(recordMedia);
 
-        TravelRecordDetailResponse result = travelRecordService.findById(10L, 101L);
+        TravelRecordDetailResponse result = travelRecordService.findById(member, 101L);
 
         assertThat(result.id()).isEqualTo(101L);
         assertThat(result.content()).isEqualTo("제주시를 걸었다.");
@@ -133,7 +130,7 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(102L))
                 .thenReturn(List.of());
 
-        TravelRecordDetailResponse result = travelRecordService.findById(10L, 102L);
+        TravelRecordDetailResponse result = travelRecordService.findById(member, 102L);
 
         assertThat(result.region().country().code()).isEqualTo("JP");
         assertThat(result.region().province()).isNull();
@@ -146,7 +143,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.empty());
 
-        assertError(() -> travelRecordService.findById(10L, 101L), "TRAVEL_RECORD_NOT_FOUND");
+        assertError(() -> travelRecordService.findById(member, 101L), "TRAVEL_RECORD_NOT_FOUND");
         verify(recordMediaRepository, never()).findByTravelRecordIdOrderBySortOrderAsc(101L);
     }
 
@@ -186,7 +183,7 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.saveAll(anyList()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecordDetailResponse result = travelRecordService.update(10L, 101L, request);
+        TravelRecordDetailResponse result = travelRecordService.update(member, 101L, request);
 
         assertThat(result.title()).isEqualTo("수정된 제목");
         assertThat(result.content()).isEqualTo("수정된 본문");
@@ -220,7 +217,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        assertError(() -> travelRecordService.update(10L, 101L, request), "INVALID_OBJECT_KEY");
+        assertError(() -> travelRecordService.update(member, 101L, request), "INVALID_OBJECT_KEY");
         verify(regionResolver, never()).resolve("JP", null, null);
     }
 
@@ -253,7 +250,7 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.findByObjectKeyIn(List.of("travel-records/20/used.jpg")))
                 .thenReturn(List.of(mock(RecordMedia.class)));
 
-        assertError(() -> travelRecordService.update(10L, 101L, request), "INVALID_OBJECT_KEY");
+        assertError(() -> travelRecordService.update(member, 101L, request), "INVALID_OBJECT_KEY");
         assertThat(travelRecord.getTitle()).isEqualTo("일본 여행");
         verify(recordMediaRepository, never()).saveAll(anyList());
     }
@@ -293,7 +290,7 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.saveAll(anyList()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecordDetailResponse result = travelRecordService.update(10L, 101L, request);
+        TravelRecordDetailResponse result = travelRecordService.update(member, 101L, request);
 
         assertThat(result.objectKeys()).isEmpty();
         verify(recordMediaRepository).deleteAll(org.mockito.ArgumentMatchers.argThat(records ->
@@ -317,7 +314,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.empty());
 
-        assertError(() -> travelRecordService.update(10L, 101L, request), "TRAVEL_RECORD_NOT_FOUND");
+        assertError(() -> travelRecordService.update(member, 101L, request), "TRAVEL_RECORD_NOT_FOUND");
         verify(regionResolver, never()).resolve("JP", null, null);
         verify(recordMediaRepository, never()).findByTravelRecordIdOrderBySortOrderAsc(101L);
     }
@@ -328,7 +325,7 @@ class TravelRecordServiceTest {
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberId(eq(10L), any(Pageable.class))).thenReturn(expected);
 
-        Page<TravelRecord> result = travelRecordService.findAll(10L, null, null, null, 0, 20);
+        Page<TravelRecord> result = travelRecordService.findAll(member, null, null, null, 0, 20);
 
         assertThat(result).isEqualTo(expected);
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
@@ -344,7 +341,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByMemberIdAndCountryId(eq(10L), eq(1L), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(10L, "KR", null, null, 0, 20)).isEqualTo(expected);
+        assertThat(travelRecordService.findAll(member, "KR", null, null, 0, 20)).isEqualTo(expected);
     }
 
     @Test
@@ -356,7 +353,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByMemberIdAndProvinceId(eq(10L), eq(2L), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(10L, "KR", "49", null, 0, 20)).isEqualTo(expected);
+        assertThat(travelRecordService.findAll(member, "KR", "49", null, 0, 20)).isEqualTo(expected);
     }
 
     @Test
@@ -369,33 +366,26 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByMemberIdAndRegionId(eq(10L), eq(3L), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(10L, "KR", "49", "50110", 0, 20)).isEqualTo(expected);
+        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", 0, 20)).isEqualTo(expected);
     }
 
     @Test
     void 잘못된_지역_필터_조합을_거부한다() {
-        assertError(() -> travelRecordService.findAll(10L, null, "49", null, 0, 20), "REGION_REQUIRED");
-        assertError(() -> travelRecordService.findAll(10L, "KR", null, "50110", 0, 20), "REGION_REQUIRED");
+        assertError(() -> travelRecordService.findAll(member, null, "49", null, 0, 20), "REGION_REQUIRED");
+        assertError(() -> travelRecordService.findAll(member, "KR", null, "50110", 0, 20), "REGION_REQUIRED");
     }
 
     @Test
     void 잘못된_지역_코드_형식을_거부한다() {
-        assertError(() -> travelRecordService.findAll(10L, "kr", null, null, 0, 20), "VALIDATION_ERROR");
-        assertError(() -> travelRecordService.findAll(10L, "KR", " ", null, 0, 20), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, "kr", null, null, 0, 20), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, "KR", " ", null, 0, 20), "VALIDATION_ERROR");
     }
 
     @Test
     void 잘못된_페이지네이션을_거부한다() {
-        assertError(() -> travelRecordService.findAll(10L, null, null, null, -1, 20), "VALIDATION_ERROR");
-        assertError(() -> travelRecordService.findAll(10L, null, null, null, 0, 0), "VALIDATION_ERROR");
-        assertError(() -> travelRecordService.findAll(10L, null, null, null, 0, 101), "VALIDATION_ERROR");
-    }
-
-    @Test
-    void 존재하지_않는_회원을_거부한다() {
-        when(memberRepository.existsById(10L)).thenReturn(false);
-
-        assertError(() -> travelRecordService.findAll(10L, null, null, null, 0, 20), "MEMBER_NOT_FOUND");
+        assertError(() -> travelRecordService.findAll(member, null, null, null, -1, 20), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, null, null, null, 0, 0), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, null, null, null, 0, 101), "VALIDATION_ERROR");
     }
 
     @Test
@@ -404,7 +394,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        travelRecordService.delete(10L, 101L);
+        travelRecordService.delete(member, 101L);
 
         verify(travelRecordRepository).delete(travelRecord);
     }
@@ -414,7 +404,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.empty());
 
-        assertError(() -> travelRecordService.delete(10L, 101L), "TRAVEL_RECORD_NOT_FOUND");
+        assertError(() -> travelRecordService.delete(member, 101L), "TRAVEL_RECORD_NOT_FOUND");
         verify(travelRecordRepository, never()).delete(any(TravelRecord.class));
     }
 

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
@@ -1,5 +1,9 @@
 package com.mapmory.backend.travelrecord.mapsummary.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -9,13 +13,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.mapmory.backend.IntegrationTest;
 import com.mapmory.backend.auth.jwt.JwtProvider;
 import com.mapmory.backend.common.exception.BusinessException;
-import com.mapmory.backend.member.exception.MemberErrorCode;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
 import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,8 +42,19 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
     @Autowired
     private JwtProvider jwtProvider;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @MockitoBean
     private RegionMapSummaryService regionMapSummaryService;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUpMember() {
+        Member member = memberRepository.save(Member.of("지도 요약 테스트 회원", UUID.randomUUID()));
+        memberId = member.getId();
+    }
 
     private String bearer(Long memberId) {
         return "Bearer " + jwtProvider.issueAccessToken(memberId);
@@ -49,7 +67,7 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
         @Test
         @DisplayName("회원의 루트 지역별 지도 요약을 의미 기반 단계와 함께 반환한다")
         void returnsRootSummaries() throws Exception {
-            when(regionMapSummaryService.getSummaries(10L, null)).thenReturn(List.of(
+            when(regionMapSummaryService.getSummaries(any(Member.class), isNull())).thenReturn(List.of(
                     new RegionMapSummaryResponse(
                             1L,
                             "KR",
@@ -61,7 +79,7 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
             ));
 
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/roots")
-                            .header(HttpHeaders.AUTHORIZATION, bearer(10L)))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(memberId)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data[0].regionId").value(1))
                     .andExpect(jsonPath("$.data[0].code").value("KR"))
@@ -70,7 +88,10 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
                     .andExpect(jsonPath("$.data[0].count").value(3))
                     .andExpect(jsonPath("$.data[0].level").value("MEDIUM"));
 
-            verify(regionMapSummaryService).getSummaries(10L, null);
+            verify(regionMapSummaryService).getSummaries(
+                    argThat(member -> member.getId().equals(memberId)),
+                    isNull()
+            );
         }
 
         @Test
@@ -84,11 +105,8 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
         @Test
         @DisplayName("회원을 찾을 수 없으면 MEMBER_NOT_FOUND를 반환한다")
         void returnsMemberNotFound() throws Exception {
-            when(regionMapSummaryService.getSummaries(999L, null))
-                    .thenThrow(new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
-
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/roots")
-                            .header(HttpHeaders.AUTHORIZATION, bearer(999L)))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(Long.MAX_VALUE)))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("MEMBER_NOT_FOUND"));
         }
@@ -101,7 +119,7 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
         @Test
         @DisplayName("선택 지역의 직속 하위 지역별 지도 요약을 반환한다")
         void returnsChildSummaries() throws Exception {
-            when(regionMapSummaryService.getSummaries(10L, 1L)).thenReturn(List.of(
+            when(regionMapSummaryService.getSummaries(any(Member.class), eq(1L))).thenReturn(List.of(
                     new RegionMapSummaryResponse(
                             15L,
                             "49",
@@ -113,7 +131,7 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
             ));
 
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/1/children")
-                            .header(HttpHeaders.AUTHORIZATION, bearer(10L)))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(memberId)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data[0].regionId").value(15))
                     .andExpect(jsonPath("$.data[0].code").value("49"))
@@ -121,14 +139,17 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
                     .andExpect(jsonPath("$.data[0].count").value(3))
                     .andExpect(jsonPath("$.data[0].level").value("MEDIUM"));
 
-            verify(regionMapSummaryService).getSummaries(10L, 1L);
+            verify(regionMapSummaryService).getSummaries(
+                    argThat(member -> member.getId().equals(memberId)),
+                    eq(1L)
+            );
         }
 
         @Test
         @DisplayName("지역 ID가 양수가 아니면 400을 반환한다")
         void rejectsNonPositiveRegionId() throws Exception {
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/0/children")
-                            .header(HttpHeaders.AUTHORIZATION, bearer(10L)))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(memberId)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
         }
@@ -136,11 +157,11 @@ class RegionMapSummaryControllerTest extends IntegrationTest {
         @Test
         @DisplayName("상위 지역을 찾을 수 없으면 REGION_NOT_FOUND를 반환한다")
         void returnsRegionNotFound() throws Exception {
-            when(regionMapSummaryService.getSummaries(10L, 999L))
+            when(regionMapSummaryService.getSummaries(any(Member.class), eq(999L)))
                     .thenThrow(new BusinessException(RegionErrorCode.REGION_NOT_FOUND));
 
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/999/children")
-                            .header(HttpHeaders.AUTHORIZATION, bearer(10L)))
+                            .header(HttpHeaders.AUTHORIZATION, bearer(memberId)))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("REGION_NOT_FOUND"));
         }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
@@ -7,8 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.mapmory.backend.common.exception.BusinessException;
-import com.mapmory.backend.member.exception.MemberErrorCode;
-import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
@@ -32,7 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RegionMapSummaryServiceTest {
 
     @Mock
-    private MemberRepository memberRepository;
+    private Member member;
 
     @Mock
     private RegionRepository regionRepository;
@@ -50,11 +49,11 @@ class RegionMapSummaryServiceTest {
         @DisplayName("부모 ID가 없으면 루트 국가별 요약을 반환한다")
         void returnsRootCountrySummaries() {
             RegionMapSummaryService service = service();
-            when(memberRepository.existsById(10L)).thenReturn(true);
+            when(member.getId()).thenReturn(10L);
             when(regionMapSummaryRepository.findRegionMapSummaries(10L, null))
                     .thenReturn(List.of(result(1L, "KR", "대한민국", "COUNTRY", 3L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(10L, null);
+            List<RegionMapSummaryResponse> responses = service.getSummaries(member, null);
 
             assertThat(responses).containsExactly(new RegionMapSummaryResponse(
                     1L,
@@ -81,12 +80,12 @@ class RegionMapSummaryServiceTest {
                 String name
         ) {
             RegionMapSummaryService service = service();
-            when(memberRepository.existsById(10L)).thenReturn(true);
+            when(member.getId()).thenReturn(10L);
             when(regionRepository.existsById(parentRegionId)).thenReturn(true);
             when(regionMapSummaryRepository.findRegionMapSummaries(10L, parentRegionId))
                     .thenReturn(List.of(result(childRegionId, regionCode, name, regionType, 1L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(10L, parentRegionId);
+            List<RegionMapSummaryResponse> responses = service.getSummaries(member, parentRegionId);
 
             assertThat(responses).containsExactly(new RegionMapSummaryResponse(
                     childRegionId,
@@ -99,26 +98,12 @@ class RegionMapSummaryServiceTest {
         }
 
         @Test
-        @DisplayName("회원을 찾을 수 없으면 Region과 기록을 조회하지 않는다")
-        void rejectsUnknownMember() {
-            RegionMapSummaryService service = service();
-            when(memberRepository.existsById(999L)).thenReturn(false);
-
-            assertThatThrownBy(() -> service.getSummaries(999L, 1L))
-                    .isInstanceOfSatisfying(BusinessException.class, exception ->
-                            assertThat(exception.getErrorCode()).isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
-            verify(regionRepository, never()).existsById(1L);
-            verify(regionMapSummaryRepository, never()).findRegionMapSummaries(999L, 1L);
-        }
-
-        @Test
         @DisplayName("부모 Region을 찾을 수 없으면 기록을 조회하지 않는다")
         void rejectsUnknownParentRegion() {
             RegionMapSummaryService service = service();
-            when(memberRepository.existsById(10L)).thenReturn(true);
             when(regionRepository.existsById(999L)).thenReturn(false);
 
-            assertThatThrownBy(() -> service.getSummaries(10L, 999L))
+            assertThatThrownBy(() -> service.getSummaries(member, 999L))
                     .isInstanceOfSatisfying(BusinessException.class, exception ->
                             assertThat(exception.getErrorCode()).isEqualTo(RegionErrorCode.REGION_NOT_FOUND));
             verify(regionMapSummaryRepository, never()).findRegionMapSummaries(10L, 999L);
@@ -127,7 +112,6 @@ class RegionMapSummaryServiceTest {
 
     private RegionMapSummaryService service() {
         return new RegionMapSummaryService(
-                memberRepository,
                 regionRepository,
                 regionMapSummaryRepository,
                 levelPolicy


### PR DESCRIPTION
## 변경 사항

- @LoginMemberId Long memberId를 @LoginMember Member member로 변경했습니다.
- LoginMemberArgumentResolver가 SecurityContext의 회원 ID로 Member를 조회하도록 했습니다.
- 여행 기록과 지도 요약 컨트롤러·서비스가 Member를 직접 전달받도록 수정했습니다.
- 서비스에 중복되어 있던 회원 조회 및 존재 검증을 제거했습니다.
- 회원 조회 실패를 공통 MemberErrorCode.MEMBER_NOT_FOUND로 통일했습니다.
- 인증 ADR과 관련 단위·통합 테스트를 변경된 흐름에 맞췄습니다.

## 배경

컨트롤러가 회원 ID만 주입받으면서 서비스마다 회원 조회 또는 존재 확인을 반복하고 있었습니다. 인증 회원 조회 책임을 Argument Resolver에 모아 컨트롤러와 서비스의 회원 전달 방식을 일관되게 만들었습니다.

## 영향 및 고려사항

- @LoginMember를 사용하는 요청은 인증 회원의 현재 존재 여부를 확인하기 위해 DB 조회가 한 번 발생합니다.
- 여행 기록 생성·목록 및 지도 요약 API는 기존 회원 조회·검증이 Resolver로 이동하므로 중복 조회가 제거됩니다.
- 여행 기록 상세·수정·삭제 API에는 회원 조회 한 번이 추가됩니다.

## 검증

- [x] ./gradlew.bat compileTestJava
- [x] LoginMemberArgumentResolverTest
- [x] TravelRecordServiceTest
- [x] TravelRecordControllerTest
- [x] RegionMapSummaryServiceTest

Closes #92