### PR TITLE
fix: 여행기록 작성/수정 페이지 UI/UX 개편

### DIFF
--- a/client/androidApp/build.gradle.kts
+++ b/client/androidApp/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 dependencies {
     implementation(project(":shared"))
     implementation("androidx.activity:activity-compose:1.11.0")
+    implementation("androidx.activity:activity-ktx:1.11.0")
     implementation(libs.androidx.compose.foundation)
     implementation("org.jetbrains.compose.material3:material3:1.9.0")
     implementation("androidx.compose.ui:ui-tooling-preview:${libs.versions.androidxCompose.get()}")

--- a/client/androidApp/src/main/java/com/mapmory/android/MainActivity.kt
+++ b/client/androidApp/src/main/java/com/mapmory/android/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
@@ -26,6 +27,8 @@ import com.mapmory.shared.MapmoryNavigation
 private val SystemBarColor = Color(0xFF111518)
 
 class MainActivity : ComponentActivity() {
+    private val appViewModel: MapmoryAppViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge(
@@ -45,6 +48,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     MapmoryApp(
+                        providedRecordsViewModel = appViewModel.recordsViewModel,
                         navigation = navigation,
                         contentWindowInsets = WindowInsets.safeDrawing,
                     )

--- a/client/androidApp/src/main/java/com/mapmory/android/MapmoryAppViewModel.kt
+++ b/client/androidApp/src/main/java/com/mapmory/android/MapmoryAppViewModel.kt
@@ -1,0 +1,9 @@
+package com.mapmory.android
+
+import androidx.lifecycle.ViewModel
+import com.mapmory.shared.createTripRecordsViewModel
+import com.mapmory.shared.presentation.triprecord.viewmodel.TripRecordsViewModel
+
+class MapmoryAppViewModel : ViewModel() {
+    val recordsViewModel: TripRecordsViewModel = createTripRecordsViewModel()
+}

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/date/PlatformDatePicker.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/date/PlatformDatePicker.android.kt
@@ -1,0 +1,70 @@
+package com.mapmory.shared.presentation.date
+
+import android.app.DatePickerDialog
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+
+@Composable
+actual fun PlatformDatePicker(
+    visible: Boolean,
+    initialDate: String?,
+    minimumDate: String?,
+    onDateSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val latestOnDateSelected by rememberUpdatedState(onDateSelected)
+    val latestOnDismiss by rememberUpdatedState(onDismiss)
+    var dialog by remember { mutableStateOf<DatePickerDialog?>(null) }
+
+    DisposableEffect(visible, initialDate, minimumDate) {
+        if (!visible) {
+            onDispose { }
+        } else {
+            val initial = initialDate.toDatePickerLocalDate()
+                ?: Clock.System.now()
+                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .date
+            var callbackSent = false
+            val picker = DatePickerDialog(
+                context,
+                { _, year, month, dayOfMonth ->
+                    callbackSent = true
+                    latestOnDateSelected(LocalDate(year, month + 1, dayOfMonth).toString())
+                    latestOnDismiss()
+                },
+                initial.year,
+                initial.month.number - 1,
+                initial.day,
+            )
+            minimumDate
+                .toDatePickerLocalDate()
+                ?.toDatePickerEpochMillis()
+                ?.let { picker.datePicker.minDate = it }
+            picker.setOnDismissListener {
+                if (!callbackSent) latestOnDismiss()
+                if (dialog === picker) dialog = null
+            }
+            dialog = picker
+            picker.show()
+
+            onDispose {
+                callbackSent = true
+                picker.setOnDismissListener(null)
+                picker.dismiss()
+                if (dialog === picker) dialog = null
+            }
+        }
+    }
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -54,11 +54,14 @@ private data class DetailRoute(
 
 @Composable
 fun MapmoryApp(
+    providedRecordsViewModel: TripRecordsViewModel? = null,
     navigation: MapmoryNavigation? = null,
     contentWindowInsets: WindowInsets = WindowInsets(0, 0, 0, 0),
 ) {
     val navController = rememberNavController()
-    val recordsViewModel = remember { TripRecordsViewModel(appLocations) }
+    val recordsViewModel = remember(providedRecordsViewModel) {
+        providedRecordsViewModel ?: TripRecordsViewModel(appLocations)
+    }
     val recordsUiState = recordsViewModel.uiState
 
     fun navigateBack(): Boolean {
@@ -273,6 +276,8 @@ fun MapmoryApp(
         }
     }
 }
+
+fun createTripRecordsViewModel(): TripRecordsViewModel = TripRecordsViewModel(appLocations)
 
 private val appLocations = buildList {
     add(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -204,6 +204,9 @@ fun MapmoryApp(
                 onLocationSelected = { location ->
                     recordsViewModel.onAction(TripRecordAction.LocationSelected(location))
                 },
+                onLocationTouched = {
+                    recordsViewModel.onAction(TripRecordAction.LocationTouched)
+                },
                 onTitleChanged = { title ->
                     recordsViewModel.onAction(TripRecordAction.TitleChanged(title))
                 },

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/PrivacyPolicy.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/PrivacyPolicy.kt
@@ -1,11 +1,5 @@
 package com.mapmory.shared
 
-/**
- * Privacy policy link configuration.
- *
- * Set [URL] when the privacy policy page is published. The profile screen
- * displays the link only when this value is not blank.
- */
 object PrivacyPolicy {
     const val URL = "https://woowacourse-teams.github.io/2026-Mapmory/privacy-policy.html"
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepository.kt
@@ -56,7 +56,7 @@ class FakeTripRecordRepository(
             title = draft.title,
             content = draft.content,
             startDate = draft.startDate,
-            endDate = draft.endDate ?: draft.startDate,
+            endDate = draft.endDate,
             media = createMedia(draft.mediaObjectKeys),
             createdAt = timestamp,
             updatedAt = timestamp,
@@ -75,7 +75,7 @@ class FakeTripRecordRepository(
             title = draft.title,
             content = draft.content,
             startDate = draft.startDate,
-            endDate = draft.endDate ?: draft.startDate,
+            endDate = draft.endDate,
             media = createMedia(draft.mediaObjectKeys),
             updatedAt = now(),
         )

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecord.kt
@@ -8,12 +8,12 @@ data class TripRecord(
     val imageUrl: String,
     val tripRecordTitle: String,
     val tripRecordDescription: String?,
-    val startTripDate: LocalDate,
-    val endTripDate: LocalDate,
+    val startTripDate: LocalDate?,
+    val endTripDate: LocalDate?,
     val location: String,
 ) {
     init {
-        require(startTripDate <= endTripDate) {
+        require(startTripDate == null || endTripDate == null || startTripDate <= endTripDate) {
             "여행 시작일은 종료일보다 늦을 수 없습니다"
         }
     }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/TripRecords.kt
@@ -15,8 +15,8 @@ class TripRecords(
         tripRecordTitle: String,
         tripRecordDescription: String?,
         tripLocation: String,
-        startTripDate: LocalDate,
-        endTripDate: LocalDate,
+        startTripDate: LocalDate?,
+        endTripDate: LocalDate?,
     ): TripRecords {
         val newRecord = TripRecord(
             imageUrl = imageUri,
@@ -45,6 +45,8 @@ class TripRecords(
         editingStartTripDate: LocalDate?,
         editingEndTripDate: LocalDate?,
         editingLocation: String?,
+        clearStartTripDate: Boolean = false,
+        clearEndTripDate: Boolean = false,
     ): TripRecords {
         val record = findTripRecordId(editingRecord.id)
             ?: throw IllegalArgumentException("해당 id를 찾을 수 없습니다")
@@ -53,8 +55,8 @@ class TripRecords(
             imageUrl = editingImage ?: record.imageUrl,
             tripRecordTitle = editingTitle ?: record.tripRecordTitle,
             tripRecordDescription = editingDescription ?: record.tripRecordDescription,
-            startTripDate = editingStartTripDate ?: record.startTripDate,
-            endTripDate = editingEndTripDate ?: record.endTripDate,
+            startTripDate = if (clearStartTripDate) null else editingStartTripDate ?: record.startTripDate,
+            endTripDate = if (clearEndTripDate) null else editingEndTripDate ?: record.endTripDate,
             location = editingLocation ?: record.location,
         )
 

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/TripRecordData.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/TripRecordData.kt
@@ -26,10 +26,9 @@ data class TripRecordDraft(
 )
 
 fun TripRecordDraft.dateValidationError(): String? = when {
-    endDate != null && startDate == null -> "종료일만 입력할 수 없습니다."
     startDate != null && !startDate.isValidIsoDate() -> "올바른 시작일을 입력해 주세요."
     endDate != null && !endDate.isValidIsoDate() -> "올바른 종료일을 입력해 주세요."
-    endDate != null && endDate < startDate!! -> "종료일은 시작일보다 빠를 수 없습니다."
+    startDate != null && endDate != null && endDate < startDate -> "종료일은 시작일보다 빠를 수 없습니다."
     else -> null
 }
 

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/date/PlatformDatePicker.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/date/PlatformDatePicker.kt
@@ -1,0 +1,102 @@
+package com.mapmory.shared.presentation.date
+
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SelectableDates
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
+
+/**
+ * Opens the platform date picker when [visible] is true.
+ *
+ * Android and iOS use their native date controls. The JVM target, which is used by previews and
+ * tests, provides the common Material 3 picker as a fallback.
+ */
+@Composable
+expect fun PlatformDatePicker(
+    visible: Boolean,
+    initialDate: String?,
+    minimumDate: String?,
+    onDateSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+)
+
+internal fun String?.toDatePickerLocalDate(): LocalDate? = runCatching {
+    this
+        ?.trim()
+        ?.takeIf(String::isNotBlank)
+        ?.replace('.', '-')
+        ?.let(LocalDate::parse)
+}.getOrNull()
+
+internal fun LocalDate.toDatePickerEpochMillis(): Long =
+    atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+
+internal fun Long.toDatePickerString(): String =
+    Instant.fromEpochMilliseconds(this)
+        .toLocalDateTime(TimeZone.UTC)
+        .date
+        .toString()
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun MaterialDatePickerFallback(
+    visible: Boolean,
+    initialDate: String?,
+    minimumDate: String?,
+    onDateSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (!visible) return
+
+    val minimumDateMillis = minimumDate
+        .toDatePickerLocalDate()
+        ?.toDatePickerEpochMillis()
+    val selectableDates = remember(minimumDateMillis) {
+        if (minimumDateMillis == null) {
+            DatePickerDefaults.AllDates
+        } else {
+            object : SelectableDates {
+                override fun isSelectableDate(utcTimeMillis: Long): Boolean =
+                    utcTimeMillis >= minimumDateMillis
+            }
+        }
+    }
+
+    key(initialDate, minimumDate) {
+        val pickerState = androidx.compose.material3.rememberDatePickerState(
+            initialSelectedDateMillis = initialDate
+                .toDatePickerLocalDate()
+                ?.toDatePickerEpochMillis(),
+            selectableDates = selectableDates,
+        )
+
+        DatePickerDialog(
+            onDismissRequest = onDismiss,
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        pickerState.selectedDateMillis
+                            ?.toDatePickerString()
+                            ?.let(onDateSelected)
+                        onDismiss()
+                    },
+                ) {
+                    Text("확인")
+                }
+            },
+        ) {
+            DatePicker(state = pickerState)
+        }
+    }
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
@@ -13,6 +13,7 @@ data class SelectedPhoto(
     val latitude: Double? = null,
     val longitude: Double? = null,
     val capturedAt: String? = null,
+    val originalBytes: ByteArray? = null,
 )
 
 data class PhotoLibraryActions(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDesign.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDesign.kt
@@ -51,6 +51,11 @@ internal object TripRecordPalette {
     val accent = Color(0xFF35C988)
     val accentSoft = Color(0xFF123E3A)
     val danger = Color(0xFFFF6264)
+    val photoRecommendText = Color.White
+    val photoRecommendBackground = Color(0xFF382125)
+    val photoRecommendBorder = Color(0xFF99555D)
+    val photoGalleryBackground = Color(0xFF1B2D26)
+    val photoGalleryBorder = Color(0xFF3E7960)
 }
 
 @Composable
@@ -311,14 +316,16 @@ internal fun TripPhotoPlaceholder(
 
 @Composable
 internal fun TripPhotoImage(
-    previewBytes: ByteArray?,
+    imageBytes: ByteArray?,
+    fallbackBytes: ByteArray? = null,
     contentDescription: String,
     modifier: Modifier = Modifier,
     placeholderVariant: Int = 0,
     shape: Shape = RoundedCornerShape(18.dp),
 ) {
-    val bitmap = remember(previewBytes) {
-        previewBytes?.let { bytes -> runCatching { bytes.decodeToImageBitmap() }.getOrNull() }
+    val bitmap = remember(imageBytes, fallbackBytes) {
+        imageBytes.decodeToImageBitmapOrNull()
+            ?: fallbackBytes.decodeToImageBitmapOrNull()
     }
     if (bitmap == null) {
         TripPhotoPlaceholder(modifier, placeholderVariant, shape)
@@ -331,6 +338,9 @@ internal fun TripPhotoImage(
         )
     }
 }
+
+private fun ByteArray?.decodeToImageBitmapOrNull() =
+    this?.let { bytes -> runCatching { bytes.decodeToImageBitmap() }.getOrNull() }
 
 @Composable
 fun TripMapArtwork(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDesign.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDesign.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,6 +33,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -56,6 +60,18 @@ internal object TripRecordPalette {
     val photoRecommendBorder = Color(0xFF99555D)
     val photoGalleryBackground = Color(0xFF1B2D26)
     val photoGalleryBorder = Color(0xFF3E7960)
+}
+
+@Composable
+internal fun rememberDismissKeyboardOnTapModifier(): Modifier {
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    return Modifier.pointerInput(focusManager, keyboardController) {
+        detectTapGestures {
+            focusManager.clearFocus(force = true)
+            keyboardController?.hide()
+        }
+    }
 }
 
 @Composable

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
@@ -2,8 +2,6 @@ package com.mapmory.shared.presentation.triprecord.screen
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
@@ -159,7 +159,7 @@ private fun TripRecordPhotoSection(
     Box(modifier = modifier) {
         if (media.isEmpty()) {
             TripPhotoImage(
-                previewBytes = null,
+                imageBytes = null,
                 contentDescription = record.title,
                 modifier = Modifier.fillMaxSize(),
                 placeholderVariant = record.id.toInt() + 1,
@@ -176,7 +176,9 @@ private fun TripRecordPhotoSection(
             ) { page ->
                 val photo = media[page]
                 TripPhotoImage(
-                    previewBytes = photo.previewBytes?.bytesForDecoding(),
+                    imageBytes = photo.originalBytes?.bytesForDecoding()
+                        ?: photo.previewBytes?.bytesForDecoding(),
+                    fallbackBytes = photo.previewBytes?.bytesForDecoding(),
                     contentDescription = "${record.title} 사진 ${page + 1}",
                     modifier = Modifier.fillMaxSize(),
                     placeholderVariant = record.id.toInt() + page + 1,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -92,6 +92,7 @@ fun TripRecordEditorScreen(
     var recommendedPhotos by remember { mutableStateOf(emptyList<SelectedPhoto>()) }
     var selectedRecommendationIds by remember { mutableStateOf(emptySet<String>()) }
     var showRecommendationSheet by remember { mutableStateOf(false) }
+    val dismissKeyboardOnTap = rememberDismissKeyboardOnTapModifier()
     val photoLibrary = rememberPhotoLibraryActions(
         onPhotosPicked = { photos ->
             photoMessage = null
@@ -118,7 +119,7 @@ fun TripRecordEditorScreen(
         }
     }
 
-    TripRecordBackground(modifier = modifier) {
+    TripRecordBackground(modifier = modifier.then(dismissKeyboardOnTap)) {
         Column(Modifier.fillMaxSize()) {
             EditorTopBar(
                 title = if (uiState.recordId == null) "기록 남기기" else "기록 수정하기",
@@ -259,6 +260,7 @@ fun TripRecordEditorScreen(
                     .fillMaxWidth()
                     .navigationBarsPadding()
                     .imePadding()
+                    .then(dismissKeyboardOnTap)
                     .padding(horizontal = 20.dp),
             ) {
                 Text(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -123,7 +123,7 @@ fun TripRecordEditorScreen(
             EditorTopBar(
                 title = if (uiState.recordId == null) "기록 남기기" else "기록 수정하기",
                 onBackClick = onBackClick,
-                isDirty = uiState.isDirty,
+                isSaveEnabled = uiState.isSaveEnabled,
                 isSaving = uiState.isSaving,
                 onSaveClick = onSaveClick,
             )
@@ -391,7 +391,7 @@ fun TripRecordEditorScreen(
 private fun EditorTopBar(
     title: String,
     onBackClick: () -> Unit,
-    isDirty: Boolean,
+    isSaveEnabled: Boolean,
     isSaving: Boolean,
     onSaveClick: () -> Unit,
 ) {
@@ -425,7 +425,7 @@ private fun EditorTopBar(
             )
             TextButton(
                 onClick = onSaveClick,
-                enabled = isDirty && !isSaving,
+                enabled = isSaveEnabled,
                 contentPadding = PaddingValues(horizontal = 12.dp),
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
@@ -433,7 +433,7 @@ private fun EditorTopBar(
             ) {
                 Text(
                     text = if (isSaving) "저장 중" else "저장",
-                    color = if (isDirty && !isSaving) TripRecordPalette.accent else TripRecordPalette.muted,
+                    color = if (isSaveEnabled) TripRecordPalette.accent else TripRecordPalette.muted,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold,
                 )
@@ -476,19 +476,17 @@ private fun PhotoSection(
                 contentPadding = PaddingValues(horizontal = 9.dp, vertical = 2.dp),
                 modifier = Modifier
                     .height(36.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(TripRecordPalette.photoRecommendBackground)
                     .border(
                         width = 1.dp,
-                        color = if (recommendationsAvailable) {
-                            TripRecordPalette.danger.copy(alpha = 0.7f)
-                        } else {
-                            TripRecordPalette.line
-                        },
+                        color = TripRecordPalette.photoRecommendBorder,
                         shape = RoundedCornerShape(6.dp),
                     ),
             ) {
                 Text(
                     text = "위치 기반 사진\n불러오기",
-                    color = if (recommendationsAvailable) TripRecordPalette.text else TripRecordPalette.muted,
+                    color = TripRecordPalette.photoRecommendText,
                     fontSize = 9.sp,
                     lineHeight = 11.sp,
                 )
@@ -754,8 +752,8 @@ private fun PhotoActionButton(onClick: () -> Unit) {
             .size(112.dp, 84.dp)
             .clip(RoundedCornerShape(14.dp))
             .clickable(onClick = onClick)
-            .background(TripRecordPalette.accentSoft.copy(alpha = 0.6f))
-            .border(1.dp, TripRecordPalette.accent.copy(alpha = 0.45f), RoundedCornerShape(14.dp)),
+            .background(TripRecordPalette.photoGalleryBackground)
+            .border(1.dp, TripRecordPalette.photoGalleryBorder, RoundedCornerShape(14.dp)),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -813,7 +811,7 @@ private fun RecommendedPhoto(
 @Composable
 private fun PhotoPreview(photo: SelectedPhoto, modifier: Modifier = Modifier) {
     TripPhotoImage(
-        previewBytes = photo.previewBytes,
+        imageBytes = photo.previewBytes,
         contentDescription = photo.displayName,
         modifier = modifier,
         placeholderVariant = photo.id.hashCode(),
@@ -823,7 +821,7 @@ private fun PhotoPreview(photo: SelectedPhoto, modifier: Modifier = Modifier) {
 @Composable
 private fun PhotoPreview(photo: TripRecordPhotoUiState, modifier: Modifier = Modifier) {
     TripPhotoImage(
-        previewBytes = photo.previewBytes?.bytesForDecoding(),
+        imageBytes = photo.previewBytes?.bytesForDecoding(),
         contentDescription = photo.displayName,
         modifier = modifier,
         placeholderVariant = photo.id.hashCode(),

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -57,6 +57,7 @@ import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.photo.MaxPhotosPerRecord
 import com.mapmory.shared.presentation.photo.SelectedPhoto
 import com.mapmory.shared.presentation.photo.rememberPhotoLibraryActions
+import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorErrorTarget
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorUiState
 import com.mapmory.shared.presentation.triprecord.state.TripRecordPhotoUiState
 
@@ -66,6 +67,7 @@ fun TripRecordEditorScreen(
     uiState: TripRecordEditorUiState,
     locations: List<Location>,
     onLocationSelected: (Location) -> Unit,
+    onLocationTouched: () -> Unit = {},
     onTitleChanged: (String) -> Unit,
     onContentChanged: (String) -> Unit,
     onStartDateChanged: (String) -> Unit,
@@ -121,6 +123,7 @@ fun TripRecordEditorScreen(
             EditorTopBar(
                 title = if (uiState.recordId == null) "기록 남기기" else "기록 수정하기",
                 onBackClick = onBackClick,
+                isDirty = uiState.isDirty,
                 isSaving = uiState.isSaving,
                 onSaveClick = onSaveClick,
             )
@@ -162,29 +165,44 @@ fun TripRecordEditorScreen(
                             modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
                         )
                     }
+                    EditorErrorMessage(
+                        message = uiState.errorMessageFor(TripRecordEditorErrorTarget.PHOTOS),
+                        modifier = Modifier.padding(start = 20.dp, end = 20.dp, bottom = 8.dp),
+                    )
                     EditorDivider()
                 }
 
                 item {
-                    EditorTitleField(
-                        value = uiState.title,
-                        onValueChange = onTitleChanged,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 20.dp, vertical = 18.dp),
-                    )
+                    Column(Modifier.padding(horizontal = 20.dp, vertical = 18.dp)) {
+                        EditorTitleField(
+                            value = uiState.title,
+                            onValueChange = onTitleChanged,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        EditorErrorMessage(
+                            message = uiState.errorMessageFor(TripRecordEditorErrorTarget.TITLE),
+                            modifier = Modifier.padding(top = 6.dp),
+                        )
+                    }
                     EditorDivider(Modifier.padding(horizontal = 20.dp))
                 }
 
                 item {
-                    LocationSelector(
-                        selectedLocation = uiState.selectedLocation,
-                        locations = locations,
-                        onClick = { showLocationSheet = true },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 20.dp, vertical = 12.dp),
-                    )
+                    Column(Modifier.padding(horizontal = 20.dp, vertical = 12.dp)) {
+                        LocationSelector(
+                            selectedLocation = uiState.selectedLocation,
+                            locations = locations,
+                            onClick = {
+                                onLocationTouched()
+                                showLocationSheet = true
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        EditorErrorMessage(
+                            message = uiState.errorMessageFor(TripRecordEditorErrorTarget.LOCATION),
+                            modifier = Modifier.padding(top = 6.dp),
+                        )
+                    }
                     EditorDivider(Modifier.padding(horizontal = 20.dp))
                 }
 
@@ -192,6 +210,8 @@ fun TripRecordEditorScreen(
                     DateFields(
                         startDate = uiState.startDate,
                         endDate = uiState.endDate,
+                        startDateError = uiState.errorMessageFor(TripRecordEditorErrorTarget.START_DATE),
+                        endDateError = uiState.errorMessageFor(TripRecordEditorErrorTarget.END_DATE),
                         onStartDateChanged = onStartDateChanged,
                         onEndDateChanged = onEndDateChanged,
                         modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
@@ -215,12 +235,10 @@ fun TripRecordEditorScreen(
                     )
                 }
 
-                uiState.errorMessage?.let { message ->
+                uiState.generalErrorMessage?.takeIf { uiState.isDirty }?.let { message ->
                     item {
-                        Text(
-                            text = message,
-                            color = TripRecordPalette.danger,
-                            fontSize = 12.sp,
+                        EditorErrorMessage(
+                            message = message,
                             modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
                         )
                     }
@@ -373,6 +391,7 @@ fun TripRecordEditorScreen(
 private fun EditorTopBar(
     title: String,
     onBackClick: () -> Unit,
+    isDirty: Boolean,
     isSaving: Boolean,
     onSaveClick: () -> Unit,
 ) {
@@ -406,7 +425,7 @@ private fun EditorTopBar(
             )
             TextButton(
                 onClick = onSaveClick,
-                enabled = !isSaving,
+                enabled = isDirty && !isSaving,
                 contentPadding = PaddingValues(horizontal = 12.dp),
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
@@ -414,7 +433,7 @@ private fun EditorTopBar(
             ) {
                 Text(
                     text = if (isSaving) "저장 중" else "저장",
-                    color = if (isSaving) TripRecordPalette.muted else TripRecordPalette.accent,
+                    color = if (isDirty && !isSaving) TripRecordPalette.accent else TripRecordPalette.muted,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold,
                 )
@@ -521,6 +540,8 @@ private fun EditorTitleField(
 private fun DateFields(
     startDate: String,
     endDate: String,
+    startDateError: String?,
+    endDateError: String?,
     onStartDateChanged: (String) -> Unit,
     onEndDateChanged: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -532,12 +553,14 @@ private fun DateFields(
         DateField(
             label = "시작",
             value = startDate,
+            errorMessage = startDateError,
             onValueChange = onStartDateChanged,
             modifier = Modifier.weight(1f),
         )
         DateField(
             label = "종료",
             value = endDate,
+            errorMessage = endDateError,
             onValueChange = onEndDateChanged,
             modifier = Modifier.weight(1f),
         )
@@ -548,6 +571,7 @@ private fun DateFields(
 private fun DateField(
     label: String,
     value: String,
+    errorMessage: String?,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -594,8 +618,31 @@ private fun DateField(
                 fontSize = 10.sp,
             )
         }
+        EditorErrorMessage(
+            message = errorMessage,
+            modifier = Modifier.padding(top = 6.dp),
+        )
     }
 }
+
+@Composable
+private fun EditorErrorMessage(
+    message: String?,
+    modifier: Modifier = Modifier,
+) {
+    message ?: return
+    Text(
+        text = message,
+        color = TripRecordPalette.danger,
+        fontSize = 11.sp,
+        modifier = modifier,
+    )
+}
+
+private fun TripRecordEditorUiState.errorMessageFor(target: TripRecordEditorErrorTarget): String? =
+    fieldErrors[target]?.takeIf {
+        target == TripRecordEditorErrorTarget.PHOTOS || isFieldDirty(target)
+    }
 
 @Composable
 private fun CompanionChips(modifier: Modifier = Modifier) {

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -57,9 +57,13 @@ import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.photo.MaxPhotosPerRecord
 import com.mapmory.shared.presentation.photo.SelectedPhoto
 import com.mapmory.shared.presentation.photo.rememberPhotoLibraryActions
+import com.mapmory.shared.presentation.date.PlatformDatePicker
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorErrorTarget
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorUiState
 import com.mapmory.shared.presentation.triprecord.state.TripRecordPhotoUiState
+
+private const val StartDatePickerTarget = "start"
+private const val EndDatePickerTarget = "end"
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -92,6 +96,7 @@ fun TripRecordEditorScreen(
     var recommendedPhotos by remember { mutableStateOf(emptyList<SelectedPhoto>()) }
     var selectedRecommendationIds by remember { mutableStateOf(emptySet<String>()) }
     var showRecommendationSheet by remember { mutableStateOf(false) }
+    var datePickerTarget by rememberSaveable { mutableStateOf<String?>(null) }
     val dismissKeyboardOnTap = rememberDismissKeyboardOnTapModifier()
     val photoLibrary = rememberPhotoLibraryActions(
         onPhotosPicked = { photos ->
@@ -213,8 +218,8 @@ fun TripRecordEditorScreen(
                         endDate = uiState.endDate,
                         startDateError = uiState.errorMessageFor(TripRecordEditorErrorTarget.START_DATE),
                         endDateError = uiState.errorMessageFor(TripRecordEditorErrorTarget.END_DATE),
-                        onStartDateChanged = onStartDateChanged,
-                        onEndDateChanged = onEndDateChanged,
+                        onStartDateClick = { datePickerTarget = StartDatePickerTarget },
+                        onEndDateClick = { datePickerTarget = EndDatePickerTarget },
                         modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
                     )
                     EditorDivider(Modifier.padding(horizontal = 20.dp))
@@ -387,6 +392,31 @@ fun TripRecordEditorScreen(
             }
         }
     }
+
+    val activeDatePickerTarget = datePickerTarget
+    val isStartDatePicker = activeDatePickerTarget == StartDatePickerTarget
+    PlatformDatePicker(
+        visible = activeDatePickerTarget != null,
+        initialDate = when {
+            isStartDatePicker -> uiState.startDate
+            activeDatePickerTarget == EndDatePickerTarget -> uiState.endDate
+            else -> null
+        },
+        minimumDate = if (activeDatePickerTarget == EndDatePickerTarget) {
+            uiState.startDate
+        } else {
+            null
+        },
+        onDateSelected = { date ->
+            if (isStartDatePicker) {
+                onStartDateChanged(date)
+            } else if (activeDatePickerTarget == EndDatePickerTarget) {
+                onEndDateChanged(date)
+            }
+            datePickerTarget = null
+        },
+        onDismiss = { datePickerTarget = null },
+    )
 }
 
 @Composable
@@ -542,8 +572,8 @@ private fun DateFields(
     endDate: String,
     startDateError: String?,
     endDateError: String?,
-    onStartDateChanged: (String) -> Unit,
-    onEndDateChanged: (String) -> Unit,
+    onStartDateClick: () -> Unit,
+    onEndDateClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -554,14 +584,14 @@ private fun DateFields(
             label = "시작",
             value = startDate,
             errorMessage = startDateError,
-            onValueChange = onStartDateChanged,
+            onClick = onStartDateClick,
             modifier = Modifier.weight(1f),
         )
         DateField(
             label = "종료",
             value = endDate,
             errorMessage = endDateError,
-            onValueChange = onEndDateChanged,
+            onClick = onEndDateClick,
             modifier = Modifier.weight(1f),
         )
     }
@@ -572,7 +602,7 @@ private fun DateField(
     label: String,
     value: String,
     errorMessage: String?,
-    onValueChange: (String) -> Unit,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -588,35 +618,34 @@ private fun DateField(
                 .padding(top = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            BasicTextField(
-                value = value,
-                onValueChange = onValueChange,
-                singleLine = true,
-                textStyle = TextStyle(
-                    color = TripRecordPalette.text,
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable(onClick = onClick),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Text(
+                    text = value.ifBlank { "연도. 월. 일." },
+                    color = if (value.isBlank()) TripRecordPalette.muted else TripRecordPalette.text,
                     fontSize = 11.sp,
                     fontWeight = FontWeight.Medium,
-                ),
-                cursorBrush = SolidColor(TripRecordPalette.accent),
-                decorationBox = { innerTextField ->
-                    Box(contentAlignment = Alignment.CenterStart) {
-                        if (value.isBlank()) {
-                            Text(
-                                text = "연도. 월. 일.",
-                                color = TripRecordPalette.muted,
-                                fontSize = 11.sp,
-                            )
-                        }
-                        innerTextField()
-                    }
-                },
-                modifier = Modifier.weight(1f),
-            )
-            Text(
-                text = "□",
-                color = TripRecordPalette.muted,
-                fontSize = 10.sp,
-            )
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable(onClick = onClick),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "▦",
+                    color = TripRecordPalette.muted,
+                    fontSize = 16.sp,
+                )
+            }
         }
         EditorErrorMessage(
             message = errorMessage,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -1,6 +1,7 @@
 package com.mapmory.shared.presentation.triprecord.screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +24,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -40,10 +42,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -113,56 +118,22 @@ fun TripRecordEditorScreen(
 
     TripRecordBackground(modifier = modifier) {
         Column(Modifier.fillMaxSize()) {
-            TripRecordTopBar(
-                title = if (uiState.recordId == null) "새 기록 작성" else "기록 수정",
+            EditorTopBar(
+                title = if (uiState.recordId == null) "기록 남기기" else "기록 수정하기",
                 onBackClick = onBackClick,
-                trailing = {
-                    TextButton(
-                        onClick = onSaveClick,
-                        enabled = !uiState.isSaving,
-                    ) {
-                        Text(
-                            text = if (uiState.isSaving) "저장 중" else "완료",
-                            color = if (uiState.isSaving) TripRecordPalette.muted else TripRecordPalette.accent,
-                            fontWeight = FontWeight.Bold,
-                        )
-                    }
-                },
+                isSaving = uiState.isSaving,
+                onSaveClick = onSaveClick,
             )
 
             LazyColumn(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
-                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 10.dp),
-                verticalArrangement = Arrangement.spacedBy(18.dp),
+                contentPadding = PaddingValues(bottom = 32.dp),
             ) {
                 item {
-                    EditorSectionLabel("제목")
-                    OutlinedTextField(
-                        value = uiState.title,
-                        onValueChange = onTitleChanged,
-                        placeholder = { Text("여행의 제목을 입력해 주세요") },
-                        singleLine = true,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 8.dp),
-                    )
-                }
-
-                item {
-                    EditorSectionLabel("장소")
-                    LocationSelector(
-                        selectedLocation = uiState.selectedLocation,
-                        locations = locations,
-                        onClick = { showLocationSheet = true },
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
-
-                item {
-                    EditorSectionLabel("여행 사진")
-                    PhotoEditor(
+                    PhotoSection(
+                        locationName = uiState.selectedLocation?.name ?: "여행 장소",
                         photos = uiState.selectedPhotos,
                         onAddClick = photoLibrary.pickFromGallery,
                         onRecommendClick = {
@@ -179,71 +150,82 @@ fun TripRecordEditorScreen(
                         },
                         onRemoveClick = onPhotoRemoved,
                         recommendationsAvailable = photoLibrary.recommendationsAvailable,
-                        modifier = Modifier.padding(top = 8.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 18.dp),
                     )
                     photoMessage?.let { message ->
                         Text(
                             text = message,
                             color = TripRecordPalette.muted,
                             fontSize = 11.sp,
-                            modifier = Modifier.padding(top = 8.dp),
+                            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
                         )
                     }
+                    EditorDivider()
                 }
 
                 item {
-                    EditorSectionLabel("여행 날짜")
-                    Row(
+                    EditorTitleField(
+                        value = uiState.title,
+                        onValueChange = onTitleChanged,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    ) {
-                        OutlinedTextField(
-                            value = uiState.startDate,
-                            onValueChange = onStartDateChanged,
-                            placeholder = { Text("YYYY.MM.DD") },
-                            singleLine = true,
-                            modifier = Modifier.weight(1f),
-                        )
-                        OutlinedTextField(
-                            value = uiState.endDate,
-                            onValueChange = onEndDateChanged,
-                            placeholder = { Text("종료일") },
-                            singleLine = true,
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
+                            .padding(horizontal = 20.dp, vertical = 18.dp),
+                    )
+                    EditorDivider(Modifier.padding(horizontal = 20.dp))
                 }
 
                 item {
-                    EditorSectionLabel("기록")
-                    OutlinedTextField(
+                    LocationSelector(
+                        selectedLocation = uiState.selectedLocation,
+                        locations = locations,
+                        onClick = { showLocationSheet = true },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp, vertical = 12.dp),
+                    )
+                    EditorDivider(Modifier.padding(horizontal = 20.dp))
+                }
+
+                item {
+                    DateFields(
+                        startDate = uiState.startDate,
+                        endDate = uiState.endDate,
+                        onStartDateChanged = onStartDateChanged,
+                        onEndDateChanged = onEndDateChanged,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                    )
+                    EditorDivider(Modifier.padding(horizontal = 20.dp))
+                }
+
+                item {
+                    CompanionChips(
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                    )
+                }
+
+                item {
+                    EditorContentField(
                         value = uiState.content,
                         onValueChange = onContentChanged,
-                        placeholder = { Text("여행에서 느낀 점을 기록해 보세요") },
-                        minLines = 4,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 8.dp),
+                            .padding(horizontal = 20.dp, vertical = 8.dp),
                     )
                 }
 
                 uiState.errorMessage?.let { message ->
                     item {
-                        Text(message, color = TripRecordPalette.danger, fontSize = 12.sp)
+                        Text(
+                            text = message,
+                            color = TripRecordPalette.danger,
+                            fontSize = 12.sp,
+                            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                        )
                     }
                 }
-
-                item { Spacer(Modifier.height(18.dp)) }
             }
-
-            TripBottomBar(
-                selected = TripBottomTab.CREATE,
-                onMapClick = onMapClick,
-                onRecordClick = onRecordClick,
-                onProfileClick = onProfileClick,
-            )
         }
     }
 
@@ -388,7 +370,63 @@ fun TripRecordEditorScreen(
 }
 
 @Composable
-private fun PhotoEditor(
+private fun EditorTopBar(
+    title: String,
+    onBackClick: () -> Unit,
+    isSaving: Boolean,
+    onSaveClick: () -> Unit,
+) {
+    Column {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(64.dp),
+        ) {
+            TextButton(
+                onClick = onBackClick,
+                contentPadding = PaddingValues(0.dp),
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = 8.dp)
+                    .size(48.dp),
+            ) {
+                Text(
+                    text = "←",
+                    color = TripRecordPalette.text,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Light,
+                )
+            }
+            Text(
+                text = title,
+                color = TripRecordPalette.text,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.align(Alignment.Center),
+            )
+            TextButton(
+                onClick = onSaveClick,
+                enabled = !isSaving,
+                contentPadding = PaddingValues(horizontal = 12.dp),
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 8.dp),
+            ) {
+                Text(
+                    text = if (isSaving) "저장 중" else "저장",
+                    color = if (isSaving) TripRecordPalette.muted else TripRecordPalette.accent,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+        EditorDivider()
+    }
+}
+
+@Composable
+private fun PhotoSection(
+    locationName: String,
     photos: List<TripRecordPhotoUiState>,
     onAddClick: () -> Unit,
     onRecommendClick: () -> Unit,
@@ -396,12 +434,251 @@ private fun PhotoEditor(
     recommendationsAvailable: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    Column(modifier) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "$locationName · 여행 일정과 가까운 사진",
+                color = TripRecordPalette.text,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(10.dp))
+            TextButton(
+                onClick = onRecommendClick,
+                enabled = recommendationsAvailable,
+                contentPadding = PaddingValues(horizontal = 9.dp, vertical = 2.dp),
+                modifier = Modifier
+                    .height(36.dp)
+                    .border(
+                        width = 1.dp,
+                        color = if (recommendationsAvailable) {
+                            TripRecordPalette.danger.copy(alpha = 0.7f)
+                        } else {
+                            TripRecordPalette.line
+                        },
+                        shape = RoundedCornerShape(6.dp),
+                    ),
+            ) {
+                Text(
+                    text = "위치 기반 사진\n불러오기",
+                    color = if (recommendationsAvailable) TripRecordPalette.text else TripRecordPalette.muted,
+                    fontSize = 9.sp,
+                    lineHeight = 11.sp,
+                )
+            }
+        }
+        PhotoEditor(
+            photos = photos,
+            onAddClick = onAddClick,
+            onRemoveClick = onRemoveClick,
+            modifier = Modifier.padding(top = 12.dp, bottom = 16.dp),
+        )
+    }
+}
+
+@Composable
+private fun EditorTitleField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        textStyle = TextStyle(
+            color = TripRecordPalette.text,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+        ),
+        cursorBrush = SolidColor(TripRecordPalette.accent),
+        decorationBox = { innerTextField ->
+            Box(contentAlignment = Alignment.CenterStart) {
+                if (value.isBlank()) {
+                    Text(
+                        text = "여행의 제목을 적어주세요",
+                        color = TripRecordPalette.muted,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                innerTextField()
+            }
+        },
+        modifier = modifier.height(34.dp),
+    )
+}
+
+@Composable
+private fun DateFields(
+    startDate: String,
+    endDate: String,
+    onStartDateChanged: (String) -> Unit,
+    onEndDateChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        DateField(
+            label = "시작",
+            value = startDate,
+            onValueChange = onStartDateChanged,
+            modifier = Modifier.weight(1f),
+        )
+        DateField(
+            label = "종료",
+            value = endDate,
+            onValueChange = onEndDateChanged,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun DateField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        Text(
+            text = label,
+            color = TripRecordPalette.muted,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                singleLine = true,
+                textStyle = TextStyle(
+                    color = TripRecordPalette.text,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Medium,
+                ),
+                cursorBrush = SolidColor(TripRecordPalette.accent),
+                decorationBox = { innerTextField ->
+                    Box(contentAlignment = Alignment.CenterStart) {
+                        if (value.isBlank()) {
+                            Text(
+                                text = "연도. 월. 일.",
+                                color = TripRecordPalette.muted,
+                                fontSize = 11.sp,
+                            )
+                        }
+                        innerTextField()
+                    }
+                },
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = "□",
+                color = TripRecordPalette.muted,
+                fontSize = 10.sp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompanionChips(modifier: Modifier = Modifier) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        listOf("가족", "애인", "친구", "혼자").forEach { companion ->
+            Text(
+                text = companion,
+                color = TripRecordPalette.text,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50.dp))
+                    .background(TripRecordPalette.surface)
+                    .border(1.dp, TripRecordPalette.line, RoundedCornerShape(50.dp))
+                    .padding(horizontal = 11.dp, vertical = 7.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EditorContentField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        textStyle = TextStyle(
+            color = TripRecordPalette.text,
+            fontSize = 12.sp,
+            lineHeight = 18.sp,
+        ),
+        cursorBrush = SolidColor(TripRecordPalette.accent),
+        decorationBox = { innerTextField ->
+            Box {
+                if (value.isBlank()) {
+                    Text(
+                        text = "이곳에서의 추억을 자유롭게 남겨보세요. (선택)",
+                        color = TripRecordPalette.muted,
+                        fontSize = 12.sp,
+                    )
+                }
+                innerTextField()
+            }
+        },
+        modifier = modifier.heightIn(min = 150.dp),
+    )
+}
+
+@Composable
+private fun EditorDivider(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(TripRecordPalette.line.copy(alpha = 0.55f)),
+    )
+}
+
+@Composable
+private fun PhotoEditor(
+    photos: List<TripRecordPhotoUiState>,
+    onAddClick: () -> Unit,
+    onRemoveClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
+        if (photos.size < MaxPhotosPerRecord) {
+            PhotoActionButton(onClick = onAddClick)
+        }
         photos.forEach { photo ->
             Box {
                 PhotoPreview(photo = photo, modifier = Modifier.size(112.dp, 84.dp))
@@ -420,28 +697,33 @@ private fun PhotoEditor(
                 )
             }
         }
-        if (photos.size < MaxPhotosPerRecord) {
-            PhotoActionButton(icon = "＋", label = "사진 추가", onClick = onAddClick)
-        }
-        if (recommendationsAvailable) {
-            PhotoActionButton(icon = "⌖", label = "위치 기반 사진 \n 불러오기", onClick = onRecommendClick)
-        }
     }
 }
 
 @Composable
-private fun PhotoActionButton(icon: String, label: String, onClick: () -> Unit) {
+private fun PhotoActionButton(onClick: () -> Unit) {
     Column(
         modifier = Modifier
-            .size(84.dp)
-            .clip(RoundedCornerShape(16.dp))
+            .size(112.dp, 84.dp)
+            .clip(RoundedCornerShape(14.dp))
             .clickable(onClick = onClick)
-            .background(TripRecordPalette.surface),
+            .background(TripRecordPalette.accentSoft.copy(alpha = 0.6f))
+            .border(1.dp, TripRecordPalette.accent.copy(alpha = 0.45f), RoundedCornerShape(14.dp)),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(icon, color = TripRecordPalette.accent, fontSize = 27.sp)
-        Text(label, color = TripRecordPalette.muted, fontSize = 10.sp)
+        Text(
+            text = "사진첩",
+            color = TripRecordPalette.text,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text = "전체 보기",
+            color = TripRecordPalette.muted,
+            fontSize = 9.sp,
+            modifier = Modifier.padding(top = 4.dp),
+        )
     }
 }
 
@@ -501,54 +783,61 @@ private fun PhotoPreview(photo: TripRecordPhotoUiState, modifier: Modifier = Mod
     )
 }
 @Composable
-private fun EditorSectionLabel(text: String) {
-    Text(
-        text = text,
-        color = TripRecordPalette.muted,
-        fontSize = 12.sp,
-        fontWeight = FontWeight.SemiBold,
-    )
-}
-
-@Composable
 private fun LocationSelector(
     selectedLocation: Location?,
     locations: List<Location>,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
-            .clickable(onClick = onClick)
-            .background(TripRecordPalette.surface)
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
+            .clickable(onClick = onClick),
     ) {
-        Column(Modifier.weight(1f)) {
-            Text(
-                text = selectedLocation?.name ?: "여행 장소를 선택해 주세요",
-                color = if (selectedLocation == null) TripRecordPalette.muted else TripRecordPalette.text,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = selectedLocation?.let {
-                    "${locationTypeLabel(it)} · ${locationContext(it, locations)}"
-                } ?: "국가, 시·도, 시·군·구 검색",
-                color = TripRecordPalette.muted,
-                fontSize = 12.sp,
-                modifier = Modifier.padding(top = 5.dp),
-            )
-        }
         Text(
-            text = if (selectedLocation == null) "선택" else "변경",
+            text = if (selectedLocation == null) {
+                "여행 장소"
+            } else if (selectedLocation.countryId == KoreaCountryId) {
+                "국내 여행"
+            } else {
+                "해외 여행"
+            },
             color = TripRecordPalette.accent,
-            fontSize = 12.sp,
+            fontSize = 9.sp,
             fontWeight = FontWeight.Bold,
         )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "⊙",
+                color = TripRecordPalette.muted,
+                fontSize = 12.sp,
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = selectedLocation?.displayName(locations) ?: "여행 장소를 선택해 주세요",
+                color = if (selectedLocation == null) TripRecordPalette.muted else TripRecordPalette.text,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = "⌄",
+                color = TripRecordPalette.muted,
+                fontSize = 14.sp,
+            )
+        }
     }
+}
+
+private fun Location.displayName(locations: List<Location>): String {
+    if (type != LocationType.DISTRICT) return name
+    val parentName = locations.firstOrNull { it.id == parentId }?.name ?: return name
+    return "$parentName $name"
 }
 
 @Composable

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordListScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordListScreen.kt
@@ -46,7 +46,7 @@ fun TripRecordListScreen(
     onProfileClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    TripRecordBackground(modifier = modifier) {
+    TripRecordBackground(modifier = modifier.then(rememberDismissKeyboardOnTapModifier())) {
         Column(Modifier.fillMaxSize()) {
             TripRecordTopBar(
                 title = "Mapmory",

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordListScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordListScreen.kt
@@ -231,7 +231,7 @@ private fun TripRecordCard(
     ) {
         Column {
             TripPhotoImage(
-                previewBytes = record.photos.minByOrNull { it.sortOrder }?.previewBytes?.bytesForDecoding(),
+                imageBytes = record.photos.minByOrNull { it.sortOrder }?.previewBytes?.bytesForDecoding(),
                 contentDescription = record.title,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordEditorUiState.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordEditorUiState.kt
@@ -11,6 +11,31 @@ data class TripRecordEditorUiState(
     val endDate: String = "",
     val mediaObjectKeys: List<String> = emptyList(),
     val selectedPhotos: List<TripRecordPhotoUiState> = emptyList(),
+    val isDirty: Boolean = false,
+    val dirtyFields: Set<TripRecordEditorErrorTarget> = emptySet(),
     val isSaving: Boolean = false,
-    val errorMessage: String? = null,
-)
+    val fieldErrors: Map<TripRecordEditorErrorTarget, String> = emptyMap(),
+    val generalErrorMessage: String? = null,
+) {
+    val errorMessage: String?
+        get() = generalErrorMessage ?: fieldErrors.values.firstOrNull()
+
+    val errorTarget: TripRecordEditorErrorTarget?
+        get() = if (generalErrorMessage != null) {
+            TripRecordEditorErrorTarget.GENERAL
+        } else {
+            fieldErrors.keys.firstOrNull()
+        }
+
+    fun isFieldDirty(target: TripRecordEditorErrorTarget): Boolean = target in dirtyFields
+}
+
+enum class TripRecordEditorErrorTarget {
+    PHOTOS,
+    LOCATION,
+    TITLE,
+    START_DATE,
+    END_DATE,
+    CONTENT,
+    GENERAL,
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordEditorUiState.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordEditorUiState.kt
@@ -27,6 +27,9 @@ data class TripRecordEditorUiState(
             fieldErrors.keys.firstOrNull()
         }
 
+    val isSaveEnabled: Boolean
+        get() = isDirty && title.isNotBlank() && selectedLocation != null && !isSaving
+
     fun isFieldDirty(target: TripRecordEditorErrorTarget): Boolean = target in dirtyFields
 }
 

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordItemUiState.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordItemUiState.kt
@@ -23,6 +23,7 @@ data class TripRecordPhotoUiState(
     val latitude: Double? = null,
     val longitude: Double? = null,
     val capturedAt: String? = null,
+    val originalBytes: PhotoPreviewBytes? = null,
 )
 
 /** ByteArray의 변경 가능성을 UI 상태 밖으로 숨기고 생성 시점에 방어적으로 복사한다. */
@@ -54,6 +55,7 @@ fun SelectedPhoto.toTripRecordPhotoUiState(sortOrder: Int): TripRecordPhotoUiSta
         latitude = latitude,
         longitude = longitude,
         capturedAt = capturedAt,
+        originalBytes = PhotoPreviewBytes.from(originalBytes),
     )
 
 fun TripRecordData.toTripRecordItemUiState(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordItemUiState.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordItemUiState.kt
@@ -83,8 +83,8 @@ internal fun TripRecord.toTripRecordItemUiState(
     id = id,
     title = tripRecordTitle,
     content = tripRecordDescription.orEmpty(),
-    startDate = startTripDate.toString(),
-    endDate = endTripDate.toString(),
+    startDate = startTripDate?.toString(),
+    endDate = endTripDate?.toString(),
     locationName = location,
     photos = photos.sortedBy { it.sortOrder },
 )

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModel.kt
@@ -10,6 +10,7 @@ import com.mapmory.shared.domain.model.dateValidationError
 import com.mapmory.shared.domain.usecase.CreateTripRecordUseCase
 import com.mapmory.shared.domain.usecase.UpdateTripRecordUseCase
 import com.mapmory.shared.presentation.photo.SelectedPhoto
+import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorErrorTarget
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorUiState
 import com.mapmory.shared.presentation.triprecord.state.toTripRecordPhotoUiState
 
@@ -44,47 +45,68 @@ class TripRecordEditorViewModel(
     }
 
     fun selectLocation(location: Location) {
-        uiState = uiState.copy(selectedLocation = location, errorMessage = null)
+        uiState = uiState.copy(
+            selectedLocation = location,
+        ).revalidatedAfterChange(TripRecordEditorErrorTarget.LOCATION)
+    }
+
+    fun touchLocation() {
+        uiState = uiState.revalidatedAfterChange(TripRecordEditorErrorTarget.LOCATION)
     }
 
     fun clearLocation() {
-        uiState = uiState.copy(selectedLocation = null, errorMessage = null)
+        uiState = uiState.copy(
+            selectedLocation = null,
+        ).revalidatedAfterChange(TripRecordEditorErrorTarget.LOCATION)
     }
 
     fun updateTitle(title: String) {
-        uiState = uiState.copy(title = title, errorMessage = null)
+        uiState = uiState.copy(
+            title = title,
+        ).revalidatedAfterChange(TripRecordEditorErrorTarget.TITLE)
     }
 
     fun updateContent(content: String) {
-        uiState = uiState.copy(content = content, errorMessage = null)
+        uiState = uiState.copy(
+            content = content,
+        ).revalidatedAfterChange()
     }
 
     fun updateStartDate(startDate: String) {
-        uiState = uiState.copy(startDate = startDate, errorMessage = null)
+        uiState = uiState.copy(
+            startDate = startDate,
+        ).revalidatedAfterChange(TripRecordEditorErrorTarget.START_DATE)
     }
 
     fun updateEndDate(endDate: String) {
-        uiState = uiState.copy(endDate = endDate, errorMessage = null)
+        uiState = uiState.copy(
+            endDate = endDate,
+        ).revalidatedAfterChange(TripRecordEditorErrorTarget.END_DATE)
     }
 
     fun addMediaObjectKey(objectKey: String) {
         val trimmedObjectKey = objectKey.trim()
         if (trimmedObjectKey.isBlank() || trimmedObjectKey in uiState.mediaObjectKeys) return
 
-        uiState = uiState.copy(mediaObjectKeys = uiState.mediaObjectKeys + trimmedObjectKey)
+        uiState = uiState.copy(
+            mediaObjectKeys = uiState.mediaObjectKeys + trimmedObjectKey,
+        ).revalidatedAfterChange()
     }
 
     fun removeMediaObjectKey(objectKey: String) {
         uiState = uiState.copy(
             mediaObjectKeys = uiState.mediaObjectKeys - objectKey,
             selectedPhotos = uiState.selectedPhotos.filterNot { it.id == objectKey },
-        )
+            fieldErrors = uiState.fieldErrors - TripRecordEditorErrorTarget.PHOTOS,
+        ).revalidatedAfterChange()
     }
 
     suspend fun save(): Boolean {
         val state = uiState
-        val location = state.selectedLocation ?: return fail("장소를 선택해 주세요.")
-        if (state.title.isBlank()) return fail("제목을 입력해 주세요.")
+        val validationErrors = state.validationErrors()
+        if (validationErrors.isNotEmpty()) return fail(validationErrors)
+
+        val location = requireNotNull(state.selectedLocation)
 
         val draft = TripRecordDraft(
             locationId = location.id,
@@ -94,9 +116,7 @@ class TripRecordEditorViewModel(
             endDate = state.endDate.ifBlank { null },
             mediaObjectKeys = state.mediaObjectKeys,
         )
-        draft.dateValidationError()?.let { return fail(it) }
-
-        uiState = state.copy(isSaving = true, errorMessage = null)
+        uiState = state.copy(isSaving = true, fieldErrors = emptyMap(), generalErrorMessage = null)
         val result = state.recordId?.let { updateTripRecord(it, draft) }
             ?: createTripRecord(draft)
 
@@ -108,15 +128,77 @@ class TripRecordEditorViewModel(
             onFailure = { error ->
                 uiState = uiState.copy(
                     isSaving = false,
-                    errorMessage = error.message ?: "여행 기록을 저장하지 못했습니다.",
+                    generalErrorMessage = error.message ?: "여행 기록을 저장하지 못했습니다.",
                 )
                 false
             },
         )
     }
 
-    private fun fail(message: String): Boolean {
-        uiState = uiState.copy(errorMessage = message)
+    private fun fail(errors: Map<TripRecordEditorErrorTarget, String>): Boolean {
+        uiState = uiState.copy(
+            isDirty = true,
+            dirtyFields = uiState.dirtyFields + errors.keys,
+            fieldErrors = errors,
+            generalErrorMessage = null,
+        )
         return false
+    }
+}
+
+private fun TripRecordEditorUiState.revalidatedAfterChange(
+    dirtyTarget: TripRecordEditorErrorTarget? = null,
+): TripRecordEditorUiState {
+    if (dirtyTarget == null) {
+        return copy(isDirty = true, generalErrorMessage = null)
+    }
+
+    val updatedDirtyFields = if (dirtyTarget in dirtyFields) dirtyFields else dirtyFields + dirtyTarget
+    val nonValidationErrors = fieldErrors.filterKeys { target ->
+        target == TripRecordEditorErrorTarget.PHOTOS
+    }
+    val dateRangeErrorTarget = when (dirtyTarget) {
+        TripRecordEditorErrorTarget.START_DATE,
+        TripRecordEditorErrorTarget.END_DATE -> dirtyTarget
+
+        else -> fieldErrors.keys.firstOrNull { target ->
+            target == TripRecordEditorErrorTarget.START_DATE ||
+                target == TripRecordEditorErrorTarget.END_DATE
+        } ?: TripRecordEditorErrorTarget.END_DATE
+    }
+    return copy(
+        isDirty = true,
+        dirtyFields = updatedDirtyFields,
+        fieldErrors = nonValidationErrors + validationErrors(dateRangeErrorTarget)
+            .filterKeys(updatedDirtyFields::contains),
+        generalErrorMessage = null,
+    )
+}
+
+private fun TripRecordEditorUiState.validationErrors(
+    dateRangeErrorTarget: TripRecordEditorErrorTarget = TripRecordEditorErrorTarget.END_DATE,
+): Map<TripRecordEditorErrorTarget, String> = buildMap {
+    if (selectedLocation == null) {
+        put(TripRecordEditorErrorTarget.LOCATION, "장소를 선택해 주세요.")
+    }
+    if (title.isBlank()) {
+        put(TripRecordEditorErrorTarget.TITLE, "제목을 입력해 주세요.")
+    }
+
+    val dateError = TripRecordDraft(
+        locationId = selectedLocation?.id ?: 0L,
+        title = title,
+        content = content,
+        startDate = startDate.ifBlank { null },
+        endDate = endDate.ifBlank { null },
+        mediaObjectKeys = mediaObjectKeys,
+    ).dateValidationError()
+    if (dateError != null) {
+        val target = when (dateError) {
+            "올바른 시작일을 입력해 주세요." -> TripRecordEditorErrorTarget.START_DATE
+            "올바른 종료일을 입력해 주세요." -> TripRecordEditorErrorTarget.END_DATE
+            else -> dateRangeErrorTarget
+        }
+        put(target, dateError)
     }
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModel.kt
@@ -3,7 +3,6 @@ package com.mapmory.shared.presentation.triprecord.viewmodel
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import com.mapmory.shared.domain.TripRecord
 import com.mapmory.shared.domain.TripRecords
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModel.kt
@@ -8,6 +8,7 @@ import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.photo.MaxPhotosPerRecord
 import com.mapmory.shared.presentation.photo.SelectedPhoto
+import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorErrorTarget
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorUiState
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEffect
 import com.mapmory.shared.presentation.triprecord.state.TripRecordFilterUiState
@@ -32,6 +33,8 @@ sealed interface TripRecordAction {
     data class StartEditing(val recordId: Long) : TripRecordAction
 
     data class LocationSelected(val location: Location) : TripRecordAction
+
+    data object LocationTouched : TripRecordAction
 
     data class TitleChanged(val title: String) : TripRecordAction
 
@@ -100,23 +103,37 @@ class TripRecordsViewModel(
             is TripRecordAction.StartCreating -> startCreating(action.selectedLocation)
             is TripRecordAction.StartEditing -> startEditing(action.recordId)
             is TripRecordAction.LocationSelected -> updateEditor {
-                copy(selectedLocation = action.location, errorMessage = null)
+                copy(
+                    selectedLocation = action.location,
+                ).revalidatedAfterChange(TripRecordEditorErrorTarget.LOCATION)
+            }
+
+            TripRecordAction.LocationTouched -> updateEditor {
+                revalidatedAfterChange(TripRecordEditorErrorTarget.LOCATION)
             }
 
             is TripRecordAction.TitleChanged -> updateEditor {
-                copy(title = action.title, errorMessage = null)
+                copy(
+                    title = action.title,
+                ).revalidatedAfterChange(TripRecordEditorErrorTarget.TITLE)
             }
 
             is TripRecordAction.ContentChanged -> updateEditor {
-                copy(content = action.content, errorMessage = null)
+                copy(
+                    content = action.content,
+                ).revalidatedAfterChange()
             }
 
             is TripRecordAction.StartDateChanged -> updateEditor {
-                copy(startDate = action.date, errorMessage = null)
+                copy(
+                    startDate = action.date,
+                ).revalidatedAfterChange(TripRecordEditorErrorTarget.START_DATE)
             }
 
             is TripRecordAction.EndDateChanged -> updateEditor {
-                copy(endDate = action.date, errorMessage = null)
+                copy(
+                    endDate = action.date,
+                ).revalidatedAfterChange(TripRecordEditorErrorTarget.END_DATE)
             }
 
             is TripRecordAction.PhotosAdded -> addPhotos(action.photos)
@@ -152,8 +169,8 @@ class TripRecordsViewModel(
                 selectedLocation = locations.firstOrNull { it.name == record.location },
                 title = record.tripRecordTitle,
                 content = record.tripRecordDescription.orEmpty(),
-                startDate = record.startTripDate.toString(),
-                endDate = record.endTripDate.toString(),
+                startDate = record.startTripDate?.toString().orEmpty(),
+                endDate = record.endTripDate?.toString().orEmpty(),
                 mediaObjectKeys = photos.map(TripRecordPhotoUiState::id),
                 selectedPhotos = photos,
             ),
@@ -174,16 +191,20 @@ class TripRecordsViewModel(
             }
         }.take(MaxPhotosPerRecord)
 
+        val updatedEditor = editor.copy(
+            selectedPhotos = merged,
+            mediaObjectKeys = merged.map(TripRecordPhotoUiState::id),
+            fieldErrors = if (merged.size < requested.size) {
+                editor.fieldErrors + mapOf(
+                    TripRecordEditorErrorTarget.PHOTOS to
+                        "사진은 최대 ${MaxPhotosPerRecord}장까지 추가할 수 있어요.",
+                )
+            } else {
+                editor.fieldErrors - TripRecordEditorErrorTarget.PHOTOS
+            },
+        ).revalidatedAfterChange()
         uiState = uiState.copy(
-            editor = editor.copy(
-                selectedPhotos = merged,
-                mediaObjectKeys = merged.map(TripRecordPhotoUiState::id),
-                errorMessage = if (merged.size < requested.size) {
-                    "사진은 최대 ${MaxPhotosPerRecord}장까지 추가할 수 있어요."
-                } else {
-                    null
-                },
-            ),
+            editor = updatedEditor,
         )
     }
 
@@ -195,28 +216,24 @@ class TripRecordsViewModel(
             copy(
                 selectedPhotos = remaining,
                 mediaObjectKeys = remaining.map(TripRecordPhotoUiState::id),
-                errorMessage = null,
-            )
+                fieldErrors = fieldErrors - TripRecordEditorErrorTarget.PHOTOS,
+            ).revalidatedAfterChange()
         }
     }
 
     private fun save() {
         val editor = uiState.editor
-        val location = editor.selectedLocation ?: return fail("장소를 선택해 주세요.")
         val title = editor.title.trim()
-        if (title.isEmpty()) return fail("제목을 입력해 주세요.")
+        val startDate = editor.startDate.takeIf(String::isNotBlank)?.toLocalDateOrNull()
+        val endDate = editor.endDate.takeIf(String::isNotBlank)?.toLocalDateOrNull()
+        val validationErrors = editor.validationErrors(startDate, endDate)
+        if (validationErrors.isNotEmpty()) return fail(validationErrors)
 
-        val startDate = editor.startDate.toLocalDateOrNull()
-            ?: return fail("올바른 시작일을 입력해 주세요.")
-        val endDate = if (editor.endDate.isBlank()) {
-            startDate
-        } else {
-            editor.endDate.toLocalDateOrNull()
-                ?: return fail("올바른 종료일을 입력해 주세요.")
-        }
-        if (startDate > endDate) return fail("종료일은 시작일보다 빠를 수 없습니다.")
+        val location = requireNotNull(editor.selectedLocation)
 
-        uiState = uiState.copy(editor = editor.copy(isSaving = true, errorMessage = null))
+        uiState = uiState.copy(
+            editor = editor.copy(isSaving = true, fieldErrors = emptyMap(), generalErrorMessage = null),
+        )
         val photos = editor.selectedPhotos.mapIndexed { index, photo -> photo.copy(sortOrder = index) }
         val imageUrl = photos.firstOrNull()?.id.orEmpty()
 
@@ -231,6 +248,8 @@ class TripRecordsViewModel(
                     editingDescription = editor.content.trim(),
                     editingStartTripDate = startDate,
                     editingEndTripDate = endDate,
+                    clearStartTripDate = editor.startDate.isBlank(),
+                    clearEndTripDate = editor.endDate.isBlank(),
                     editingLocation = location.name,
                 )
                 domainRecords.tripRecords.first { it.id == recordId }
@@ -246,14 +265,16 @@ class TripRecordsViewModel(
                 domainRecords.tripRecords.last()
             }
         }.getOrElse { error ->
-            fail(error.message ?: "여행 기록을 저장하지 못했습니다.")
+            fail(
+                generalErrorMessage = error.message ?: "여행 기록을 저장하지 못했습니다.",
+            )
             return
         }
 
         photosByRecordId = photosByRecordId + (savedRecord.id to photos)
         val wasEditing = editor.recordId != null
         publishRecords(
-            editor = editor.copy(isSaving = false, errorMessage = null),
+            editor = editor.copy(isSaving = false, fieldErrors = emptyMap(), generalErrorMessage = null),
             filter = TripRecordFilterUiState(),
             effect = if (wasEditing) {
                 TripRecordEffect.OpenDetail(savedRecord.id, replaceCurrent = true)
@@ -278,8 +299,20 @@ class TripRecordsViewModel(
         uiState = uiState.copy(editor = uiState.editor.transform())
     }
 
-    private fun fail(message: String) {
-        updateEditor { copy(isSaving = false, errorMessage = message) }
+    private fun fail(errors: Map<TripRecordEditorErrorTarget, String>) {
+        updateEditor {
+            copy(
+                isDirty = true,
+                dirtyFields = dirtyFields + errors.keys,
+                isSaving = false,
+                fieldErrors = errors,
+                generalErrorMessage = null,
+            )
+        }
+    }
+
+    private fun fail(generalErrorMessage: String) {
+        updateEditor { copy(isSaving = false, fieldErrors = emptyMap(), generalErrorMessage = generalErrorMessage) }
     }
 
     private fun emit(effect: TripRecordEffect) {
@@ -331,5 +364,61 @@ class TripRecordsViewModel(
 private fun String.toLocalDateOrNull(): LocalDate? = runCatching {
     LocalDate.parse(trim().replace(" ", "").replace('.', '-'))
 }.getOrNull()
+
+private fun TripRecordEditorUiState.revalidatedAfterChange(
+    dirtyTarget: TripRecordEditorErrorTarget? = null,
+): TripRecordEditorUiState {
+    if (dirtyTarget == null) {
+        return copy(isDirty = true, generalErrorMessage = null)
+    }
+
+    val startDateValue = startDate.takeIf(String::isNotBlank)?.toLocalDateOrNull()
+    val endDateValue = endDate.takeIf(String::isNotBlank)?.toLocalDateOrNull()
+    val updatedDirtyFields = if (dirtyTarget in dirtyFields) dirtyFields else dirtyFields + dirtyTarget
+    val nonValidationErrors = fieldErrors.filterKeys { target ->
+        target == TripRecordEditorErrorTarget.PHOTOS
+    }
+    val dateRangeErrorTarget = when (dirtyTarget) {
+        TripRecordEditorErrorTarget.START_DATE,
+        TripRecordEditorErrorTarget.END_DATE -> dirtyTarget
+
+        else -> fieldErrors.keys.firstOrNull { target ->
+            target == TripRecordEditorErrorTarget.START_DATE ||
+                target == TripRecordEditorErrorTarget.END_DATE
+        } ?: TripRecordEditorErrorTarget.END_DATE
+    }
+    return copy(
+        isDirty = true,
+        dirtyFields = updatedDirtyFields,
+        fieldErrors = nonValidationErrors + validationErrors(
+            startDateValue = startDateValue,
+            endDateValue = endDateValue,
+            dateRangeErrorTarget = dateRangeErrorTarget,
+        ).filterKeys(updatedDirtyFields::contains),
+        generalErrorMessage = null,
+    )
+}
+
+private fun TripRecordEditorUiState.validationErrors(
+    startDateValue: LocalDate?,
+    endDateValue: LocalDate?,
+    dateRangeErrorTarget: TripRecordEditorErrorTarget = TripRecordEditorErrorTarget.END_DATE,
+): Map<TripRecordEditorErrorTarget, String> = buildMap {
+    if (selectedLocation == null) {
+        put(TripRecordEditorErrorTarget.LOCATION, "장소를 선택해 주세요.")
+    }
+    if (title.isBlank()) {
+        put(TripRecordEditorErrorTarget.TITLE, "제목을 입력해 주세요.")
+    }
+    if (startDate.isNotBlank() && startDateValue == null) {
+        put(TripRecordEditorErrorTarget.START_DATE, "올바른 시작일을 입력해 주세요.")
+    }
+    if (endDate.isNotBlank() && endDateValue == null) {
+        put(TripRecordEditorErrorTarget.END_DATE, "올바른 종료일을 입력해 주세요.")
+    }
+    if (startDateValue != null && endDateValue != null && startDateValue > endDateValue) {
+        put(dateRangeErrorTarget, "종료일은 시작일보다 빠를 수 없습니다.")
+    }
+}
 
 private const val KoreaCountryId = 1L

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepositoryTest.kt
@@ -27,7 +27,7 @@ class FakeTripRecordRepositoryTest {
             ),
         ).getOrThrow()
 
-        assertEquals("2026-08-01", created.endDate)
+        assertEquals(null, created.endDate)
         assertEquals(0, created.media.single().sortOrder)
         assertEquals(1, repository.getTripRecords(TripRecordQuery()).getOrThrow().totalElements)
 

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordTest.kt
@@ -39,7 +39,22 @@ class TripRecordTest {
             endTripDate = LocalDate(2027, 1, 1),
         )
 
-        assertTrue(record.startTripDate < record.endTripDate)
+        assertTrue(requireNotNull(record.startTripDate) < requireNotNull(record.endTripDate))
+    }
+
+    @Test
+    fun `시작일과 종료일 없이 여행 기록을 생성할 수 있다`() {
+        val record = TripRecord(
+            imageUrl = "",
+            tripRecordTitle = "날짜 없는 여행",
+            tripRecordDescription = null,
+            startTripDate = null,
+            endTripDate = null,
+            location = "서울",
+        )
+
+        assertEquals(null, record.startTripDate)
+        assertEquals(null, record.endTripDate)
     }
 
     @Test

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModelTest.kt
@@ -7,6 +7,7 @@ import com.mapmory.shared.domain.model.TripRecordQuery
 import com.mapmory.shared.domain.usecase.CreateTripRecordUseCase
 import com.mapmory.shared.domain.usecase.GetTripRecordsUseCase
 import com.mapmory.shared.domain.usecase.UpdateTripRecordUseCase
+import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorErrorTarget
 import com.mapmory.shared.runSuspend
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -50,7 +51,7 @@ class TripRecordEditorViewModelTest {
     }
 
     @Test
-    fun saveRejectsInvalidDateRange() {
+    fun saveAllowsEitherDateToBeOmittedAndRejectsInvalidDateRange() {
         runSuspend {
             val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
             val viewModel = TripRecordEditorViewModel(
@@ -62,17 +63,62 @@ class TripRecordEditorViewModelTest {
             viewModel.updateTitle("서울 여행")
             viewModel.updateEndDate("2026-08-01")
 
-            assertFalse(viewModel.save())
-            assertEquals("종료일만 입력할 수 없습니다.", viewModel.uiState.errorMessage)
+            assertTrue(viewModel.save())
+            assertTrue(viewModel.uiState.fieldErrors.isEmpty())
 
             viewModel.updateStartDate("2026-08-02")
+            assertEquals("종료일은 시작일보다 빠를 수 없습니다.", viewModel.uiState.errorMessage)
+            assertEquals(TripRecordEditorErrorTarget.START_DATE, viewModel.uiState.errorTarget)
             assertFalse(viewModel.save())
             assertEquals("종료일은 시작일보다 빠를 수 없습니다.", viewModel.uiState.errorMessage)
+            assertEquals(TripRecordEditorErrorTarget.END_DATE, viewModel.uiState.errorTarget)
 
             viewModel.updateStartDate("2026-02-29")
             viewModel.updateEndDate("")
+            assertEquals("올바른 시작일을 입력해 주세요.", viewModel.uiState.errorMessage)
+            assertEquals(TripRecordEditorErrorTarget.START_DATE, viewModel.uiState.errorTarget)
             assertFalse(viewModel.save())
             assertEquals("올바른 시작일을 입력해 주세요.", viewModel.uiState.errorMessage)
+            assertEquals(TripRecordEditorErrorTarget.START_DATE, viewModel.uiState.errorTarget)
+        }
+    }
+
+    @Test
+    fun editingShowsOnlyTheTouchedFieldErrorImmediately() {
+        runSuspend {
+            val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
+            val viewModel = TripRecordEditorViewModel(
+                createTripRecord = CreateTripRecordUseCase(repository),
+                updateTripRecord = UpdateTripRecordUseCase(repository),
+            )
+            assertFalse(viewModel.uiState.isDirty)
+            viewModel.updateContent("작성 시작")
+
+            assertTrue(viewModel.uiState.isDirty)
+            assertTrue(viewModel.uiState.fieldErrors.isEmpty())
+
+            viewModel.updateTitle(" ")
+            assertEquals(
+                mapOf(TripRecordEditorErrorTarget.TITLE to "제목을 입력해 주세요."),
+                viewModel.uiState.fieldErrors,
+            )
+
+            viewModel.touchLocation()
+            assertEquals(
+                mapOf(
+                    TripRecordEditorErrorTarget.LOCATION to "장소를 선택해 주세요.",
+                    TripRecordEditorErrorTarget.TITLE to "제목을 입력해 주세요.",
+                ),
+                viewModel.uiState.fieldErrors,
+            )
+
+            viewModel.selectLocation(Location(101, 1, 1, "11680", "강남구", LocationType.DISTRICT))
+            assertEquals(
+                mapOf(TripRecordEditorErrorTarget.TITLE to "제목을 입력해 주세요."),
+                viewModel.uiState.fieldErrors,
+            )
+            viewModel.updateTitle("서울 여행")
+            assertTrue(viewModel.uiState.fieldErrors.isEmpty())
         }
     }
 

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModelTest.kt
@@ -18,6 +18,24 @@ import kotlin.test.assertTrue
 
 class TripRecordsViewModelTest {
     @Test
+    fun `저장 버튼은 제목과 위치가 모두 입력된 수정 상태에서만 활성화된다`() {
+        val viewModel = TripRecordsViewModel(locations)
+        viewModel.onAction(TripRecordAction.StartCreating())
+        viewModel.onAction(TripRecordAction.EffectHandled)
+
+        assertFalse(viewModel.uiState.editor.isSaveEnabled)
+
+        viewModel.onAction(TripRecordAction.TitleChanged("서울 여행"))
+        assertFalse(viewModel.uiState.editor.isSaveEnabled)
+
+        viewModel.onAction(TripRecordAction.LocationSelected(gangnam))
+        assertTrue(viewModel.uiState.editor.isSaveEnabled)
+
+        viewModel.onAction(TripRecordAction.TitleChanged(" "))
+        assertFalse(viewModel.uiState.editor.isSaveEnabled)
+    }
+
+    @Test
     fun `화면 액션으로 도메인 여행 기록을 생성하고 UI 상태를 발행한다`() {
         val viewModel = TripRecordsViewModel(locations)
         val initialState = viewModel.uiState
@@ -35,6 +53,7 @@ class TripRecordsViewModelTest {
                         id = "photo-1",
                         displayName = "서울.jpg",
                         previewBytes = byteArrayOf(1, 2, 3),
+                        originalBytes = byteArrayOf(4, 5, 6, 7),
                     ),
                 ),
             ),
@@ -51,6 +70,10 @@ class TripRecordsViewModelTest {
         assertContentEquals(
             byteArrayOf(1, 2, 3),
             record.photos.single().previewBytes?.bytesForDecoding(),
+        )
+        assertContentEquals(
+            byteArrayOf(4, 5, 6, 7),
+            record.photos.single().originalBytes?.bytesForDecoding(),
         )
         assertEquals(TripRecordEffect.OpenRecords, viewModel.uiState.effect)
     }

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModelTest.kt
@@ -5,6 +5,7 @@ import com.mapmory.shared.domain.TripRecords
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.photo.SelectedPhoto
+import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorErrorTarget
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEffect
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
@@ -109,12 +110,83 @@ class TripRecordsViewModelTest {
         viewModel.onAction(TripRecordAction.StartDateChanged("2026-08-03"))
         viewModel.onAction(TripRecordAction.EndDateChanged("2026-08-01"))
 
+        assertEquals("종료일은 시작일보다 빠를 수 없습니다.", viewModel.uiState.editor.errorMessage)
+        assertEquals(TripRecordEditorErrorTarget.END_DATE, viewModel.uiState.editor.errorTarget)
         viewModel.onAction(TripRecordAction.Save)
 
         assertTrue(viewModel.uiState.records.isEmpty())
         assertEquals("종료일은 시작일보다 빠를 수 없습니다.", viewModel.uiState.editor.errorMessage)
+        assertEquals(TripRecordEditorErrorTarget.END_DATE, viewModel.uiState.editor.errorTarget)
         assertFalse(viewModel.uiState.editor.isSaving)
         assertNull(viewModel.uiState.effect)
+    }
+
+    @Test
+    fun `수정한 컴포넌트의 오류만 즉시 발행한다`() {
+        val viewModel = TripRecordsViewModel(locations)
+        viewModel.onAction(TripRecordAction.StartCreating())
+        viewModel.onAction(TripRecordAction.EffectHandled)
+        assertFalse(viewModel.uiState.editor.isDirty)
+        viewModel.onAction(TripRecordAction.ContentChanged("작성 시작"))
+
+        assertTrue(viewModel.uiState.editor.isDirty)
+        assertTrue(viewModel.uiState.editor.fieldErrors.isEmpty())
+
+        viewModel.onAction(TripRecordAction.TitleChanged(" "))
+        assertEquals(
+            mapOf(TripRecordEditorErrorTarget.TITLE to "제목을 입력해 주세요."),
+            viewModel.uiState.editor.fieldErrors,
+        )
+
+        viewModel.onAction(TripRecordAction.LocationTouched)
+        assertEquals(
+            mapOf(
+                TripRecordEditorErrorTarget.LOCATION to "장소를 선택해 주세요.",
+                TripRecordEditorErrorTarget.TITLE to "제목을 입력해 주세요.",
+            ),
+            viewModel.uiState.editor.fieldErrors,
+        )
+        viewModel.onAction(TripRecordAction.LocationSelected(gangnam))
+        assertEquals(
+            mapOf(TripRecordEditorErrorTarget.TITLE to "제목을 입력해 주세요."),
+            viewModel.uiState.editor.fieldErrors,
+        )
+        viewModel.onAction(TripRecordAction.TitleChanged("서울 여행"))
+        assertTrue(viewModel.uiState.editor.fieldErrors.isEmpty())
+    }
+
+    @Test
+    fun `시작일과 종료일 없이 기록을 저장할 수 있다`() {
+        val viewModel = TripRecordsViewModel(locations)
+        viewModel.onAction(TripRecordAction.StartCreating(gangnam))
+        viewModel.onAction(TripRecordAction.EffectHandled)
+        viewModel.onAction(TripRecordAction.TitleChanged("날짜 없는 여행"))
+
+        viewModel.onAction(TripRecordAction.Save)
+
+        val record = viewModel.uiState.records.single()
+        assertNull(record.startDate)
+        assertNull(record.endDate)
+        assertEquals(TripRecordEffect.OpenRecords, viewModel.uiState.effect)
+    }
+
+    @Test
+    fun `기존 기록의 시작일과 종료일을 비울 수 있다`() {
+        val initialRecord = createRecord(id = 1L, title = "날짜가 있는 여행")
+        val viewModel = TripRecordsViewModel(
+            locations = locations,
+            initialRecords = TripRecords(listOf(initialRecord)),
+        )
+        viewModel.onAction(TripRecordAction.StartEditing(initialRecord.id))
+        viewModel.onAction(TripRecordAction.EffectHandled)
+        viewModel.onAction(TripRecordAction.StartDateChanged(""))
+        viewModel.onAction(TripRecordAction.EndDateChanged(""))
+
+        viewModel.onAction(TripRecordAction.Save)
+
+        val record = viewModel.uiState.records.single()
+        assertNull(record.startDate)
+        assertNull(record.endDate)
     }
 
     private fun createRecord(

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/date/PlatformDatePicker.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/date/PlatformDatePicker.ios.kt
@@ -1,0 +1,205 @@
+@file:OptIn(
+    kotlinx.cinterop.BetaInteropApi::class,
+    kotlinx.cinterop.ExperimentalForeignApi::class,
+)
+
+package com.mapmory.shared.presentation.date
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSLocale
+import platform.Foundation.NSSelectorFromString
+import platform.UIKit.UIApplication
+import platform.UIKit.UIButton
+import platform.UIKit.UIButtonTypeSystem
+import platform.UIKit.UIColor
+import platform.UIKit.UIControlEventTouchUpInside
+import platform.UIKit.UIControlStateNormal
+import platform.UIKit.UIDatePicker
+import platform.UIKit.UIDatePickerMode
+import platform.UIKit.UIDatePickerStyle
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+
+@Composable
+actual fun PlatformDatePicker(
+    visible: Boolean,
+    initialDate: String?,
+    minimumDate: String?,
+    onDateSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val presenter = remember { IosDatePickerPresenter() }
+    var nativeUnavailable by remember { mutableStateOf(false) }
+    presenter.onDateSelected = onDateSelected
+    presenter.onDismiss = onDismiss
+
+    LaunchedEffect(visible, initialDate, minimumDate) {
+        if (visible) {
+            nativeUnavailable = !presenter.present(initialDate, minimumDate)
+        } else {
+            nativeUnavailable = false
+            presenter.dismiss()
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { presenter.dismiss() }
+    }
+
+    if (nativeUnavailable) {
+        MaterialDatePickerFallback(
+            visible = true,
+            initialDate = initialDate,
+            minimumDate = minimumDate,
+            onDateSelected = onDateSelected,
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+private class IosDatePickerPresenter {
+    var onDateSelected: (String) -> Unit = {}
+    var onDismiss: () -> Unit = {}
+
+    private var controller: IosDatePickerViewController? = null
+
+    fun present(initialDate: String?, minimumDate: String?): Boolean {
+        if (controller != null) return true
+
+        val presenter = topViewControllerForDatePicker() ?: return false
+        val pickerController = IosDatePickerViewController(
+            initialDate = initialDate.toIosDate(),
+            minimumDate = minimumDate.toIosDate(),
+            onDateSelected = { date -> onDateSelected(date) },
+            onDismiss = {
+                controller = null
+                onDismiss()
+            },
+        )
+        controller = pickerController
+        presenter.presentViewController(pickerController, animated = true, completion = null)
+        return true
+    }
+
+    fun dismiss() {
+        controller?.let { activeController ->
+            controller = null
+            activeController.dismissSilently()
+        }
+    }
+}
+
+private class IosDatePickerViewController(
+    initialDate: NSDate?,
+    minimumDate: NSDate?,
+    private val onDateSelected: (String) -> Unit,
+    private val onDismiss: () -> Unit,
+) : UIViewController(nibName = null, bundle = null) {
+    private val datePicker = UIDatePicker()
+    private val cancelButton = UIButton.buttonWithType(UIButtonTypeSystem)
+    private val doneButton = UIButton.buttonWithType(UIButtonTypeSystem)
+    private var didFinish = false
+
+    init {
+        datePicker.datePickerMode = UIDatePickerMode.UIDatePickerModeDate
+        datePicker.preferredDatePickerStyle = UIDatePickerStyle.UIDatePickerStyleInline
+        datePicker.locale = NSLocale(localeIdentifier = "ko_KR")
+        datePicker.date = initialDate ?: NSDate()
+        minimumDate?.let { datePicker.minimumDate = it }
+    }
+
+    override fun viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.whiteColor
+
+        cancelButton.setTitle("취소", forState = UIControlStateNormal)
+        cancelButton.addTarget(
+            target = this,
+            action = NSSelectorFromString("cancelPressed"),
+            forControlEvents = UIControlEventTouchUpInside,
+        )
+        doneButton.setTitle("완료", forState = UIControlStateNormal)
+        doneButton.addTarget(
+            target = this,
+            action = NSSelectorFromString("donePressed"),
+            forControlEvents = UIControlEventTouchUpInside,
+        )
+
+        view.addSubview(cancelButton)
+        view.addSubview(doneButton)
+        view.addSubview(datePicker)
+    }
+
+    override fun viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        val width = view.bounds.useContents { size.width }
+        cancelButton.setFrame(CGRectMake(20.0, 24.0, 80.0, 44.0))
+        doneButton.setFrame(CGRectMake(width - 100.0, 24.0, 80.0, 44.0))
+        datePicker.setFrame(CGRectMake(16.0, 80.0, width - 32.0, 360.0))
+    }
+
+    @ObjCAction
+    fun cancelPressed() {
+        finish(null)
+    }
+
+    @ObjCAction
+    fun donePressed() {
+        finish(datePicker.date)
+    }
+
+    fun dismissSilently() {
+        didFinish = true
+        dismissViewControllerAnimated(true, completion = null)
+    }
+
+    override fun viewDidDisappear(animated: Boolean) {
+        super.viewDidDisappear(animated)
+        if (!didFinish) {
+            didFinish = true
+            onDismiss()
+        }
+    }
+
+    private fun finish(date: NSDate?) {
+        if (didFinish) return
+        didFinish = true
+        date?.let { onDateSelected(it.toIosDateString()) }
+        onDismiss()
+        dismissViewControllerAnimated(true, completion = null)
+    }
+}
+
+private fun String?.toIosDate(): NSDate? = this
+    ?.trim()
+    ?.takeIf(String::isNotBlank)
+    ?.let { value -> iosDateFormatter().dateFromString(value) }
+
+private fun NSDate.toIosDateString(): String = iosDateFormatter().stringFromDate(this)
+
+private fun iosDateFormatter(): NSDateFormatter = NSDateFormatter().apply {
+    locale = NSLocale(localeIdentifier = "en_US_POSIX")
+    dateFormat = "yyyy-MM-dd"
+}
+
+private fun topViewControllerForDatePicker(): UIViewController? {
+    val application = UIApplication.sharedApplication
+    val window = application.keyWindow
+        ?: application.windows.filterIsInstance<UIWindow>().firstOrNull { it.isKeyWindow() }
+    var controller = window?.rootViewController
+    while (controller?.presentedViewController != null) {
+        controller = controller.presentedViewController
+    }
+    return controller
+}

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
@@ -244,11 +244,13 @@ private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDele
                 return@loadDataRepresentationForTypeIdentifier
             }
             onMain {
+                val originalBytes = data.toByteArray()
                 completion(
                     SelectedPhoto(
                         id = result.assetIdentifier ?: "ios-${data.hash}",
                         displayName = result.itemProvider.suggestedName ?: "여행 사진",
-                        previewBytes = data.toByteArray(),
+                        previewBytes = data.toPreviewByteArray() ?: originalBytes,
+                        originalBytes = originalBytes,
                     ),
                 )
             }
@@ -283,6 +285,9 @@ private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDele
             val previewBytes = data
                 ?.takeIf { it.length > 0UL }
                 ?.toPreviewByteArray()
+            val originalBytes = data
+                ?.takeIf { it.length > 0UL }
+                ?.toByteArray()
             onMain {
                 // requestImageDataAndOrientationForAsset invokes its result handler once.
                 // Keep completion serialized on the main queue with the other photo paths.
@@ -297,6 +302,7 @@ private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDele
                             latitude = latitude,
                             longitude = longitude,
                             capturedAt = asset.creationDate?.formattedPhotoDate(),
+                            originalBytes = originalBytes,
                         )
                     },
                 )

--- a/client/shared/src/jvmMain/kotlin/com/mapmory/shared/presentation/date/PlatformDatePicker.jvm.kt
+++ b/client/shared/src/jvmMain/kotlin/com/mapmory/shared/presentation/date/PlatformDatePicker.jvm.kt
@@ -1,0 +1,20 @@
+package com.mapmory.shared.presentation.date
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun PlatformDatePicker(
+    visible: Boolean,
+    initialDate: String?,
+    minimumDate: String?,
+    onDateSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    MaterialDatePickerFallback(
+        visible = visible,
+        initialDate = initialDate,
+        minimumDate = minimumDate,
+        onDateSelected = onDateSelected,
+        onDismiss = onDismiss,
+    )
+}


### PR DESCRIPTION
## 📌 작업 내용

  여행 기록 작성 화면의 입력 검증과 상태 보존을 개선하고, Android/iOS 네이티브 날짜 선택기를 추가
  했습니다.

  ##  변경 사항

  ### 작성 화면 UX
  - 작성 화면을 스크롤 가능한 구조로 개선
  - 화면 외부 터치 시 키보드 자동 해제
  - 화면 회전 시 작성 중인 상태 유지
  - 제목, 장소, 날짜 오류를 각 컴포넌트 하단에 표시
  - 필드별 `isDirty` 상태를 적용해 사용자가 수정한 필드부터 오류 표시

  ### 입력 검증
  - 제목과 장소만 필수 입력으로 변경
  - 날짜, 사진, 설명은 선택 입력으로 처리
  - 시작일과 종료일이 모두 입력된 경우 날짜 범위 검증
  - 제목과 장소가 모두 입력된 경우에만 저장 버튼 활성화
  - 저장 시 발생하는 일반 오류와 필드 오류를 분리

  ### 날짜 선택
  - 시작일/종료일 텍스트 영역 및 달력 아이콘 클릭 시 달력 표시
  - Android: `DatePickerDialog`
  - iOS: UIKit `UIDatePicker`
  - JVM/Preview: Material 3 날짜 선택기 fallback
  - 종료일 선택 시 시작일 이전 날짜 선택 제한

  ### 사진 처리
  - iOS에서 원본 사진 bytes를 보존
  - 상세 화면에서 원본 이미지를 우선 사용하고 실패 시 썸네일로 fallback
  - 위치 기반 사진 불러오기 및 사진첩 버튼 스타일 개선