### PR TITLE
docs: 태그 기반 지도 API와 ERD 설계

### DIFF
--- a/api.md
+++ b/api.md
@@ -1,6 +1,8 @@
-# Mapmory MVP API 명세
+# Mapmory API 명세
 
-> 기준일: 2026-08-11 · 범위: 지역 선택, 지도 마킹, 여행 기록, 이미지 첨부
+> 기준일: 2026-08-20 · 범위: 인증, 지역 선택, 지도 마킹, 여행 기록, 이미지 첨부, 사용자 생성 태그
+
+이 문서는 Mapmory API의 기준 계약이다. API 목록의 `구현 전 설계` 항목은 구현에 앞서 합의한 목표 계약이며, 구현이 끝나면 `구현됨`으로 상태를 변경한다.
 
 ## 1. 기본 정보
 
@@ -10,26 +12,30 @@
 | 요청·응답 형식 | `application/json` |
 | 오류 응답 형식 | `application/problem+json` |
 | 날짜 형식 | `YYYY-MM-DD` |
-| 임시 사용자 식별 | `X-Member-Id` 요청 헤더 |
+| 인증 | `Authorization: Bearer {accessToken}` |
 | 페이지네이션 | `page` 기본 0, `size` 기본 20·최대 100 |
 
-여행 기록은 비공개이며 작성자 본인만 조회·생성·수정·삭제할 수 있다. 다른 회원의 기록 ID를 요청해도 존재 여부를 숨기기 위해 `404`를 반환한다.
+`/auth/**`와 `/health`를 제외한 API는 유효한 Access Token이 필요하다. 여행 기록과 태그는 비공개이며 소유자 본인만 접근할 수 있다. 다른 회원의 리소스 ID를 요청해도 존재 여부를 숨기기 위해 `404`를 반환한다.
 
 ### API 목록
 
-`*`는 `X-Member-Id` 헤더가 필요한 API다.
-
-| Method | Endpoint | 설명 |
-| --- | --- | --- |
-| `GET` | `/countries` | 국가 목록 조회 |
-| `POST` | `/uploads/presigned-urls` * | 이미지 업로드용 Presigned URL 발급 |
-| `POST` | `/travel-records` * | 여행 기록 생성 |
-| `GET` | `/travel-records` * | 내 여행 기록 목록 조회 |
-| `GET` | `/travel-records/{travelRecordId}` * | 내 여행 기록 상세 조회 |
-| `PUT` | `/travel-records/{travelRecordId}` * | 내 여행 기록 전체 수정 |
-| `DELETE` | `/travel-records/{travelRecordId}` * | 내 여행 기록 삭제 |
-| `GET` | `/travel-records/map-summary/regions/roots` * | 루트 Region별 지도 색칠 정보 조회 |
-| `GET` | `/travel-records/map-summary/regions/{regionId}/children` * | 직속 하위 Region별 지도 색칠 정보 조회 |
+| 상태 | Method | Endpoint | 설명 |
+| --- | --- | --- | --- |
+| 구현됨 | `POST` | `/auth/login/kakao` | 카카오 로그인 |
+| 구현됨 | `POST` | `/auth/token/refresh` | Access·Refresh Token 회전 재발급 |
+| 구현됨 | `POST` | `/auth/logout` | Refresh Token 폐기 |
+| 구현됨 | `POST` | `/uploads/presigned-urls` | 이미지 업로드용 Presigned URL 발급 |
+| 구현됨 | `POST` | `/travel-records` | 여행 기록 생성 |
+| 구현됨 | `GET` | `/travel-records` | 내 여행 기록 목록 조회 |
+| 구현됨 | `GET` | `/travel-records/{travelRecordId}` | 내 여행 기록 상세 조회 |
+| 구현됨 | `PUT` | `/travel-records/{travelRecordId}` | 내 여행 기록 전체 수정 |
+| 구현됨 | `DELETE` | `/travel-records/{travelRecordId}` | 내 여행 기록 삭제 |
+| 구현됨 | `GET` | `/travel-records/map-summary/regions/roots` | 루트 Region별 지도 색칠 정보 조회 |
+| 구현됨 | `GET` | `/travel-records/map-summary/regions/{regionId}/children` | 직속 하위 Region별 지도 색칠 정보 조회 |
+| 구현 전 설계 | `POST` | `/tags` | 내 태그 생성 |
+| 구현 전 설계 | `GET` | `/tags` | 내 태그 목록 조회 |
+| 구현 전 설계 | `PATCH` | `/tags/{tagId}` | 내 태그 이름 수정 |
+| 구현 전 설계 | `DELETE` | `/tags/{tagId}` | 내 태그 삭제 |
 
 ### 공통 응답
 
@@ -65,33 +71,87 @@
 | `201 Created` | 생성 성공 |
 | `204 No Content` | 삭제 성공 |
 | `400 Bad Request` | 형식·유효성·업무 규칙 오류 |
+| `401 Unauthorized` | 인증 실패 또는 토큰 만료 |
+| `403 Forbidden` | 인증됐지만 접근 권한 없음 |
 | `404 Not Found` | 리소스 없음 또는 타인 기록 |
-| `409 Conflict` | 업로드 상태 충돌 |
+| `409 Conflict` | 중복 또는 리소스 상태 충돌 |
 
-## 2. Country API
+## 2. Auth API
 
-### 국가 목록 조회
+Auth API는 Access Token 없이 호출한다. 로그인 성공 후 보호 API에는 다음 헤더를 전달한다.
 
-`GET /api/v1/countries`
+```http
+Authorization: Bearer {accessToken}
+```
 
-`region_type = COUNTRY`인 Region을 반환한다. 지역 및 지도 경계 데이터는 안드로이드 앱의 로컬 데이터로 관리하므로, 서버는 별도 지역 목록 API를 제공하지 않는다.
+### 카카오 로그인
+
+`POST /api/v1/auth/login/kakao`
+
+```json
+{
+  "kakaoAccessToken": "kakao-access-token"
+}
+```
 
 #### Response `200 OK`
 
 ```json
 {
-  "data": [
-    {
-      "countryCode": "KR",
-      "name": "대한민국"
-    },
-    {
-      "countryCode": "JP",
-      "name": "일본"
-    }
-  ]
+  "data": {
+    "accessToken": "mapmory-access-token",
+    "refreshToken": "mapmory-refresh-token",
+    "isNewMember": true
+  }
 }
 ```
+
+### 토큰 재발급
+
+`POST /api/v1/auth/token/refresh`
+
+Refresh Token은 회전한다. 재발급에 성공하면 기존 Refresh Token을 폐기하고 새 Access·Refresh Token 쌍을 반환한다.
+
+```json
+{
+  "refreshToken": "mapmory-refresh-token"
+}
+```
+
+#### Response `200 OK`
+
+```json
+{
+  "data": {
+    "accessToken": "new-mapmory-access-token",
+    "refreshToken": "new-mapmory-refresh-token"
+  }
+}
+```
+
+### 로그아웃
+
+`POST /api/v1/auth/logout`
+
+```json
+{
+  "refreshToken": "mapmory-refresh-token"
+}
+```
+
+#### Response `204 No Content`
+
+### Auth 오류
+
+| 상태 | `code` | 조건 |
+| --- | --- | --- |
+| `401` | `INVALID_ACCESS_TOKEN` | Access Token이 유효하지 않음 |
+| `401` | `EXPIRED_ACCESS_TOKEN` | Access Token이 만료됨 |
+| `401` | `INVALID_KAKAO_TOKEN` | 카카오 Access Token이 유효하지 않음 |
+| `401` | `INVALID_REFRESH_TOKEN` | Refresh Token이 유효하지 않거나 폐기됨 |
+| `401` | `EXPIRED_REFRESH_TOKEN` | Refresh Token이 만료됨 |
+| `403` | `ACCESS_DENIED` | 리소스 접근 권한 없음 |
+| `503` | `KAKAO_UNAVAILABLE` | 카카오 인증 서버를 일시적으로 사용할 수 없음 |
 
 ## 3. Upload API
 
@@ -142,7 +202,102 @@
 
 업로드 후 24시간 안에 여행 기록과 연결되지 않은 객체는 고아 객체로 정리한다.
 
-## 4. Travel Record API
+## 4. Tag API — 구현 전 설계
+
+태그는 회원이 직접 만드는 비공개 리소스다. `연인`, `친구`, `가족`, `라멘맛집`처럼 자유롭게 만들 수 있으며 하나의 여행 기록에 여러 태그를 연결할 수 있다.
+
+`#`은 UI 표현이므로 태그 이름에 저장하지 않는다. 서버는 이름의 앞뒤 공백과 연속 공백을 정리하고 Unicode NFC·소문자를 적용한 `normalizedName`을 중복 판단에 사용한다.
+
+- 이름: 정규화 후 1~30자
+- 회원당 최대 10개
+- 기록당 최대 5개
+- 같은 회원은 정규화 이름이 같은 태그를 중복 생성할 수 없음
+- 다른 회원은 같은 이름의 태그를 만들 수 있음
+
+회원당 10개와 기록당 5개는 MVP 사용성을 검증하기 위한 임시 제한이다. 사용자 테스트와 실제 태그 사용 분포를 확인한 뒤 유지·완화 여부를 다시 결정한다.
+
+### 태그 생성
+
+`POST /api/v1/tags`
+
+```json
+{
+  "name": "라멘맛집"
+}
+```
+
+#### Response `201 Created`
+
+```json
+{
+  "data": {
+    "id": 12,
+    "name": "라멘맛집",
+    "createdAt": "2026-08-20T15:30:00",
+    "updatedAt": "2026-08-20T15:30:00"
+  }
+}
+```
+
+### 내 태그 목록 조회
+
+`GET /api/v1/tags`
+
+태그는 `createdAt ASC, id ASC`로 정렬한다. 연결된 기록이 없는 태그도 목록에 반환한다. 임시 회원당 제한이 10개이므로 MVP에서는 페이지네이션하지 않는다.
+
+#### Response `200 OK`
+
+```json
+{
+  "data": [
+    {
+      "id": 9,
+      "name": "연인",
+      "createdAt": "2026-08-19T12:00:00",
+      "updatedAt": "2026-08-19T12:00:00"
+    },
+    {
+      "id": 12,
+      "name": "라멘맛집",
+      "createdAt": "2026-08-20T15:30:00",
+      "updatedAt": "2026-08-20T15:30:00"
+    }
+  ]
+}
+```
+
+### 태그 이름 수정
+
+`PATCH /api/v1/tags/{tagId}`
+
+```json
+{
+  "name": "서울 라멘맛집"
+}
+```
+
+성공 시 태그 생성 응답과 같은 객체를 `200 OK`로 반환한다. 이름 변경은 연결된 모든 여행 기록에 즉시 반영된다.
+
+### 태그 삭제
+
+`DELETE /api/v1/tags/{tagId}`
+
+태그와 여행 기록의 연결만 삭제하며 여행 기록 자체는 유지한다.
+
+#### Response `204 No Content`
+
+### Tag 오류
+
+| 상태 | `code` | 조건 |
+| --- | --- | --- |
+| `400` | `VALIDATION_ERROR` | 이름 형식 또는 길이가 유효하지 않음 |
+| `404` | `TAG_NOT_FOUND` | 태그가 없거나 현재 회원의 태그가 아님 |
+| `409` | `TAG_NAME_CONFLICT` | 현재 회원에게 같은 정규화 이름의 태그가 있음 |
+| `409` | `TAG_LIMIT_EXCEEDED` | 임시 회원당 태그 10개 제한 초과 |
+
+## 5. Travel Record API
+
+기존 여행 기록 엔드포인트는 구현돼 있다. 이 절의 `tagIds`, `tags`, `tagId` 계약은 태그 기능 구현 전 설계다.
 
 ### 지역 선택 규칙
 
@@ -176,7 +331,8 @@
   "endDate": null,
   "objectKeys": [
     "travel-records/10/550e8400-e29b-41d4-a716-446655440000.jpg"
-  ]
+  ],
+  "tagIds": [9, 12]
 }
 ```
 
@@ -191,7 +347,8 @@
   "content": "",
   "startDate": "2026-08-11",
   "endDate": null,
-  "objectKeys": []
+  "objectKeys": [],
+  "tagIds": [8]
 }
 ```
 
@@ -205,8 +362,11 @@
 | `startDate` | LocalDate | 예 | `YYYY-MM-DD` |
 | `endDate` | LocalDate | 아니요 | 시작일보다 빠를 수 없음 |
 | `objectKeys` | String[] | 아니요 | 업로드 완료된 Object Key 목록 |
+| `tagIds` | Long[] | 아니요 | 빈 배열 허용, 최대 5개, 중복 불가, 모두 현재 회원 소유 |
 
 `objectKeys`는 배열 순서대로 `record_media.sort_order`를 0부터 부여해 저장한다. 값이 없거나 `null`이면 미디어를 생성하지 않는다.
+
+`tagIds`가 없거나 `null`이면 태그를 연결하지 않는다. 새 태그를 입력한 클라이언트는 먼저 `POST /tags`로 태그를 생성한 뒤 반환된 ID를 여행 기록 요청에 포함한다. 여행 기록과 태그 연결은 같은 트랜잭션에서 저장한다.
 
 #### Response `201 Created`
 
@@ -227,6 +387,8 @@
 | `400` | `INVALID_TRAVEL_DATE_RANGE` | 종료일이 시작일보다 빠름 |
 | `400` | `INVALID_OBJECT_KEY` | Object Key 형식 또는 소유자가 올바르지 않음 |
 | `409` | `OBJECT_NOT_UPLOADED` | S3 업로드가 확인되지 않음 |
+| `400` | `TOO_MANY_TAGS` | 임시 기록당 태그 5개 제한 초과 |
+| `404` | `TAG_NOT_FOUND` | 태그가 없거나 현재 회원의 태그가 아님 |
 
 ### 여행 기록 목록 조회
 
@@ -239,8 +401,11 @@
 | `countryCode` | 아니요 | 선택 국가 자체와 `root_id`가 해당 국가인 모든 하위 Region 기록 |
 | `provinceCode` | 아니요 | 선택 시도 자체와 `parent_id`가 해당 시도인 시·군·구 기록. `countryCode` 필수 |
 | `districtCode` | 아니요 | 선택 시·군·구에 직접 저장된 기록. `countryCode`, `provinceCode` 필수 |
+| `tagId` | 아니요 | 현재 회원의 해당 태그가 연결된 기록만 조회 |
 | `page` | 아니요 | 기본값 `0`, 0 이상 |
 | `size` | 아니요 | 기본값 `20`, 1 이상 100 이하 |
+
+지역 조건과 `tagId`를 함께 전달하면 모든 조건을 `AND`로 결합한다. MVP에서는 태그 하나만 필터링하며 여러 태그의 `ANY`/`ALL` 검색은 제공하지 않는다.
 
 #### 조회 예시
 
@@ -256,6 +421,9 @@ GET /api/v1/travel-records?countryCode=KR&provinceCode=49
 
 # 제주시 기록
 GET /api/v1/travel-records?countryCode=KR&provinceCode=49&districtCode=50110
+
+# 라멘맛집 태그가 연결된 내 기록
+GET /api/v1/travel-records?tagId=12
 ```
 
 #### Response `200 OK`
@@ -270,7 +438,11 @@ GET /api/v1/travel-records?countryCode=KR&provinceCode=49&districtCode=50110
         "regionName": "제주시",
         "startDate": "2026-08-11",
         "endDate": null,
-        "thumbnailUrl": null
+        "thumbnailUrl": null,
+        "tags": [
+          { "id": 9, "name": "연인" },
+          { "id": 12, "name": "라멘맛집" }
+        ]
       }
     ],
     "page": 0,
@@ -284,17 +456,20 @@ GET /api/v1/travel-records?countryCode=KR&provinceCode=49&districtCode=50110
 
 목록에는 본문과 전체 미디어 목록을 포함하지 않는다. `thumbnailUrl` 필드는 후속 구현을 위해 포함했으며 현재는 `null`을 반환한다.
 
+`tags`는 `tag.created_at ASC, tag.id ASC` 순서로 반환한다.
+
 #### 검증 및 오류 응답
 
-`X-Member-Id` 헤더는 필수이며 양의 정수여야 한다. 헤더 누락·형식 오류·0 이하 값은 `400 VALIDATION_ERROR`를 반환한다.
+Access Token에서 식별한 현재 회원의 기록만 반환한다.
 
 | 상태 | `code` | 조건 |
 | --- | --- | --- |
 | `400` | `VALIDATION_ERROR` | 지역 코드 형식이 올바르지 않음, `page < 0`, `size`가 1 미만 또는 100 초과 |
 | `400` | `REGION_REQUIRED` | `provinceCode`에 `countryCode`가 없거나, `districtCode`에 `countryCode` 또는 `provinceCode`가 없음 |
-| `404` | `MEMBER_NOT_FOUND` | `X-Member-Id`에 해당하는 회원이 없음 |
+| `404` | `MEMBER_NOT_FOUND` | Access Token의 회원이 더 이상 존재하지 않음 |
 | `404` | `REGION_NOT_FOUND` | 요청한 국가·시도·시군구 코드가 없음 |
 | `400` | `INVALID_REGION_HIERARCHY` | 시도가 선택 국가의 직계 자식이 아니거나, 시군구가 선택 시도의 직계 자식이 아님 |
+| `404` | `TAG_NOT_FOUND` | 태그가 없거나 현재 회원의 태그가 아님 |
 
 조건에 맞는 기록이 없는 경우는 오류가 아니며 `200 OK`와 빈 `items`를 반환한다.
 
@@ -302,7 +477,7 @@ GET /api/v1/travel-records?countryCode=KR&provinceCode=49&districtCode=50110
 
 `GET /api/v1/travel-records/{travelRecordId}`
 
-`X-Member-Id` 헤더와 `travelRecordId`는 양의 정수여야 한다. 현재 회원이 소유한 기록만 조회하며, 기록이 없거나 다른 회원의 기록이면 모두 `404 TRAVEL_RECORD_NOT_FOUND`를 반환한다.
+`travelRecordId`는 양의 정수여야 한다. 현재 회원이 소유한 기록만 조회하며, 기록이 없거나 다른 회원의 기록이면 모두 `404 TRAVEL_RECORD_NOT_FOUND`를 반환한다.
 
 #### Response `200 OK`
 
@@ -331,6 +506,10 @@ GET /api/v1/travel-records?countryCode=KR&provinceCode=49&districtCode=50110
     "objectKeys": [
       "travel-records/10/550e8400-e29b-41d4-a716-446655440000.jpg"
     ],
+    "tags": [
+      { "id": 9, "name": "연인" },
+      { "id": 12, "name": "라멘맛집" }
+    ],
     "createdAt": "2026-08-14T10:30:00",
     "updatedAt": "2026-08-15T09:00:00"
   }
@@ -343,7 +522,7 @@ GET /api/v1/travel-records?countryCode=KR&provinceCode=49&districtCode=50110
 
 `PUT /api/v1/travel-records/{travelRecordId}`
 
-현재 회원이 소유한 여행 기록을 생성 요청과 같은 본문으로 전체 수정한다. `objectKeys`는 수정 후 유지할 전체 미디어 목록이며 배열 순서가 노출 순서가 된다.
+현재 회원이 소유한 여행 기록을 생성 요청과 같은 본문으로 전체 수정한다. `objectKeys`는 수정 후 유지할 전체 미디어 목록이며 배열 순서가 노출 순서가 된다. `tagIds`도 수정 후 연결할 전체 태그 목록이며 `null` 또는 빈 배열이면 기존 태그 연결을 모두 제거한다.
 
 - 기존 Object Key가 요청에도 있으면 미디어를 유지하고 순서만 변경한다.
 - 요청에서 빠진 기존 Object Key는 `record_media` 연결을 삭제한다.
@@ -381,16 +560,26 @@ Region 관련 오류는 생성 API와 동일하게 처리한다.
 
 | 상태 | `code` | 조건 |
 | --- | --- | --- |
-| `400` | `VALIDATION_ERROR` | 회원 ID 또는 여행 기록 ID가 양의 정수가 아님 |
+| `400` | `VALIDATION_ERROR` | 여행 기록 ID가 양의 정수가 아님 |
 | `404` | `TRAVEL_RECORD_NOT_FOUND` | 기록이 없거나 현재 회원의 기록이 아님 |
 
-## 5. 지도 요약 API
+## 6. 지도 요약 API
 
 지도 요약 응답에는 현재 회원의 기록이 있는 Region만 포함한다. 응답에 없는 Region은 앱에서 `count = 0`, `level = NONE`으로 처리한다.
 
+기존 지도 요약 엔드포인트와 `count`, `level` 응답은 구현돼 있다. 이 절의 선택 파라미터 `tagId` 계약은 태그 기능 구현 전 설계다.
+
+두 지도 요약 API는 선택 쿼리 파라미터 `tagId`를 받는다.
+
+| 파라미터 | 필수 | 설명 |
+| --- | --- | --- |
+| `tagId` | 아니요 | 현재 회원의 해당 태그가 연결된 기록만 집계 |
+
+`tagId`가 없으면 전체 기록을 집계하고, 값이 있으면 태그가 연결된 기록만 집계한다. 지도에 표시할 지역을 태그에 직접 저장하지 않고 `travel_record_tag`와 `travel_record.region_id`를 실시간 집계한다.
+
 ### 루트 Region별 지도 색칠 정보 조회
 
-`GET /api/v1/travel-records/map-summary/regions/roots`
+`GET /api/v1/travel-records/map-summary/regions/roots?tagId={tagId}`
 
 #### Response `200 OK`
 
@@ -423,15 +612,15 @@ Region 관련 오류는 생성 API와 동일하게 처리한다.
 
 ### 직속 하위 Region별 지도 색칠 정보 조회
 
-`GET /api/v1/travel-records/map-summary/regions/{regionId}/children`
+`GET /api/v1/travel-records/map-summary/regions/{regionId}/children?tagId={tagId}`
 
 이전 지도 요약 응답에서 받은 `regionId`를 경로에 전달한다.
 
 #### 요청 예시
 
 ```http
-GET /api/v1/travel-records/map-summary/regions/1/children
-X-Member-Id: 10
+GET /api/v1/travel-records/map-summary/regions/1/children?tagId=12
+Authorization: Bearer {accessToken}
 ```
 
 #### Response `200 OK`
@@ -460,3 +649,21 @@ X-Member-Id: 10
 | --- | --- | --- |
 | `400` | `VALIDATION_ERROR` | `regionId`가 양수가 아님 |
 | `404` | `REGION_NOT_FOUND` | 상위 Region이 존재하지 않음 |
+| `404` | `TAG_NOT_FOUND` | 태그가 없거나 현재 회원의 태그가 아님 |
+
+### 태그별 집계 규칙
+
+- 한 기록에 같은 태그를 중복 연결할 수 없으므로 한 지역 집계에서 기록을 한 번만 센다.
+- 태그는 존재하지만 연결된 기록이 없으면 빈 배열을 반환한다.
+- 기존 `count`와 `level` 계약은 유지한다. 태그 필터 적용 후의 `count`를 현재 `LevelPolicy` 기준으로 `NONE`, `LOW`, `MEDIUM`, `HIGH`로 변환한다.
+- 데이터 규모와 응답 시간을 측정하기 전에는 별도 태그–지역 집계 테이블을 만들지 않는다. 원본 관계를 실시간 집계해 기록·태그 변경과 지도 결과의 동기화 문제를 피한다.
+
+## 7. 구현 전 확인 사항
+
+- `tag`, `travel_record_tag` Flyway 마이그레이션과 JPA 모델 추가
+- 태그 이름 정규화 규칙을 서버와 클라이언트에서 동일하게 적용
+- 여행 기록 생성·수정 시 태그 소유권 검증과 연결 변경을 같은 트랜잭션에서 처리
+- 지도 요약 Repository에 선택적 `tagId` 조건을 추가하고 MySQL 실행 계획 검증
+- 목록·상세 응답에 `tags`를 추가한 뒤 KMP DTO 계약 갱신
+- 현재 구현에서 누락된 `title` 최대 200자 검증, `content` null 검증, 여행 날짜 범위 검증 보완
+- 여행 기록 생성에서도 Object Key 중복·소유권·업로드 완료 검증을 문서 계약과 일치시킴

--- a/backend/docs/erd.md
+++ b/backend/docs/erd.md
@@ -1,21 +1,147 @@
 # Mapmory ERD
 
-> 기준일: 2026-08-11 · 범위: 지역 선택, 지도 마킹, 여행 기록, 이미지 첨부
+> 기준일: 2026-08-20 · 기준 스키마: Flyway V1~V14 + 사용자 생성 태그 구현 전 설계
 
+이 문서는 현재 운영 스키마와 다음 구현 대상인 태그 스키마를 함께 보여준다.
 
-<img width="588" height="364" alt="스크린샷 2026-08-11 오후 3 04 34" src="https://github.com/user-attachments/assets/1d24fb8f-2ca7-400a-8525-cea938246569" />
+- `구현됨`: 현재 Flyway 마이그레이션과 JPA 모델에 존재한다.
+- `구현 전 설계`: API·ERD 합의 후 새 Flyway 마이그레이션으로 추가한다.
 
+## ERD
 
-## 테이블 역할
+```mermaid
+erDiagram
+    MEMBER ||--o{ REFRESH_TOKEN : issues
+    MEMBER ||--o{ TRAVEL_RECORD : writes
+    MEMBER ||--o{ TAG : owns
+    REGION ||--o{ REGION : parent_of
+    REGION ||--o{ TRAVEL_RECORD : locates
+    TRAVEL_RECORD ||--o{ RECORD_MEDIA : has
+    TRAVEL_RECORD ||--o{ TRAVEL_RECORD_TAG : tagged_with
+    TAG ||--o{ TRAVEL_RECORD_TAG : assigned_to
 
-| 테이블 | 역할 |
-| --- | --- |
-| `member` | 여행 기록 소유자. `uuid`는 외부 노출용 식별자다. |
-| `region` | 국가와 행정구역을 하나의 계층으로 관리한다. |
-| `travel_record` | 회원이 선택한 국가 또는 최종 행정구역에 남기는 기록이다. |
-| `record_media` | S3 객체 키, 썸네일 키, 노출 순서를 보관한다. |
+    MEMBER {
+        bigint id PK
+        char uuid UK
+        varchar name
+        varchar provider
+        varchar provider_id
+        datetime created_at
+        datetime updated_at
+    }
 
-## Region 계층과 코드
+    REFRESH_TOKEN {
+        bigint id PK
+        bigint member_id FK
+        varchar token_hash UK
+        datetime expires_at
+        datetime revoked_at
+        datetime created_at
+    }
+
+    REGION {
+        bigint id PK
+        bigint parent_id FK
+        bigint root_id FK
+        varchar region_code
+        varchar name
+        varchar region_type
+        datetime created_at
+        datetime updated_at
+    }
+
+    TRAVEL_RECORD {
+        bigint id PK
+        bigint member_id FK
+        bigint region_id FK
+        varchar title
+        text content
+        date start_date
+        date end_date
+        datetime created_at
+        datetime updated_at
+    }
+
+    RECORD_MEDIA {
+        bigint id PK
+        bigint travel_record_id FK
+        varchar object_key UK
+        varchar thumb_key
+        int sort_order
+        datetime created_at
+    }
+
+    TAG {
+        bigint id PK
+        bigint member_id FK
+        varchar name
+        varchar normalized_name
+        datetime created_at
+        datetime updated_at
+    }
+
+    TRAVEL_RECORD_TAG {
+        bigint travel_record_id PK,FK
+        bigint tag_id PK,FK
+        datetime created_at
+    }
+```
+
+## 테이블 상태와 역할
+
+| 상태 | 테이블 | 역할 |
+| --- | --- | --- |
+| 구현됨 | `member` | 회원과 소셜 로그인 식별 정보를 저장한다. |
+| 구현됨 | `refresh_token` | 회전 가능한 Refresh Token의 SHA-256 해시와 만료·폐기 시각을 저장한다. |
+| 구현됨 | `region` | 국가와 행정구역을 하나의 계층으로 관리한다. |
+| 구현됨 | `travel_record` | 회원이 선택한 국가 또는 최종 행정구역에 남기는 기록이다. |
+| 구현됨 | `record_media` | S3 객체 키, 썸네일 키, 노출 순서를 보관한다. |
+| 구현 전 설계 | `tag` | 회원이 만든 개인 태그를 저장한다. |
+| 구현 전 설계 | `travel_record_tag` | 여행 기록과 태그의 다대다 관계를 저장한다. |
+
+## 현재 구현 스키마
+
+### `member`
+
+| 컬럼 | 타입 | 제약조건 | 설명 |
+| --- | --- | --- | --- |
+| `id` | `BIGINT` | PK, AUTO_INCREMENT | 내부 회원 식별자 |
+| `uuid` | `CHAR(36)` | NOT NULL, UNIQUE | 외부 노출용 회원 식별자 |
+| `name` | `VARCHAR(50)` | NOT NULL | 회원 표시 이름 |
+| `provider` | `VARCHAR(20)` | NULL | `KAKAO` 등 소셜 로그인 제공자 |
+| `provider_id` | `VARCHAR(255)` | NULL | 소셜 제공자가 발급한 회원 식별자 |
+| `created_at` | `DATETIME` | NOT NULL | 생성 시각 |
+| `updated_at` | `DATETIME` | NOT NULL | 마지막 수정 시각 |
+
+`UNIQUE(provider, provider_id)`로 같은 소셜 계정의 중복 가입을 막는다. V11의 임시 회원을 보존하기 위해 두 소셜 로그인 컬럼은 현재 NULL을 허용한다.
+
+### `refresh_token`
+
+| 컬럼 | 타입 | 제약조건 | 설명 |
+| --- | --- | --- | --- |
+| `id` | `BIGINT` | PK, AUTO_INCREMENT | Refresh Token 식별자 |
+| `member_id` | `BIGINT` | NOT NULL, FK → `member.id` | 토큰 소유 회원 |
+| `token_hash` | `VARCHAR(64)` | NOT NULL, UNIQUE | 원문이 아닌 SHA-256 해시 |
+| `expires_at` | `DATETIME` | NOT NULL | 만료 시각 |
+| `revoked_at` | `DATETIME` | NULL | 회전 또는 로그아웃으로 폐기된 시각 |
+| `created_at` | `DATETIME` | NOT NULL | 생성 시각 |
+
+`INDEX(member_id)`로 회원의 토큰 일괄 폐기 조회를 지원한다.
+
+### `region`
+
+| 컬럼 | 타입 | 제약조건 | 설명 |
+| --- | --- | --- | --- |
+| `id` | `BIGINT` | PK, AUTO_INCREMENT | Region 식별자 |
+| `parent_id` | `BIGINT` | NULL, FK → `region.id` | 직속 상위 Region |
+| `root_id` | `BIGINT` | NULL, FK → `region.id` | 하위 Region이 속한 국가 Region |
+| `region_code` | `VARCHAR(20)` | NOT NULL | Region 타입별 원본 표준 코드 |
+| `name` | `VARCHAR(100)` | NOT NULL | 표시 이름 |
+| `region_type` | `VARCHAR(20)` | NOT NULL | `COUNTRY`, `PROVINCE`, `DISTRICT` |
+| `created_at` | `DATETIME` | NOT NULL | 생성 시각 |
+| `updated_at` | `DATETIME` | NOT NULL | 마지막 수정 시각 |
+
+#### Region 계층과 코드
 
 | `region_type` | `parent_id` | `root_id` | `region_code` 체계 |
 | --- | --- | --- | --- |
@@ -23,29 +149,135 @@
 | `PROVINCE` | 국가 Region | 국가 Region ID | ISO 3166-2 지역 코드 |
 | `DISTRICT` | 시·도 Region | 국가 Region ID | 행정표준코드 |
 
-`region_code`에는 해당 노드의 원본 표준 코드만 저장한다. 계층 관계는 어떤 경우에도 코드 접두사가 아닌 `parent_id`로만 판단한다.
+계층은 코드 접두사가 아닌 `parent_id`로만 판단한다. `root_id`는 국가별 필터와 집계를 빠르게 처리하기 위한 보조 컬럼이다.
 
-`root_id`는 국가별 통계와 필터를 위한 보조 컬럼이다. 직접 부모 관계를 표현하는 `parent_id`를 대체하지 않는다.
+현재 인덱스:
 
-## 예시 데이터
+- `INDEX(parent_id)`
+- `INDEX(root_id)`
 
-| id | parent_id | root_id | region_code | region_type | name |
-| ---: | ---: | ---: | --- | --- | --- |
-| 1 | NULL | NULL | `KR` | COUNTRY | 대한민국 |
-| 2 | 1 | 1 | `49` | PROVINCE | 제주특별자치도 |
-| 3 | 2 | 1 | `50110` | DISTRICT | 제주시 |
-| 4 | NULL | NULL | `JP` | COUNTRY | 일본 |
+현재 스키마는 Region 코드의 중복을 데이터베이스 UNIQUE로 차단하지 않는다. 애플리케이션은 `(parent_id, region_type, region_code)`가 한 행을 식별한다고 가정하므로 별도 마이그레이션에서 유일성 제약 추가 여부를 결정해야 한다.
 
-| travel_record.id | member_id | region_id | 의미 |
-| ---: | ---: | ---: | --- |
-| 101 | 10 | 3 | 대한민국 → 제주특별자치도 → 제주시 기록 |
-| 102 | 10 | 4 | 일본 국가 단위 기록 |
+### `travel_record`
 
-## 무결성 및 조회 규칙
+| 컬럼 | 타입 | 제약조건 | 설명 |
+| --- | --- | --- | --- |
+| `id` | `BIGINT` | PK, AUTO_INCREMENT | 여행 기록 식별자 |
+| `member_id` | `BIGINT` | NOT NULL, FK → `member.id` | 기록 소유 회원 |
+| `region_id` | `BIGINT` | NOT NULL, FK → `region.id` | 기록 대상 Region |
+| `title` | `VARCHAR(200)` | NOT NULL | 제목, 빈 문자열 허용 |
+| `content` | `TEXT` | NOT NULL | 본문, 빈 문자열 허용 |
+| `start_date` | `DATE` | NOT NULL | 여행 시작일 |
+| `end_date` | `DATE` | NULL | 여행 종료일 |
+| `created_at` | `DATETIME` | NOT NULL | 생성 시각 |
+| `updated_at` | `DATETIME` | NOT NULL | 마지막 수정 시각 |
 
-- `travel_record.region_id`는 필수다.
 - 해외 기록은 `COUNTRY` Region을 참조한다.
-- 대한민국 기록은 `DISTRICT` Region만 참조한다. 이 규칙은 서비스에서 검증한다.
-- 국가별 통계는 `region.id = 국가 ID OR region.root_id = 국가 ID` 조건으로 조회한다.
-- 시·도·시군구 통계는 요청 Region과 그 하위 Region에 연결된 기록을 집계한다.
-- 권장 인덱스는 `region(parent_id)`, `region(root_id)`, `travel_record(member_id, region_id)`다.
+- 대한민국 기록은 `DISTRICT` Region을 참조한다.
+- Region 타입과 계층 유효성은 서비스에서 검증한다.
+- `INDEX(member_id, region_id)`로 회원별 지역 필터와 지도 집계를 지원한다.
+
+### `record_media`
+
+| 컬럼 | 타입 | 제약조건 | 설명 |
+| --- | --- | --- | --- |
+| `id` | `BIGINT` | PK, AUTO_INCREMENT | 미디어 식별자 |
+| `travel_record_id` | `BIGINT` | NOT NULL, FK → `travel_record.id` | 소속 여행 기록 |
+| `object_key` | `VARCHAR(500)` | NOT NULL, UNIQUE | 원본 S3 객체 키 |
+| `thumb_key` | `VARCHAR(500)` | NULL | 썸네일 S3 객체 키 |
+| `sort_order` | `INT` | NOT NULL, DEFAULT 0 | 노출 순서 |
+| `created_at` | `DATETIME` | NOT NULL | 생성 시각 |
+
+여행 기록 삭제 시 `ON DELETE CASCADE`로 메타데이터를 함께 삭제한다. S3 실제 객체는 데이터베이스 CASCADE로 삭제되지 않는다.
+
+## 사용자 생성 태그 스키마 — 구현 전 설계
+
+### 핵심 결정
+
+- 태그는 `member`가 소유한다.
+- 여행 기록과 태그는 다대다 관계다.
+- 태그에 Region을 직접 연결하지 않는다.
+- 태그별 지도 영역은 `travel_record_tag → travel_record.region_id`를 집계해 계산한다.
+- 태그마다 별도의 `map` 행을 만들지 않는다. 공유·멤버십·공개 범위가 필요해질 때 `map` 도메인을 별도로 검토한다.
+
+### `tag`
+
+| 컬럼 | 타입 | 제약조건 | 설명 |
+| --- | --- | --- | --- |
+| `id` | `BIGINT` | PK, AUTO_INCREMENT | 태그 식별자 |
+| `member_id` | `BIGINT` | NOT NULL, FK → `member.id` | 태그 소유 회원 |
+| `name` | `VARCHAR(30)` | NOT NULL | 화면에 표시할 이름, `#` 제외 |
+| `normalized_name` | `VARCHAR(30)` | NOT NULL | 중복 판단용 정규화 이름 |
+| `created_at` | `DATETIME` | NOT NULL | 생성 시각 |
+| `updated_at` | `DATETIME` | NOT NULL | 마지막 수정 시각 |
+
+권장 제약조건과 인덱스:
+
+```sql
+CONSTRAINT fk_tag_member
+    FOREIGN KEY (member_id) REFERENCES member (id),
+CONSTRAINT uk_tag_member_normalized_name
+    UNIQUE (member_id, normalized_name),
+INDEX idx_tag_member_created (member_id, created_at, id)
+```
+
+`normalized_name`은 앞뒤 공백 제거, 연속 공백 축약, Unicode NFC, 소문자 변환을 적용한다. 같은 회원 안에서만 유일하며 다른 회원은 같은 이름을 사용할 수 있다.
+
+### `travel_record_tag`
+
+| 컬럼 | 타입 | 제약조건 | 설명 |
+| --- | --- | --- | --- |
+| `travel_record_id` | `BIGINT` | PK, FK → `travel_record.id` | 여행 기록 식별자 |
+| `tag_id` | `BIGINT` | PK, FK → `tag.id` | 태그 식별자 |
+| `created_at` | `DATETIME` | NOT NULL | 연결 생성 시각 |
+
+권장 제약조건과 인덱스:
+
+```sql
+PRIMARY KEY (travel_record_id, tag_id),
+CONSTRAINT fk_travel_record_tag_record
+    FOREIGN KEY (travel_record_id) REFERENCES travel_record (id)
+    ON DELETE CASCADE,
+CONSTRAINT fk_travel_record_tag_tag
+    FOREIGN KEY (tag_id) REFERENCES tag (id)
+    ON DELETE CASCADE,
+INDEX idx_travel_record_tag_tag_record (tag_id, travel_record_id)
+```
+
+복합 PK는 같은 기록에 동일한 태그가 중복 연결되는 것을 차단한다. `tag_id` 선두 인덱스는 태그별 기록 목록과 지도 집계에 사용한다.
+
+데이터베이스 외래 키만으로는 기록과 태그가 같은 회원 소유인지 보장하지 못한다. 서비스는 연결 전에 요청한 모든 태그를 `member_id`로 한 번에 조회하고, 조회된 고유 ID 수가 요청 ID 수와 같은지 검증해야 한다. 검증과 연결 저장은 여행 기록 생성·수정 트랜잭션 안에서 수행한다.
+
+## 관계 및 삭제 정책
+
+- `member` 1 : N `refresh_token`
+- `member` 1 : N `travel_record`
+- `member` 1 : N `tag`
+- `region` 1 : N `region`
+- `region` 1 : N `travel_record`
+- `travel_record` 1 : N `record_media`
+- `travel_record` N : M `tag`
+- 여행 기록 삭제 시 `record_media`, `travel_record_tag`를 CASCADE 삭제한다.
+- 태그 삭제 시 `travel_record_tag`만 CASCADE 삭제하며 여행 기록은 유지한다.
+- 회원 탈퇴 정책은 아직 확정되지 않았으므로 회원 관련 외래 키의 삭제 정책은 별도 ADR에서 결정한다.
+- 참조 중인 Region은 삭제하지 않는다. 행정구역 개편은 이력·코드 변경 정책으로 처리한다.
+
+## 태그 기능 한도와 후속 범위
+
+- 회원당 태그 최대 10개
+- 기록당 태그 최대 5개
+- 두 제한은 MVP 사용성 검증을 위한 임시 정책이며 사용자 테스트와 실제 사용 분포를 확인한 뒤 재결정
+- MVP 지도 필터는 단일 `tagId`만 지원
+- 여러 태그의 `ANY`/`ALL` 검색은 후속 범위
+- 태그 색상·아이콘·정렬·공유는 후속 범위
+- 집계 성능을 측정하기 전에는 태그–Region 집계 캐시 테이블을 추가하지 않음
+
+## 구현 순서
+
+1. API·ERD 리뷰와 태그 이름 정책 확정
+2. `tag`, `travel_record_tag` Flyway 마이그레이션 추가
+3. 태그 엔티티·Repository·CRUD API 구현
+4. 여행 기록 생성·수정·목록·상세에 태그 연결 추가
+5. 여행 기록 목록과 지도 요약에 단일 `tagId` 필터 추가
+6. MySQL Testcontainers로 유일성·CASCADE·집계 쿼리 검증
+7. KMP API DTO와 태그 선택 UI 연결


### PR DESCRIPTION
## 요약

- API 문서를 현재 JWT 인증과 Region 계층 기준으로 갱신했습니다.
- 사용자 생성 태그 CRUD와 여행 기록·지도 요약의 태그 필터 계약을 설계했습니다.
- 현재 V14 스키마와 추가 예정인 tag, travel_record_tag 구조를 ERD에 반영했습니다.

## 주요 결정

- 회원당 태그 10개, 기록당 태그 5개를 MVP 임시 제한으로 둡니다.
- MVP에서는 단일 tagId 필터만 지원합니다.
- Tag 응답에 recordCount를 포함하지 않습니다.
- 별도 map 또는 태그-Region 집계 테이블 없이 원본 관계를 실시간 집계합니다.
- 구현된 계약과 구현 전 설계를 문서에서 구분합니다.

## 확인

- git diff --check 통과
- 문서 변경만 포함하므로 자동화 테스트는 실행하지 않았습니다.