### PR TITLE
test: 사진 메타데이터 동기화 자동화 테스트 추가

### DIFF
--- a/client/docs/testing/photo-metadata-automation.md
+++ b/client/docs/testing/photo-metadata-automation.md
@@ -10,7 +10,9 @@
 
 ## 실행
 
-`client` 디렉터리에서 실행한다.
+`client` 디렉터리에서 실행한다. 운영체제에 따라 Gradle Wrapper 실행 명령이 다르다.
+
+### macOS/Linux
 
 ```bash
 # 공통 캐시 규칙과 기존 공통 테스트
@@ -24,6 +26,17 @@
 
 # 앱 전체 Android 컴파일
 ./gradlew :androidApp:assembleDebug
+```
+
+### Windows
+
+Windows에서는 `./gradlew` 대신 `gradlew.bat`을 사용한다.
+
+```bat
+gradlew.bat :shared:jvmTest
+gradlew.bat :shared:testAndroidHostTest
+gradlew.bat :shared:androidConnectedCheck
+gradlew.bat :androidApp:assembleDebug
 ```
 
 `androidConnectedCheck`는 연결된 모든 기기에서 실행된다. 특정 기기만 사용할 때는 다른 기기를 종료하거나 Gradle의 device 선택 옵션을 사용한다.

--- a/client/docs/testing/photo-metadata-automation.md
+++ b/client/docs/testing/photo-metadata-automation.md
@@ -1,0 +1,48 @@
+# 사진 메타데이터 자동화 테스트
+
+사진 추천 기능은 다음 세 층으로 확인한다.
+
+| 대상 | 테스트 | 확인 내용 |
+| --- | --- | --- |
+| 순수 캐시 규칙 | `commonTest` | 수정 시각이 같을 때 좌표를 재사용하고, 달라지면 재조회하는지 |
+| 실제 Room 동기화 | `androidDeviceTest` | 신규·변경·삭제 사진이 Room 스냅샷에 반영되는지 |
+| 실제 갤러리·Photo Picker | 수동 확인 | 권한, 사진 선택, 미리보기 표시 흐름 |
+
+## 실행
+
+`client` 디렉터리에서 실행한다.
+
+```bash
+# 공통 캐시 규칙과 기존 공통 테스트
+./gradlew :shared:jvmTest
+
+# Android 호스트 컴파일·단위 테스트
+./gradlew :shared:testAndroidHostTest
+
+# 실제 Android 기기 또는 에뮬레이터에서 Room 계측 테스트
+./gradlew :shared:androidConnectedCheck
+
+# 앱 전체 Android 컴파일
+./gradlew :androidApp:assembleDebug
+```
+
+`androidConnectedCheck`는 연결된 모든 기기에서 실행된다. 특정 기기만 사용할 때는 다른 기기를 종료하거나 Gradle의 device 선택 옵션을 사용한다.
+
+## 합격 기준
+
+- 신규 사진은 EXIF를 읽고 좌표와 메타데이터를 Room에 저장한다.
+- 같은 `mediaId`와 `modifiedAtSeconds`를 가진 사진은 기존 좌표를 재사용한다.
+- 수정 시각이 바뀐 사진은 EXIF를 다시 읽고 좌표를 갱신한다.
+- 현재 MediaStore 스냅샷에 없는 사진은 Room에서 삭제된다.
+- MediaStore 조회가 실패한 경우에는 기존 스냅샷을 임의로 삭제하지 않는다.
+
+## 성능 로그
+
+기능 테스트의 합격 여부는 좌표 재사용·Room 스냅샷 테스트로 판단한다. 실제 기기에서 시간 변화를 관찰할 때만 다음 로그를 사용한다.
+
+```bash
+adb -s <serial> shell setprop log.tag.MapmoryPhotoPerf DEBUG
+adb -s <serial> logcat -v time -s MapmoryPhotoPerf:D
+```
+
+`exif_reads`, `reused_coordinates`, `metadata_sync_ms`를 비교할 수 있지만, 현재는 고정된 성능 기준선으로 사용하지 않는다. 실제 갤러리 자동화, Photo Picker UI 자동화, Macrobenchmark와 CI 성능 기준선은 별도 작업으로 남긴다.

--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidxCompose = "1.11.4"
 navigationCompose = "2.9.2"
 ksp = "2.3.10"
 room = "2.8.4"
+androidxTest = "1.7.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -32,3 +33,5 @@ androidx-compose-foundation = { module = "androidx.compose.foundation:foundation
 jetbrains-androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTest" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTest" }

--- a/client/shared/build.gradle.kts
+++ b/client/shared/build.gradle.kts
@@ -14,6 +14,10 @@ kotlin {
         minSdk = libs.versions.minSdk.get().toInt()
 
         withHostTest {}
+        withDeviceTest {
+            instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+            execution = "HOST"
+        }
     }
     jvm()
     listOf(
@@ -59,6 +63,14 @@ kotlin {
             implementation(kotlin("test"))
             implementation(libs.ktor.client.mock)
         }
+
+        getByName("androidDeviceTest") {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.androidx.test.core)
+                implementation(libs.androidx.test.runner)
+            }
+        }
     }
 }
 
@@ -68,4 +80,11 @@ ksp {
 
 dependencies {
     add("kspAndroid", libs.androidx.room.compiler)
+}
+
+// Compose 1.11.1 does not initialize the output for the newly added KMP device-test variant.
+tasks.matching { it.name == "copyAndroidDeviceTestComposeResourcesToAndroidAssets" }.configureEach {
+    val outputDirectory = javaClass.getMethod("getOutputDirectory").invoke(this)
+        as org.gradle.api.file.DirectoryProperty
+    outputDirectory.set(layout.buildDirectory.dir("generated/compose/$name"))
 }

--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncDeviceTest.kt
@@ -1,0 +1,169 @@
+package com.mapmory.shared.presentation.photo
+
+import androidx.room.Room
+import androidx.test.platform.app.InstrumentationRegistry
+import com.mapmory.shared.data.local.photo.PhotoMetadataDatabase
+import com.mapmory.shared.data.local.photo.PhotoMetadataEntity
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+class PhotoMetadataSyncDeviceTest {
+    private lateinit var database: PhotoMetadataDatabase
+
+    @BeforeTest
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            PhotoMetadataDatabase::class.java,
+        ).allowMainThreadQueries().build()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun newPhotoReadsExifAndWritesRoom() = runBlocking {
+        val exifReads = mutableListOf<String>()
+        val result = sync(
+            current = listOf(candidate(mediaId = 1L, modifiedAtSeconds = 10L)),
+            coordinates = mapOf("content://photo/1" to (37.5 to 127.0)),
+            exifReads = exifReads,
+        ).sync()
+
+        assertEquals(1, result.exifReadCount)
+        assertEquals(0, result.reusedCoordinateCount)
+        assertEquals(listOf("content://photo/1"), exifReads)
+        assertEquals(37.5, database.photoMetadataDao().getAll().single().latitude)
+        assertEquals(127.0, database.photoMetadataDao().getAll().single().longitude)
+    }
+
+    @Test
+    fun unchangedPhotoReusesCachedCoordinates() = runBlocking {
+        val exifReads = mutableListOf<String>()
+        val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
+        sync(
+            current = listOf(photo),
+            coordinates = mapOf(photo.contentUri to (37.5 to 127.0)),
+            exifReads = exifReads,
+        ).sync()
+        exifReads.clear()
+
+        val result = sync(
+            current = listOf(photo),
+            coordinates = mapOf(photo.contentUri to (35.0 to 129.0)),
+            exifReads = exifReads,
+            scanId = 2L,
+        ).sync()
+
+        assertEquals(0, result.exifReadCount)
+        assertEquals(1, result.reusedCoordinateCount)
+        assertTrue(exifReads.isEmpty())
+        assertEquals(37.5, database.photoMetadataDao().getAll().single().latitude)
+    }
+
+    @Test
+    fun modifiedPhotoReadsExifAgainAndUpdatesCoordinates() = runBlocking {
+        val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
+        sync(
+            current = listOf(photo),
+            coordinates = mapOf(photo.contentUri to (37.5 to 127.0)),
+            exifReads = mutableListOf(),
+        ).sync()
+
+        val exifReads = mutableListOf<String>()
+        val result = sync(
+            current = listOf(photo.copy(modifiedAtSeconds = 11L)),
+            coordinates = mapOf(photo.contentUri to (35.0 to 129.0)),
+            exifReads = exifReads,
+            scanId = 2L,
+        ).sync()
+
+        assertEquals(1, result.exifReadCount)
+        assertEquals(0, result.reusedCoordinateCount)
+        assertEquals(listOf(photo.contentUri), exifReads)
+        assertEquals(35.0, database.photoMetadataDao().getAll().single().latitude)
+        assertEquals(129.0, database.photoMetadataDao().getAll().single().longitude)
+    }
+
+    @Test
+    fun photoMissingFromCurrentSnapshotIsRemoved() = runBlocking {
+        val first = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
+        val second = candidate(mediaId = 2L, modifiedAtSeconds = 10L)
+        sync(
+            current = listOf(first, second),
+            coordinates = mapOf(
+                first.contentUri to (37.5 to 127.0),
+                second.contentUri to (35.1 to 129.0),
+            ),
+            exifReads = mutableListOf(),
+        ).sync()
+
+        sync(
+            current = listOf(first),
+            coordinates = mapOf(first.contentUri to (37.5 to 127.0)),
+            exifReads = mutableListOf(),
+            scanId = 2L,
+        ).sync()
+
+        assertEquals(setOf(1L), database.photoMetadataDao().getAll().map(PhotoMetadataEntity::mediaId).toSet())
+    }
+
+    @Test
+    fun mediaStoreFailureKeepsPreviousSnapshot() = runBlocking {
+        val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
+        sync(
+            current = listOf(photo),
+            coordinates = mapOf(photo.contentUri to (37.5 to 127.0)),
+            exifReads = mutableListOf(),
+        ).sync()
+
+        sync(
+            current = null,
+            coordinates = emptyMap(),
+            exifReads = mutableListOf(),
+            scanId = 2L,
+        ).sync()
+
+        assertEquals(setOf(1L), database.photoMetadataDao().getAll().map(PhotoMetadataEntity::mediaId).toSet())
+    }
+
+    private fun sync(
+        current: List<PhotoMetadataCandidate>?,
+        coordinates: Map<String, Pair<Double, Double>>,
+        exifReads: MutableList<String>,
+        scanId: Long = 1L,
+    ): PhotoMetadataSync {
+        val dao = database.photoMetadataDao()
+        return PhotoMetadataSync(
+            readPrevious = { dao.getAll() },
+            readCurrent = { current },
+            readCoordinates = { contentUri ->
+                exifReads += contentUri
+                coordinates[contentUri]
+            },
+            writeSnapshot = { photos, currentScanId -> dao.replaceSnapshot(photos, currentScanId) },
+            scanIdProvider = { scanId },
+        )
+    }
+
+    private fun candidate(
+        mediaId: Long,
+        modifiedAtSeconds: Long,
+    ) = PhotoMetadataCandidate(
+        mediaId = mediaId,
+        contentUri = "content://photo/$mediaId",
+        displayName = "photo-$mediaId.jpg",
+        capturedAtMillis = 1_000L,
+        modifiedAtSeconds = modifiedAtSeconds,
+        mimeType = "image/jpeg",
+        sizeBytes = 128L,
+        width = 100,
+        height = 100,
+    )
+}

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
@@ -191,13 +191,6 @@ private data class GalleryEntry(
     val longitude: Double,
 )
 
-private data class PhotoMetadataSyncResult(
-    val photos: List<PhotoMetadataEntity>,
-    val exifReadCount: Int,
-    val reusedCoordinateCount: Int,
-    val previousPhotoCount: Int,
-)
-
 @Suppress("DEPRECATION")
 private suspend fun Context.recommendPhotos(
     target: Location,
@@ -291,11 +284,23 @@ private suspend fun Context.recommendPhotos(
 
 private suspend fun Context.syncPhotoMetadata(): PhotoMetadataSyncResult {
     val dao = PhotoMetadataDatabase.getInstance(this).photoMetadataDao()
-    val previousPhotos = traceSuspendSection("photo.sync.room.read", TraceCookie.RoomRead) {
-        dao.getAll()
-    }
-    val previousById = previousPhotos.associateBy(PhotoMetadataEntity::mediaId)
-    val scanId = System.currentTimeMillis()
+    return PhotoMetadataSync(
+        readPrevious = {
+            traceSuspendSection("photo.sync.room.read", TraceCookie.RoomRead) {
+                dao.getAll()
+            }
+        },
+        readCurrent = { queryPhotoMetadataSnapshot() },
+        readCoordinates = { contentUri -> readCoordinates(Uri.parse(contentUri)) },
+        writeSnapshot = { photos, scanId ->
+            traceSuspendSection("photo.sync.room.write", TraceCookie.RoomWrite) {
+                dao.replaceSnapshot(photos, scanId)
+            }
+        },
+    ).sync()
+}
+
+private fun Context.queryPhotoMetadataSnapshot(): List<PhotoMetadataCandidate>? {
     val projection = arrayOf(
         MediaStore.Images.Media._ID,
         MediaStore.Images.Media.DISPLAY_NAME,
@@ -306,9 +311,7 @@ private suspend fun Context.syncPhotoMetadata(): PhotoMetadataSyncResult {
         MediaStore.Images.Media.WIDTH,
         MediaStore.Images.Media.HEIGHT,
     )
-    var exifReadCount = 0
-    var reusedCoordinateCount = 0
-    val photos = traceSection("photo.sync.mediastore") {
+    return traceSection("photo.sync.mediastore") {
         contentResolver.query(
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
             projection,
@@ -317,64 +320,32 @@ private suspend fun Context.syncPhotoMetadata(): PhotoMetadataSyncResult {
             "${MediaStore.Images.Media.DATE_TAKEN} DESC",
         )?.use { cursor ->
             val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
-            buildList<PhotoMetadataEntity> {
+            buildList {
                 while (cursor.moveToNext()) {
                     val mediaId = cursor.getLong(idColumn)
                     val uri = ContentUris.withAppendedId(
                         MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
                         mediaId,
                     )
-                    val modifiedAtSeconds = cursor.getLongOrNull(MediaStore.Images.Media.DATE_MODIFIED) ?: 0L
-                    val previous = previousById[mediaId]
-                    val coordinates = if (
-                        previous != null &&
-                        previous.modifiedAtSeconds == modifiedAtSeconds &&
-                        previous.latitude != null &&
-                        previous.longitude != null
-                    ) {
-                        reusedCoordinateCount++
-                        requireNotNull(previous.latitude) to requireNotNull(previous.longitude)
-                    } else {
-                        exifReadCount++
-                        readCoordinates(uri)
-                    }
                     add(
-                        PhotoMetadataEntity(
+                        PhotoMetadataCandidate(
                             mediaId = mediaId,
                             contentUri = uri.toString(),
                             displayName = cursor.getStringOrNull(MediaStore.Images.Media.DISPLAY_NAME)
                                 ?: "여행 사진",
                             capturedAtMillis = cursor.getLongOrNull(MediaStore.Images.Media.DATE_TAKEN)
                                 ?.takeIf { it > 0L },
-                            modifiedAtSeconds = modifiedAtSeconds,
-                            latitude = coordinates?.first,
-                            longitude = coordinates?.second,
+                            modifiedAtSeconds = cursor.getLongOrNull(MediaStore.Images.Media.DATE_MODIFIED) ?: 0L,
                             mimeType = cursor.getStringOrNull(MediaStore.Images.Media.MIME_TYPE),
                             sizeBytes = cursor.getLongOrNull(MediaStore.Images.Media.SIZE) ?: 0L,
                             width = cursor.getIntOrNull(MediaStore.Images.Media.WIDTH) ?: 0,
                             height = cursor.getIntOrNull(MediaStore.Images.Media.HEIGHT) ?: 0,
-                            scanId = scanId,
                         ),
                     )
                 }
             }
         }
-    } ?: return PhotoMetadataSyncResult(
-        photos = emptyList(),
-        exifReadCount = exifReadCount,
-        reusedCoordinateCount = reusedCoordinateCount,
-        previousPhotoCount = previousPhotos.size,
-    )
-
-    traceSuspendSection("photo.sync.room.write", TraceCookie.RoomWrite) {
-        dao.replaceSnapshot(photos, scanId)
     }
-    return PhotoMetadataSyncResult(
-        photos = photos,
-        exifReadCount = exifReadCount,
-        reusedCoordinateCount = reusedCoordinateCount,
-        previousPhotoCount = previousPhotos.size,
-    )
 }
 
 private inline fun <T> traceSection(name: String, block: () -> T): T {

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCandidate.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCandidate.kt
@@ -1,0 +1,13 @@
+package com.mapmory.shared.presentation.photo
+
+internal data class PhotoMetadataCandidate(
+    val mediaId: Long,
+    val contentUri: String,
+    val displayName: String,
+    val capturedAtMillis: Long?,
+    val modifiedAtSeconds: Long,
+    val mimeType: String?,
+    val sizeBytes: Long,
+    val width: Int,
+    val height: Int,
+)

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSync.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSync.kt
@@ -1,0 +1,68 @@
+package com.mapmory.shared.presentation.photo
+
+import com.mapmory.shared.data.local.photo.PhotoMetadataEntity
+
+internal class PhotoMetadataSync(
+    private val readPrevious: suspend () -> List<PhotoMetadataEntity>,
+    private val readCurrent: suspend () -> List<PhotoMetadataCandidate>?,
+    private val readCoordinates: suspend (String) -> Pair<Double, Double>?,
+    private val writeSnapshot: suspend (List<PhotoMetadataEntity>, Long) -> Unit,
+    private val scanIdProvider: () -> Long = { System.currentTimeMillis() },
+) {
+    suspend fun sync(): PhotoMetadataSyncResult {
+        val previousPhotos = readPrevious()
+        val previousById = previousPhotos.associateBy(PhotoMetadataEntity::mediaId)
+        val currentPhotos = readCurrent() ?: return PhotoMetadataSyncResult(
+            photos = emptyList(),
+            exifReadCount = 0,
+            reusedCoordinateCount = 0,
+            previousPhotoCount = previousPhotos.size,
+        )
+        val scanId = scanIdProvider()
+        var exifReadCount = 0
+        var reusedCoordinateCount = 0
+        val photos = currentPhotos.map { candidate ->
+            val previous = previousById[candidate.mediaId]
+            val previousCoordinates = previous?.let { cached ->
+                cached.latitude?.let { latitude ->
+                    cached.longitude?.let { longitude -> latitude to longitude }
+                }
+            }
+            val coordinates = if (
+                shouldReuseCoordinates(
+                    previousModifiedAtSeconds = previous?.modifiedAtSeconds,
+                    previousLatitude = previous?.latitude,
+                    previousLongitude = previous?.longitude,
+                    currentModifiedAtSeconds = candidate.modifiedAtSeconds,
+                )
+            ) {
+                reusedCoordinateCount++
+                requireNotNull(previousCoordinates)
+            } else {
+                exifReadCount++
+                readCoordinates(candidate.contentUri)
+            }
+            PhotoMetadataEntity(
+                mediaId = candidate.mediaId,
+                contentUri = candidate.contentUri,
+                displayName = candidate.displayName,
+                capturedAtMillis = candidate.capturedAtMillis,
+                modifiedAtSeconds = candidate.modifiedAtSeconds,
+                latitude = coordinates?.first,
+                longitude = coordinates?.second,
+                mimeType = candidate.mimeType,
+                sizeBytes = candidate.sizeBytes,
+                width = candidate.width,
+                height = candidate.height,
+                scanId = scanId,
+            )
+        }
+        writeSnapshot(photos, scanId)
+        return PhotoMetadataSyncResult(
+            photos = photos,
+            exifReadCount = exifReadCount,
+            reusedCoordinateCount = reusedCoordinateCount,
+            previousPhotoCount = previousPhotos.size,
+        )
+    }
+}

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncResult.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncResult.kt
@@ -1,0 +1,10 @@
+package com.mapmory.shared.presentation.photo
+
+import com.mapmory.shared.data.local.photo.PhotoMetadataEntity
+
+internal data class PhotoMetadataSyncResult(
+    val photos: List<PhotoMetadataEntity>,
+    val exifReadCount: Int,
+    val reusedCoordinateCount: Int,
+    val previousPhotoCount: Int,
+)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCachePolicy.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCachePolicy.kt
@@ -1,0 +1,10 @@
+package com.mapmory.shared.presentation.photo
+
+internal fun shouldReuseCoordinates(
+    previousModifiedAtSeconds: Long?,
+    previousLatitude: Double?,
+    previousLongitude: Double?,
+    currentModifiedAtSeconds: Long,
+): Boolean = previousModifiedAtSeconds == currentModifiedAtSeconds &&
+    previousLatitude != null &&
+    previousLongitude != null

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCachePolicyTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCachePolicyTest.kt
@@ -1,0 +1,15 @@
+package com.mapmory.shared.presentation.photo
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PhotoMetadataCachePolicyTest {
+    @Test
+    fun reusesCoordinatesOnlyWhenMediaStoreTimestampAndCoordinatesArePresent() {
+        assertTrue(shouldReuseCoordinates(10L, 37.5, 127.0, 10L))
+        assertFalse(shouldReuseCoordinates(11L, 37.5, 127.0, 10L))
+        assertFalse(shouldReuseCoordinates(10L, null, 127.0, 10L))
+        assertFalse(shouldReuseCoordinates(10L, 37.5, null, 10L))
+    }
+}


### PR DESCRIPTION
## 변경 내용
- PhotoMetadataSync를 주입 가능한 Android 동기화 경계로 분리했습니다.
- 동일 사진의 수정 시각이 같으면 EXIF 좌표를 재사용하고, 신규·수정 사진은 다시 읽도록 했습니다.
- Room 스냅샷 삭제와 MediaStore 조회 실패 시 기존 스냅샷 보존을 실제 디바이스 테스트로 검증했습니다.
- commonTest와 Android device test 실행 방법을 문서화했습니다.
- macOS/Linux와 Windows의 Gradle Wrapper 실행 명령 차이(`./gradlew` / `gradlew.bat`)를 문서에 명시했습니다.

## 검증
- macOS/Linux: `./gradlew :shared:jvmTest`
- Windows: `gradlew.bat :shared:jvmTest`
- `:shared:testAndroidHostTest`
- `:shared:androidConnectedCheck`
- `:androidApp:assembleDebug`
- `:shared:compileKotlinIosSimulatorArm64`
- `git diff --check`

## 참고
- 실제 갤러리·Photo Picker UI 자동화와 Macrobenchmark는 이번 범위에서 제외했습니다.
- 작업과 무관한 `.tmp-mapmory-carousel.html`은 변경하지 않았습니다.