### PR TITLE
perf: 사진 추천 성능 계측 및 검증 문서 추가

### DIFF
--- a/client/docs/performance/photo-loading-benchmark.md
+++ b/client/docs/performance/photo-loading-benchmark.md
@@ -1,0 +1,87 @@
+# 사진 추천 로딩 측정 결과
+
+## 측정 목적
+
+Room 기반 사진 메타데이터 인덱스를 연결한 뒤, 사진 추천 흐름의 단계별 소요 시간과 EXIF 좌표 재사용 여부를 확인한다.
+
+## 측정 환경
+
+- 측정일: 2026-08-18
+- 기기: Samsung SM-S938N (`R3CY103RRNL`)
+- 흐름: 장소 선택 후 사진 추천 실행
+- 측정 횟수: 3회
+- 사진 목록: 3장
+- 로그 태그: `MapmoryPhotoPerf`
+
+## 사진 추가 흐름 측정
+
+`사진 추가` 버튼은 장소 기반 추천과 다른 갤러리 선택 흐름이다. 이 흐름에서는 다음 로그가 출력된다.
+
+```text
+pick_total_ms=... requested_photos=... loaded_photos=...
+```
+
+Android Studio System Trace에서는 다음 구간을 확인할 수 있다.
+
+- `photo.pick.total`: 사진 추가 전체 시간
+- `photo.pick.read`: 선택한 사진 목록 처리 시간
+- `photo.read.metadata`: 사진 이름·촬영일 조회
+- `photo.read.exif`: EXIF 위치 조회
+- `photo.read.preview`: 썸네일 로딩 및 JPEG 변환
+
+따라서 `사진 추가` 버튼을 눌렀을 때는 `recommend_total_ms`가 아니라 `pick_total_ms`가 출력되는 것이 정상이다.
+
+### 사진 추가 실측 예시
+
+| 실행 | 전체 시간 | 선택 사진 | 정상 로딩 사진 |
+| --- | ---: | ---: | ---: |
+| 1회차 | 67ms | 3장 | 1장 |
+| 2회차 | 60ms | 3장 | 1장 |
+
+두 실행의 차이는 7ms로, 1회차 대비 약 10.4% 감소했다. 그러나 동일한 빌드에서 2회만 측정했고 정상 로딩 사진 수가 1장으로 같으므로, 유의미한 성능 개선이나 Room의 효과로 해석하지 않는다. 특히 사진을 직접 추가하는 흐름은 Room 메타데이터 인덱스를 사용하지 않는다.
+
+## 측정 결과
+
+| 실행 | 전체 | 장소 검색 | 메타데이터 동기화 | 이전 사진 | EXIF 조회 | 재사용 좌표 | 추천 사진 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1회차 | 300ms | 217ms | 81ms | 0 | 3회 | 0개 | 0장 |
+| 2회차 | 174ms | 137ms | 37ms | 3 | 3회 | 0개 | 0장 |
+| 3회차 | 159ms | 128ms | 30ms | 3 | 3회 | 0개 | 0장 |
+
+### 1회차 대비 변화
+
+| 항목 | 2회차 변화 | 3회차 변화 |
+| --- | ---: | ---: |
+| 전체 시간 | 126ms 감소, 약 42.0% 감소 | 141ms 감소, 약 47.0% 감소 |
+| 메타데이터 동기화 | 44ms 감소, 약 54.3% 감소 | 51ms 감소, 약 63.0% 감소 |
+| 장소 검색 | 80ms 감소, 약 36.9% 감소 | 89ms 감소, 약 41.0% 감소 |
+
+## 해석
+
+1. 전체 추천 시간은 300ms에서 159ms로 감소했다.
+2. 메타데이터 동기화 시간도 81ms에서 30ms로 감소했다.
+3. 그러나 `exif_reads=3`, `reused_coordinates=0`이 모든 실행에서 동일했다. 따라서 이번 측정만으로는 Room이 EXIF 재조회를 줄였다고 판단할 수 없다.
+4. 장소 검색 시간도 217ms에서 128ms로 함께 감소했으므로, 이후 실행에서 나타난 개선에는 기기·지오코더·파일 접근 등의 워밍업 효과가 포함되었을 가능성이 있다.
+5. `reverse_geocode_ms=0`, `preview_ms=0`, `recommended_photos=0`이므로 실제 추천 사진의 역지오코딩과 미리보기 로딩까지 측정된 결과는 아니다.
+
+## 현재 결론
+
+이번 결과는 “두 번째와 세 번째 실행이 첫 실행보다 빨라졌다”는 사실은 보여주지만, “Room 적용으로 빨라졌다”는 인과관계까지 증명하지는 못한다.
+
+Room 캐시 효과를 확인하려면 다음 조건의 로그가 필요하다.
+
+```text
+previous_photos=3
+exif_reads=0
+reused_coordinates=3
+```
+
+이를 확인하려면 GPS 좌표가 포함된 사진을 사용하고, 동일한 사진 목록으로 앱 데이터를 초기화한 뒤 첫 실행과 재실행을 비교해야 한다. 또한 장소와 일치하는 사진이 있어 `recommended_photos`가 1장 이상이 되어야 미리보기 로딩 시간도 함께 측정할 수 있다.
+
+## 측정 로그
+
+```text
+recommend_total_ms=300 target_geocode_ms=217 metadata_sync_ms=81 reverse_geocode_ms=0 preview_ms=0 previous_photos=0 media_store_photos=3 exif_reads=3 reused_coordinates=0 recommended_photos=0
+recommend_total_ms=174 target_geocode_ms=137 metadata_sync_ms=37 reverse_geocode_ms=0 preview_ms=0 previous_photos=3 media_store_photos=3 exif_reads=3 reused_coordinates=0 recommended_photos=0
+recommend_total_ms=159 target_geocode_ms=128 metadata_sync_ms=30 reverse_geocode_ms=0 preview_ms=0 previous_photos=3 media_store_photos=3 exif_reads=3 reused_coordinates=0 recommended_photos=0
+```

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
@@ -11,7 +11,10 @@ import android.location.Geocoder
 import android.location.Address
 import android.net.Uri
 import android.os.Build
+import android.os.SystemClock
+import android.os.Trace
 import android.provider.MediaStore
+import android.util.Log
 import android.util.Size
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -80,7 +83,21 @@ actual fun rememberPhotoLibraryActions(
         if (uris.isEmpty()) return@rememberLauncherForActivityResult
         scope.launch {
             val photos = withContext(Dispatchers.IO) {
-                uris.mapNotNull { uri -> context.readPhoto(uri) }
+                Trace.beginAsyncSection("photo.pick.total", TraceCookie.Pick)
+                val startedAt = SystemClock.elapsedRealtime()
+                try {
+                    val result = traceSection("photo.pick.read") {
+                        uris.mapNotNull { uri -> context.readPhoto(uri) }
+                    }
+                    logPhotoPickPerformance(
+                        totalMillis = SystemClock.elapsedRealtime() - startedAt,
+                        requestedPhotoCount = uris.size,
+                        loadedPhotoCount = result.size,
+                    )
+                    result
+                } finally {
+                    Trace.endAsyncSection("photo.pick.total", TraceCookie.Pick)
+                }
             }
             if (photos.isEmpty()) {
                 latestMessage("선택한 사진을 읽지 못했어요.")
@@ -153,65 +170,108 @@ private data class GalleryEntry(
     val distanceMeters: Float,
 )
 
+private data class PhotoMetadataSyncResult(
+    val photos: List<PhotoMetadataEntity>,
+    val exifReadCount: Int,
+    val reusedCoordinateCount: Int,
+    val previousPhotoCount: Int,
+)
+
 @Suppress("DEPRECATION")
 private suspend fun Context.recommendPhotos(
     target: Location,
     parentName: String?,
 ): List<SelectedPhoto> {
-    val geocoder = Geocoder(this, Locale.KOREA)
-    val targetAddress = geocoder
-        .getFromLocationName(target.recommendationSearchText(parentName), 1)
-        ?.firstOrNull()
-        ?: return emptyList()
-    val targetLatitude = targetAddress.latitude
-    val targetLongitude = targetAddress.longitude
-    val radius = target.recommendationRadiusMeters()
-    val photos = syncPhotoMetadata()
-    val entries = photos.mapNotNull { photo ->
-        val latitude = photo.latitude ?: return@mapNotNull null
-        val longitude = photo.longitude ?: return@mapNotNull null
-        val distance = FloatArray(1)
-        android.location.Location.distanceBetween(
-            targetLatitude,
-            targetLongitude,
-            latitude,
-            longitude,
-            distance,
+    Trace.beginAsyncSection("photo.recommend.total", TraceCookie.Recommend)
+    val totalStartedAt = SystemClock.elapsedRealtime()
+    try {
+        val geocoder = Geocoder(this, Locale.KOREA)
+        val geocodeStartedAt = SystemClock.elapsedRealtime()
+        val targetAddress = traceSection("photo.recommend.target_geocode") {
+            geocoder
+                .getFromLocationName(target.recommendationSearchText(parentName), 1)
+                ?.firstOrNull()
+        }
+        val geocodeMillis = SystemClock.elapsedRealtime() - geocodeStartedAt
+        if (targetAddress == null) return emptyList()
+
+        val targetLatitude = targetAddress.latitude
+        val targetLongitude = targetAddress.longitude
+        val radius = target.recommendationRadiusMeters()
+        val syncStartedAt = SystemClock.elapsedRealtime()
+        val syncResult = syncPhotoMetadata()
+        val syncMillis = SystemClock.elapsedRealtime() - syncStartedAt
+        val entries = traceSection("photo.recommend.distance_filter") {
+            syncResult.photos.mapNotNull { photo ->
+                val latitude = photo.latitude ?: return@mapNotNull null
+                val longitude = photo.longitude ?: return@mapNotNull null
+                val distance = FloatArray(1)
+                android.location.Location.distanceBetween(
+                    targetLatitude,
+                    targetLongitude,
+                    latitude,
+                    longitude,
+                    distance,
+                )
+                if (distance[0] > radius) return@mapNotNull null
+                GalleryEntry(photo, latitude, longitude, distance[0])
+            }
+        }
+
+        if (!Geocoder.isPresent()) {
+            error("이 기기에서는 사진 위치의 행정구역을 확인할 수 없어요.")
+        }
+
+        val reverseGeocodeStartedAt = SystemClock.elapsedRealtime()
+        val matchedEntries = traceSection("photo.recommend.reverse_geocode") {
+            entries
+                .sortedBy(GalleryEntry::distanceMeters)
+                .take(MaxReverseGeocodeCandidates)
+                .filter { entry ->
+                    runCatching {
+                        geocoder
+                            .getFromLocation(entry.latitude, entry.longitude, 1)
+                            ?.firstOrNull()
+                            ?.toAdministrativeArea()
+                            ?.matches(target, parentName) == true
+                    }.getOrDefault(false)
+                }
+                .take(MaxRecommendedPhotos)
+        }
+        val reverseGeocodeMillis = SystemClock.elapsedRealtime() - reverseGeocodeStartedAt
+        val previewStartedAt = SystemClock.elapsedRealtime()
+        val result = traceSection("photo.recommend.preview") {
+            matchedEntries.mapNotNull { entry ->
+                readPhoto(
+                    uri = Uri.parse(entry.photo.contentUri),
+                    knownName = entry.photo.displayName,
+                    knownCoordinates = entry.latitude to entry.longitude,
+                    knownCapturedAtMillis = entry.photo.capturedAtMillis,
+                )
+            }
+        }
+        val previewMillis = SystemClock.elapsedRealtime() - previewStartedAt
+        logPerformance(
+            totalMillis = SystemClock.elapsedRealtime() - totalStartedAt,
+            geocodeMillis = geocodeMillis,
+            syncMillis = syncMillis,
+            reverseGeocodeMillis = reverseGeocodeMillis,
+            previewMillis = previewMillis,
+            syncResult = syncResult,
+            recommendedPhotoCount = result.size,
         )
-        if (distance[0] > radius) return@mapNotNull null
-        GalleryEntry(photo, latitude, longitude, distance[0])
+        return result
+    } finally {
+        Trace.endAsyncSection("photo.recommend.total", TraceCookie.Recommend)
     }
-
-    if (!Geocoder.isPresent()) {
-        error("이 기기에서는 사진 위치의 행정구역을 확인할 수 없어요.")
-    }
-
-    return entries
-        .sortedBy(GalleryEntry::distanceMeters)
-        .take(MaxReverseGeocodeCandidates)
-        .filter { entry ->
-            runCatching {
-                geocoder
-                    .getFromLocation(entry.latitude, entry.longitude, 1)
-                    ?.firstOrNull()
-                    ?.toAdministrativeArea()
-                    ?.matches(target, parentName) == true
-            }.getOrDefault(false)
-        }
-        .take(MaxRecommendedPhotos)
-        .mapNotNull { entry ->
-            readPhoto(
-                uri = Uri.parse(entry.photo.contentUri),
-                knownName = entry.photo.displayName,
-                knownCoordinates = entry.latitude to entry.longitude,
-                knownCapturedAtMillis = entry.photo.capturedAtMillis,
-            )
-        }
 }
 
-private suspend fun Context.syncPhotoMetadata(): List<PhotoMetadataEntity> {
+private suspend fun Context.syncPhotoMetadata(): PhotoMetadataSyncResult {
     val dao = PhotoMetadataDatabase.getInstance(this).photoMetadataDao()
-    val previousById = dao.getAll().associateBy(PhotoMetadataEntity::mediaId)
+    val previousPhotos = traceSuspendSection("photo.sync.room.read", TraceCookie.RoomRead) {
+        dao.getAll()
+    }
+    val previousById = previousPhotos.associateBy(PhotoMetadataEntity::mediaId)
     val scanId = System.currentTimeMillis()
     val projection = arrayOf(
         MediaStore.Images.Media._ID,
@@ -223,57 +283,136 @@ private suspend fun Context.syncPhotoMetadata(): List<PhotoMetadataEntity> {
         MediaStore.Images.Media.WIDTH,
         MediaStore.Images.Media.HEIGHT,
     )
-    val photos = contentResolver.query(
-        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-        projection,
-        null,
-        null,
-        "${MediaStore.Images.Media.DATE_TAKEN} DESC",
-    )?.use { cursor ->
-        val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
-        buildList<PhotoMetadataEntity> {
-            while (cursor.moveToNext()) {
-                val mediaId = cursor.getLong(idColumn)
-                val uri = ContentUris.withAppendedId(
-                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                    mediaId,
-                )
-                val modifiedAtSeconds = cursor.getLongOrNull(MediaStore.Images.Media.DATE_MODIFIED) ?: 0L
-                val previous = previousById[mediaId]
-                val coordinates = if (
-                    previous != null &&
-                    previous.modifiedAtSeconds == modifiedAtSeconds &&
-                    previous.latitude != null &&
-                    previous.longitude != null
-                ) {
-                    requireNotNull(previous.latitude) to requireNotNull(previous.longitude)
-                } else {
-                    readCoordinates(uri)
+    var exifReadCount = 0
+    var reusedCoordinateCount = 0
+    val photos = traceSection("photo.sync.mediastore") {
+        contentResolver.query(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            null,
+            null,
+            "${MediaStore.Images.Media.DATE_TAKEN} DESC",
+        )?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+            buildList<PhotoMetadataEntity> {
+                while (cursor.moveToNext()) {
+                    val mediaId = cursor.getLong(idColumn)
+                    val uri = ContentUris.withAppendedId(
+                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                        mediaId,
+                    )
+                    val modifiedAtSeconds = cursor.getLongOrNull(MediaStore.Images.Media.DATE_MODIFIED) ?: 0L
+                    val previous = previousById[mediaId]
+                    val coordinates = if (
+                        previous != null &&
+                        previous.modifiedAtSeconds == modifiedAtSeconds &&
+                        previous.latitude != null &&
+                        previous.longitude != null
+                    ) {
+                        reusedCoordinateCount++
+                        requireNotNull(previous.latitude) to requireNotNull(previous.longitude)
+                    } else {
+                        exifReadCount++
+                        readCoordinates(uri)
+                    }
+                    add(
+                        PhotoMetadataEntity(
+                            mediaId = mediaId,
+                            contentUri = uri.toString(),
+                            displayName = cursor.getStringOrNull(MediaStore.Images.Media.DISPLAY_NAME)
+                                ?: "여행 사진",
+                            capturedAtMillis = cursor.getLongOrNull(MediaStore.Images.Media.DATE_TAKEN)
+                                ?.takeIf { it > 0L },
+                            modifiedAtSeconds = modifiedAtSeconds,
+                            latitude = coordinates?.first,
+                            longitude = coordinates?.second,
+                            mimeType = cursor.getStringOrNull(MediaStore.Images.Media.MIME_TYPE),
+                            sizeBytes = cursor.getLongOrNull(MediaStore.Images.Media.SIZE) ?: 0L,
+                            width = cursor.getIntOrNull(MediaStore.Images.Media.WIDTH) ?: 0,
+                            height = cursor.getIntOrNull(MediaStore.Images.Media.HEIGHT) ?: 0,
+                            scanId = scanId,
+                        ),
+                    )
                 }
-                add(
-                    PhotoMetadataEntity(
-                        mediaId = mediaId,
-                        contentUri = uri.toString(),
-                        displayName = cursor.getStringOrNull(MediaStore.Images.Media.DISPLAY_NAME)
-                            ?: "여행 사진",
-                        capturedAtMillis = cursor.getLongOrNull(MediaStore.Images.Media.DATE_TAKEN)
-                            ?.takeIf { it > 0L },
-                        modifiedAtSeconds = modifiedAtSeconds,
-                        latitude = coordinates?.first,
-                        longitude = coordinates?.second,
-                        mimeType = cursor.getStringOrNull(MediaStore.Images.Media.MIME_TYPE),
-                        sizeBytes = cursor.getLongOrNull(MediaStore.Images.Media.SIZE) ?: 0L,
-                        width = cursor.getIntOrNull(MediaStore.Images.Media.WIDTH) ?: 0,
-                        height = cursor.getIntOrNull(MediaStore.Images.Media.HEIGHT) ?: 0,
-                        scanId = scanId,
-                    ),
-                )
             }
         }
-    } ?: return emptyList()
+    } ?: return PhotoMetadataSyncResult(
+        photos = emptyList(),
+        exifReadCount = exifReadCount,
+        reusedCoordinateCount = reusedCoordinateCount,
+        previousPhotoCount = previousPhotos.size,
+    )
 
-    dao.replaceSnapshot(photos, scanId)
-    return photos
+    traceSuspendSection("photo.sync.room.write", TraceCookie.RoomWrite) {
+        dao.replaceSnapshot(photos, scanId)
+    }
+    return PhotoMetadataSyncResult(
+        photos = photos,
+        exifReadCount = exifReadCount,
+        reusedCoordinateCount = reusedCoordinateCount,
+        previousPhotoCount = previousPhotos.size,
+    )
+}
+
+private inline fun <T> traceSection(name: String, block: () -> T): T {
+    Trace.beginSection(name)
+    return try {
+        block()
+    } finally {
+        Trace.endSection()
+    }
+}
+
+private suspend inline fun <T> traceSuspendSection(
+    name: String,
+    cookie: Int,
+    crossinline block: suspend () -> T,
+): T {
+    Trace.beginAsyncSection(name, cookie)
+    return try {
+        block()
+    } finally {
+        Trace.endAsyncSection(name, cookie)
+    }
+}
+
+private fun logPerformance(
+    totalMillis: Long,
+    geocodeMillis: Long,
+    syncMillis: Long,
+    reverseGeocodeMillis: Long,
+    previewMillis: Long,
+    syncResult: PhotoMetadataSyncResult,
+    recommendedPhotoCount: Int,
+) {
+    if (!Log.isLoggable(PhotoPerformanceTag, Log.DEBUG)) return
+    Log.d(
+        PhotoPerformanceTag,
+        "recommend_total_ms=$totalMillis " +
+            "target_geocode_ms=$geocodeMillis " +
+            "metadata_sync_ms=$syncMillis " +
+            "reverse_geocode_ms=$reverseGeocodeMillis " +
+            "preview_ms=$previewMillis " +
+            "previous_photos=${syncResult.previousPhotoCount} " +
+            "media_store_photos=${syncResult.photos.size} " +
+            "exif_reads=${syncResult.exifReadCount} " +
+            "reused_coordinates=${syncResult.reusedCoordinateCount} " +
+            "recommended_photos=$recommendedPhotoCount",
+    )
+}
+
+private fun logPhotoPickPerformance(
+    totalMillis: Long,
+    requestedPhotoCount: Int,
+    loadedPhotoCount: Int,
+) {
+    if (!Log.isLoggable(PhotoPerformanceTag, Log.DEBUG)) return
+    Log.d(
+        PhotoPerformanceTag,
+        "pick_total_ms=$totalMillis " +
+            "requested_photos=$requestedPhotoCount " +
+            "loaded_photos=$loadedPhotoCount",
+    )
 }
 
 private fun Address.toAdministrativeArea(): PhotoAdministrativeArea = PhotoAdministrativeArea(
@@ -290,20 +429,26 @@ private fun Context.readPhoto(
     knownCoordinates: Pair<Double, Double>? = null,
     knownCapturedAtMillis: Long? = null,
 ): SelectedPhoto? = runCatching {
-    val metadata = if (knownName == null && knownCapturedAtMillis == null) {
-        queryPhotoMetadata(uri)
-    } else {
-        null to null
+    val metadata = traceSection("photo.read.metadata") {
+        if (knownName == null && knownCapturedAtMillis == null) {
+            queryPhotoMetadata(uri)
+        } else {
+            null to null
+        }
     }
-    val coordinates = knownCoordinates ?: readCoordinates(uri)
-    val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        contentResolver.loadThumbnail(uri, Size(PreviewSizePx, PreviewSizePx), null)
-    } else {
-        contentResolver.openInputStream(uri)?.use(BitmapFactory::decodeStream)
-    } ?: return null
-    val bytes = ByteArrayOutputStream().use { output ->
-        bitmap.compress(Bitmap.CompressFormat.JPEG, PreviewJpegQuality, output)
-        output.toByteArray()
+    val coordinates = knownCoordinates ?: traceSection("photo.read.exif") {
+        readCoordinates(uri)
+    }
+    val bytes = traceSection("photo.read.preview") {
+        val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            contentResolver.loadThumbnail(uri, Size(PreviewSizePx, PreviewSizePx), null)
+        } else {
+            contentResolver.openInputStream(uri)?.use(BitmapFactory::decodeStream)
+        } ?: return null
+        ByteArrayOutputStream().use { output ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, PreviewJpegQuality, output)
+            output.toByteArray()
+        }
     }
     SelectedPhoto(
         id = uri.toString(),
@@ -367,3 +512,11 @@ private const val PreviewSizePx = 960
 private const val PreviewJpegQuality = 84
 private const val MaxReverseGeocodeCandidates = 80
 private const val MaxRecommendedPhotos = 12
+private const val PhotoPerformanceTag = "MapmoryPhotoPerf"
+
+private object TraceCookie {
+    const val Recommend = 1
+    const val RoomRead = 2
+    const val RoomWrite = 3
+    const val Pick = 4
+}


### PR DESCRIPTION
## 변경 내용
- Room 사진 메타데이터 인덱스를 사용하는 사진 추천 흐름에 단계별 성능 계측을 추가했습니다.
- 사진 추가 흐름에도 전체 처리 시간과 요청·정상 로딩 개수를 기록하도록 했습니다.
- Android System Trace 구간과 실측 결과, 해석의 한계를 문서화했습니다.

## 변경 이유
Room 적용 전후의 사진 추천 흐름을 시간과 EXIF 좌표 재사용 여부로 확인할 수 있도록 하기 위함입니다. 단, 현재 측정 결과만으로 Room 적용의 인과적 성능 개선을 단정하지 않도록 문서에 한계를 함께 남겼습니다.

## 검증
- `git diff --check`
- `cd client && ./gradlew :shared:compileAndroidMain`

## 참고
- `.tmp-mapmory-carousel.html`은 이번 PR에 포함하지 않았습니다.