### PR TITLE
fix: ios 지오코딩 최적화

### DIFF
--- a/client/androidApp/build.gradle.kts
+++ b/client/androidApp/build.gradle.kts
@@ -20,6 +20,7 @@ android {
         applicationId = "com.mapmory.android"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.compileSdk.get().toInt()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         versionCode = 2
         versionName = "0.1.1"
         resValue(
@@ -50,4 +51,8 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview:${libs.versions.androidxCompose.get()}")
     debugImplementation("androidx.compose.ui:ui-tooling:${libs.versions.androidxCompose.get()}")
     implementation(libs.ktor.client.core)
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:${libs.versions.androidxCompose.get()}")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:${libs.versions.androidxCompose.get()}")
 }

--- a/client/androidApp/src/androidTest/java/com/mapmory/android/PhotoRecommendationFlowTest.kt
+++ b/client/androidApp/src/androidTest/java/com/mapmory/android/PhotoRecommendationFlowTest.kt
@@ -1,0 +1,136 @@
+package com.mapmory.android
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mapmory.shared.domain.model.Location
+import com.mapmory.shared.domain.model.LocationType
+import com.mapmory.shared.presentation.photo.PhotoLibraryActions
+import com.mapmory.shared.presentation.photo.SelectedPhoto
+import com.mapmory.shared.presentation.triprecord.screen.TripRecordEditorScreen
+import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorUiState
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class PhotoRecommendationFlowTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun selectedLocationRecommendationCanBeReviewedAndAdded() {
+        val seoul = province()
+        val gangnam = district(parentId = seoul.id)
+        val recommendedPhoto = SelectedPhoto(
+            id = "gangnam-photo",
+            displayName = "gangnam.jpg",
+            previewBytes = null,
+            latitude = 37.4979,
+            longitude = 127.0276,
+            capturedAt = "2026.08.21",
+        )
+        val laterLoadedPhoto = recommendedPhoto.copy(
+            id = "gangnam-photo-2",
+            displayName = "gangnam-2.jpg",
+        )
+        var requestedLocation: Location? = null
+        var requestedParentName: String? = null
+        var preparedPhotos = emptyList<SelectedPhoto>()
+        var addedPhotos = emptyList<SelectedPhoto>()
+
+        composeRule.setContent {
+            TripRecordEditorScreen(
+                uiState = TripRecordEditorUiState(selectedLocation = gangnam),
+                locations = listOf(seoul, gangnam),
+                onLocationSelected = {},
+                onTitleChanged = {},
+                onContentChanged = {},
+                onStartDateChanged = {},
+                onEndDateChanged = {},
+                onPhotosAdded = { photos -> addedPhotos = photos },
+                onSaveClick = {},
+                onBackClick = {},
+                photoLibraryActionsFactory = { _, onRecommended, _ ->
+                    PhotoLibraryActions(
+                        pickFromGallery = {},
+                        recommendForLocation = { location, parentName ->
+                            requestedLocation = location
+                            requestedParentName = parentName
+                            onRecommended(listOf(recommendedPhoto))
+                            onRecommended(listOf(recommendedPhoto, laterLoadedPhoto))
+                        },
+                        prepareForAdding = { photos, onReady ->
+                            preparedPhotos = photos
+                            onReady(photos)
+                        },
+                    )
+                },
+            )
+        }
+
+        composeRule.onNodeWithText("위치 기반 사진\n불러오기").performClick()
+
+        composeRule.onNodeWithText("이 장소에서 찍은 사진").assertIsDisplayed()
+        composeRule.runOnIdle {
+            assertEquals(gangnam, requestedLocation)
+            assertEquals(seoul.name, requestedParentName)
+        }
+
+        composeRule.onNodeWithText("선택한 사진 추가").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(listOf(recommendedPhoto, laterLoadedPhoto), preparedPhotos)
+            assertEquals(listOf(recommendedPhoto, laterLoadedPhoto), addedPhotos)
+        }
+    }
+
+    @Test
+    fun recommendationWithoutLocationShowsGuidanceWithoutCallingPhotoLibrary() {
+        var recommendationCalls = 0
+
+        composeRule.setContent {
+            TripRecordEditorScreen(
+                uiState = TripRecordEditorUiState(),
+                locations = listOf(province()),
+                onLocationSelected = {},
+                onTitleChanged = {},
+                onContentChanged = {},
+                onStartDateChanged = {},
+                onEndDateChanged = {},
+                onSaveClick = {},
+                onBackClick = {},
+                photoLibraryActionsFactory = { _, _, _ ->
+                    PhotoLibraryActions(
+                        pickFromGallery = {},
+                        recommendForLocation = { _, _ -> recommendationCalls += 1 },
+                    )
+                },
+            )
+        }
+
+        composeRule.onNodeWithText("위치 기반 사진\n불러오기").performClick()
+
+        composeRule.onNodeWithText("사진을 추천받으려면 장소를 먼저 선택해 주세요.")
+            .assertIsDisplayed()
+        composeRule.runOnIdle { assertEquals(0, recommendationCalls) }
+    }
+
+    private fun province() = Location(
+        id = 1L,
+        countryId = 1L,
+        parentId = null,
+        regionCode = "KR-11",
+        name = "서울특별시",
+        type = LocationType.PROVINCE,
+    )
+
+    private fun district(parentId: Long) = Location(
+        id = 2L,
+        countryId = 1L,
+        parentId = parentId,
+        regionCode = "11680",
+        name = "강남구",
+        type = LocationType.DISTRICT,
+    )
+}

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
@@ -9,8 +9,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
 import android.graphics.Matrix
-import android.location.Geocoder
-import android.location.Address
 import android.net.Uri
 import android.os.Build
 import android.os.SystemClock
@@ -185,12 +183,6 @@ private fun requiredRecommendationPermissions(): Array<String> = buildList {
     }
 }.toTypedArray()
 
-private data class GalleryEntry(
-    val photo: PhotoMetadataEntity,
-    val latitude: Double,
-    val longitude: Double,
-)
-
 private data class PhotoMetadataSyncResult(
     val photos: List<PhotoMetadataEntity>,
     val exifReadCount: Int,
@@ -198,7 +190,7 @@ private data class PhotoMetadataSyncResult(
     val previousPhotoCount: Int,
 )
 
-@Suppress("DEPRECATION")
+@Suppress("UNUSED_PARAMETER")
 private suspend fun Context.recommendPhotos(
     target: Location,
     parentName: String?,
@@ -206,79 +198,47 @@ private suspend fun Context.recommendPhotos(
     Trace.beginAsyncSection("photo.recommend.total", TraceCookie.Recommend)
     val totalStartedAt = SystemClock.elapsedRealtime()
     try {
-        val geocoder = Geocoder(this, Locale.KOREA)
-        val geocodeStartedAt = SystemClock.elapsedRealtime()
-        val targetAddress = traceSection("photo.recommend.target_geocode") {
-            geocoder
-                .getFromLocationName(target.recommendationSearchText(parentName), 1)
-                ?.firstOrNull()
-        }
-        val geocodeMillis = SystemClock.elapsedRealtime() - geocodeStartedAt
-        if (targetAddress == null) return emptyList()
-
-        val targetLatitude = targetAddress.latitude
-        val targetLongitude = targetAddress.longitude
-        val radius = target.recommendationRadiusMeters()
+        val boundaryStartedAt = SystemClock.elapsedRealtime()
+        val region = traceSuspendSection(
+            name = "photo.recommend.boundary_load",
+            cookie = TraceCookie.BoundaryLoad,
+        ) {
+            target.photoRecommendationRegion()
+        } ?: return emptyList()
+        val boundaryLoadMillis = SystemClock.elapsedRealtime() - boundaryStartedAt
         val syncStartedAt = SystemClock.elapsedRealtime()
         val syncResult = syncPhotoMetadata()
         val syncMillis = SystemClock.elapsedRealtime() - syncStartedAt
-        val entries = traceSection("photo.recommend.distance_filter") {
-            syncResult.photos.mapNotNull { photo ->
-                val latitude = photo.latitude ?: return@mapNotNull null
-                val longitude = photo.longitude ?: return@mapNotNull null
-                val distance = FloatArray(1)
-                android.location.Location.distanceBetween(
-                    targetLatitude,
-                    targetLongitude,
-                    latitude,
-                    longitude,
-                    distance,
-                )
-                if (distance[0] > radius) return@mapNotNull null
-                GalleryEntry(photo, latitude, longitude)
-            }
-        }
-
-        if (!Geocoder.isPresent()) {
-            error("이 기기에서는 사진 위치의 행정구역을 확인할 수 없어요.")
-        }
-
-        val reverseGeocodeStartedAt = SystemClock.elapsedRealtime()
-        val matchedEntries = traceSection("photo.recommend.reverse_geocode") {
-            entries
+        val regionFilterStartedAt = SystemClock.elapsedRealtime()
+        val matchedPhotos = traceSection("photo.recommend.region_filter") {
+            val candidates = syncResult.photos
                 .asSequence()
-                .sortedByDescending { it.photo.capturedAtMillis ?: 0L }
-                .mapNotNull { entry ->
-                    val matches = runCatching {
-                        geocoder
-                            .getFromLocation(entry.latitude, entry.longitude, 1)
-                            ?.firstOrNull()
-                            ?.toAdministrativeArea()
-                            ?.matches(target, parentName) == true
-                    }.getOrDefault(false)
-                    entry.takeIf { matches }
+                .sortedByDescending { photo -> photo.capturedAtMillis ?: 0L }
+                .mapNotNull { photo ->
+                    val latitude = photo.latitude ?: return@mapNotNull null
+                    val longitude = photo.longitude ?: return@mapNotNull null
+                    LocatedPhoto(photo, latitude, longitude)
                 }
-                .take(MaxRecommendedPhotos)
-                .toList()
+            selectPhotosInRegion(candidates, region)
         }
-        val reverseGeocodeMillis = SystemClock.elapsedRealtime() - reverseGeocodeStartedAt
+        val regionFilterMillis = SystemClock.elapsedRealtime() - regionFilterStartedAt
         val previewStartedAt = SystemClock.elapsedRealtime()
         val result = traceSection("photo.recommend.preview") {
-            matchedEntries.mapNotNull { entry ->
+            matchedPhotos.mapNotNull { photo ->
                 readPhoto(
-                    uri = Uri.parse(entry.photo.contentUri),
-                    knownName = entry.photo.displayName,
-                    knownCoordinates = entry.latitude to entry.longitude,
-                    knownCapturedAtMillis = entry.photo.capturedAtMillis,
+                    uri = Uri.parse(photo.contentUri),
+                    knownName = photo.displayName,
+                    knownCoordinates = requireNotNull(photo.latitude) to requireNotNull(photo.longitude),
+                    knownCapturedAtMillis = photo.capturedAtMillis,
                 )
             }
         }
         val previewMillis = SystemClock.elapsedRealtime() - previewStartedAt
         logPerformance(
             totalMillis = SystemClock.elapsedRealtime() - totalStartedAt,
-            geocodeMillis = geocodeMillis,
+            boundaryLoadMillis = boundaryLoadMillis,
             syncMillis = syncMillis,
-            reverseGeocodeMillis = reverseGeocodeMillis,
+            regionFilterMillis = regionFilterMillis,
             previewMillis = previewMillis,
             syncResult = syncResult,
             recommendedPhotoCount = result.size,
@@ -401,9 +361,9 @@ private suspend inline fun <T> traceSuspendSection(
 
 private fun logPerformance(
     totalMillis: Long,
-    geocodeMillis: Long,
+    boundaryLoadMillis: Long,
     syncMillis: Long,
-    reverseGeocodeMillis: Long,
+    regionFilterMillis: Long,
     previewMillis: Long,
     syncResult: PhotoMetadataSyncResult,
     recommendedPhotoCount: Int,
@@ -412,9 +372,9 @@ private fun logPerformance(
     Log.d(
         PhotoPerformanceTag,
         "recommend_total_ms=$totalMillis " +
-            "target_geocode_ms=$geocodeMillis " +
+            "boundary_load_ms=$boundaryLoadMillis " +
             "metadata_sync_ms=$syncMillis " +
-            "reverse_geocode_ms=$reverseGeocodeMillis " +
+            "region_filter_ms=$regionFilterMillis " +
             "preview_ms=$previewMillis " +
             "previous_photos=${syncResult.previousPhotoCount} " +
             "media_store_photos=${syncResult.photos.size} " +
@@ -438,14 +398,6 @@ private fun logPhotoPickPerformance(
     )
 }
 
-private fun Address.toAdministrativeArea(): PhotoAdministrativeArea = PhotoAdministrativeArea(
-    countryCode = countryCode,
-    administrativeArea = adminArea,
-    subAdministrativeArea = subAdminArea,
-    locality = locality,
-    subLocality = subLocality,
-)
-
 private fun Context.readPhoto(
     uri: Uri,
     knownName: String? = null,
@@ -465,11 +417,11 @@ private fun Context.readPhoto(
     val encodedBytes = traceSection("photo.read.original") {
         contentResolver.openInputStream(uri)?.use { input -> input.readBytes() }
     }?.takeIf(ByteArray::isNotEmpty) ?: return null
-    val originalBytes = traceSection("photo.read.orientation") {
+    val displayOrientedBytes = traceSection("photo.read.orientation") {
         encodedBytes.normalizeOrientation()
     }
     val previewBytes = traceSection("photo.read.preview") {
-        originalBytes.toPreviewByteArray() ?: originalBytes
+        displayOrientedBytes.toPreviewByteArray() ?: displayOrientedBytes
     }
     SelectedPhoto(
         id = uri.toString(),
@@ -478,7 +430,7 @@ private fun Context.readPhoto(
         latitude = coordinates?.first,
         longitude = coordinates?.second,
         capturedAt = formatDate(knownCapturedAtMillis ?: metadata.second),
-        originalBytes = originalBytes,
+        originalBytes = encodedBytes,
     )
 }.getOrNull()
 
@@ -653,10 +605,9 @@ private fun formatDate(epochMillis: Long?): String? = epochMillis?.let {
     SimpleDateFormat("yyyy.MM.dd", Locale.KOREA).format(Date(it))
 }
 
-private const val PreviewSizePx = 960
-private const val PreviewJpegQuality = 84
+private const val PreviewSizePx = 2048
+private const val PreviewJpegQuality = 96
 private const val OriginalJpegQuality = 100
-private const val MaxRecommendedPhotos = 12
 private const val PhotoPerformanceTag = "MapmoryPhotoPerf"
 private const val FullGalleryAccessMessage =
     "위치 기반 사진 추천을 사용하려면 전체 갤러리 접근 권한을 허용해 주세요."
@@ -666,4 +617,5 @@ private object TraceCookie {
     const val RoomRead = 2
     const val RoomWrite = 3
     const val Pick = 4
+    const val BoundaryLoad = 5
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
@@ -2,7 +2,6 @@ package com.mapmory.shared.presentation.photo
 
 import androidx.compose.runtime.Composable
 import com.mapmory.shared.domain.model.Location
-import com.mapmory.shared.domain.model.LocationType
 
 data class SelectedPhoto(
     val id: String,
@@ -17,16 +16,18 @@ data class SelectedPhoto(
 data class PhotoLibraryActions(
     val pickFromGallery: () -> Unit,
     val recommendForLocation: (Location, String?) -> Unit,
+    val prepareForAdding: (
+        photos: List<SelectedPhoto>,
+        onReady: (List<SelectedPhoto>) -> Unit,
+    ) -> Unit = { photos, onReady -> onReady(photos) },
     val recommendationsAvailable: Boolean = true,
 )
 
-internal data class PhotoAdministrativeArea(
-    val countryCode: String?,
-    val administrativeArea: String?,
-    val subAdministrativeArea: String?,
-    val locality: String?,
-    val subLocality: String?,
-)
+typealias PhotoLibraryActionsFactory = @Composable (
+    onPhotosPicked: (List<SelectedPhoto>) -> Unit,
+    onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
+    onMessage: (String) -> Unit,
+) -> PhotoLibraryActions
 
 @Composable
 expect fun rememberPhotoLibraryActions(
@@ -34,82 +35,6 @@ expect fun rememberPhotoLibraryActions(
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
 ): PhotoLibraryActions
-
-internal fun Location.recommendationSearchText(parentName: String?): String = buildString {
-    append(name)
-    if (
-        !parentName.isNullOrBlank() &&
-        parentName != name &&
-        !normalizeAreaName(name).startsWith(normalizeAreaName(parentName))
-    ) {
-        append(" ").append(parentName)
-    }
-    if (countryId == 1L) append(" 대한민국")
-}
-
-internal fun Location.recommendationRadiusMeters(): Double = when {
-    countryId != 1L -> 3_000_000.0
-    type == LocationType.PROVINCE -> 350_000.0
-    else -> 100_000.0
-}
-
-internal fun PhotoAdministrativeArea.matches(
-    target: Location,
-    parentName: String?,
-): Boolean {
-    if (target.countryId != 1L) {
-        return countryCode.equals(target.regionCode, ignoreCase = true)
-    }
-    if (!countryCode.isNullOrBlank() && !countryCode.equals("KR", ignoreCase = true)) return false
-
-    // Geocoder providers do not always put the same administrative level in
-    // the same field. Search all returned address levels instead of relying
-    // on one fixed Android/iOS field mapping.
-    val parentMatches = parentName == null || areaText(
-        administrativeArea,
-        locality,
-        subAdministrativeArea,
-        subLocality,
-    ).contains(normalizeAreaName(parentName))
-    if (!parentMatches) return false
-
-    return when (target.type) {
-        LocationType.PROVINCE -> geocodedArea(target.name)
-        LocationType.DISTRICT -> {
-            val normalizedTarget = normalizeAreaName(target.name)
-            val normalizedParent = parentName?.let(::normalizeAreaName).orEmpty()
-            val districtName = normalizedTarget
-                .removePrefix(normalizedParent)
-                .ifBlank { normalizedTarget }
-            areaNameCandidates(districtName).any { candidate -> geocodedArea(candidate) }
-        }
-    }
-}
-
-private fun PhotoAdministrativeArea.geocodedArea(targetName: String): Boolean = areaText(
-    administrativeArea,
-    subAdministrativeArea,
-    locality,
-    subLocality,
-).contains(normalizeAreaName(targetName))
-
-private fun areaNameCandidates(value: String): Set<String> {
-    val normalized = normalizeAreaName(value)
-    return buildSet {
-        add(normalized)
-        val withoutDistrictSuffix = normalized.removeSuffix("구")
-        if (withoutDistrictSuffix.length >= 2) add(withoutDistrictSuffix)
-    }
-}
-
-private fun areaText(vararg values: String?): String = values
-    .filterNotNull()
-    .joinToString(separator = "")
-    .let(::normalizeAreaName)
-
-private fun normalizeAreaName(value: String): String = value
-    .lowercase()
-    .filter { it.isLetterOrDigit() }
 
 internal fun mergeSelectedPhotos(
     existing: List<SelectedPhoto>,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegion.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegion.kt
@@ -1,0 +1,131 @@
+package com.mapmory.shared.presentation.photo
+
+import com.mapmory.shared.domain.model.Location
+import com.mapmory.shared.domain.model.LocationType
+import com.mapmory.shared.presentation.map.data.GeneratedKoreaDistrictMapData
+import com.mapmory.shared.presentation.map.data.GeneratedKoreaMapData
+import com.mapmory.shared.presentation.map.data.GeneratedWorldMapData
+import com.mapmory.shared.presentation.map.domain.GeoPoint
+
+/**
+ * Administrative boundary used by photo recommendations.
+ *
+ * The bounds are the high-recall pass that replaces the old generous radius around a geocoded
+ * center. Point-in-polygon is the precise pass that replaces one reverse-geocoding request per
+ * candidate photo.
+ */
+internal class PhotoRecommendationRegion(
+    val code: String,
+    rings: List<List<GeoPoint>>,
+) {
+    private val boundedRings = rings.mapNotNull { ring ->
+        boundsOf(ring)?.let { bounds -> BoundedRing(ring, bounds) }
+    }
+
+    fun contains(latitude: Double, longitude: Double): Boolean {
+        if (latitude !in -90.0..90.0 || longitude !in -180.0..180.0) return false
+        val point = GeoPoint(longitude.toFloat(), latitude.toFloat())
+        return boundedRings.any { boundedRing ->
+            boundedRing.bounds.contains(point) && pointInRing(point, boundedRing.points)
+        }
+    }
+}
+
+internal data class LocatedPhoto<T>(
+    val value: T,
+    val latitude: Double,
+    val longitude: Double,
+)
+
+internal fun <T> selectPhotosInRegion(
+    candidatesNewestFirst: Sequence<LocatedPhoto<T>>,
+    region: PhotoRecommendationRegion,
+    limit: Int = MaxRecommendedPhotos,
+): List<T> {
+    if (limit <= 0) return emptyList()
+    return candidatesNewestFirst
+        .filter { candidate -> region.contains(candidate.latitude, candidate.longitude) }
+        .map(LocatedPhoto<T>::value)
+        .take(limit)
+        .toList()
+}
+
+internal suspend fun Location.photoRecommendationRegion(): PhotoRecommendationRegion? {
+    val boundary = when {
+        countryId != KoreaCountryId -> GeneratedWorldMapData.countries
+            .firstOrNull { country -> country.code == regionCode }
+            ?.let { country -> country.code to country.rings }
+
+        type == LocationType.PROVINCE -> GeneratedKoreaMapData.provinces
+            .firstOrNull { province -> province.code == regionCode }
+            ?.let { province -> province.code to province.rings }
+
+        else -> GeneratedKoreaDistrictMapData
+            .forProvince(regionCode.take(KoreanProvinceCodeLength))
+            .firstOrNull { district -> district.code == regionCode }
+            ?.let { district -> district.code to district.rings }
+    } ?: return null
+
+    return PhotoRecommendationRegion(boundary.first, boundary.second)
+}
+
+private data class BoundedRing(
+    val points: List<GeoPoint>,
+    val bounds: GeoBounds,
+)
+
+private data class GeoBounds(
+    val minLongitude: Float,
+    val maxLongitude: Float,
+    val minLatitude: Float,
+    val maxLatitude: Float,
+) {
+    fun contains(point: GeoPoint): Boolean =
+        point.longitude in minLongitude..maxLongitude &&
+            point.latitude in minLatitude..maxLatitude
+}
+
+private fun boundsOf(ring: List<GeoPoint>): GeoBounds? {
+    if (ring.size < MinimumRingPointCount) return null
+    return GeoBounds(
+        minLongitude = ring.minOf(GeoPoint::longitude),
+        maxLongitude = ring.maxOf(GeoPoint::longitude),
+        minLatitude = ring.minOf(GeoPoint::latitude),
+        maxLatitude = ring.maxOf(GeoPoint::latitude),
+    )
+}
+
+private fun pointInRing(point: GeoPoint, ring: List<GeoPoint>): Boolean {
+    if (ring.size < MinimumRingPointCount) return false
+
+    var inside = false
+    var previous = ring.last()
+    ring.forEach { current ->
+        if (pointOnSegment(point, previous, current)) return true
+        val crossesLatitude =
+            (current.latitude > point.latitude) != (previous.latitude > point.latitude)
+        if (crossesLatitude) {
+            val intersectionLongitude =
+                (previous.longitude - current.longitude) *
+                    (point.latitude - current.latitude) /
+                    (previous.latitude - current.latitude) + current.longitude
+            if (point.longitude < intersectionLongitude) inside = !inside
+        }
+        previous = current
+    }
+    return inside
+}
+
+private fun pointOnSegment(point: GeoPoint, start: GeoPoint, end: GeoPoint): Boolean {
+    val cross = (point.latitude - start.latitude) * (end.longitude - start.longitude) -
+        (point.longitude - start.longitude) * (end.latitude - start.latitude)
+    if (kotlin.math.abs(cross) > BoundaryEpsilon) return false
+    return point.longitude in minOf(start.longitude, end.longitude)..maxOf(start.longitude, end.longitude) &&
+        point.latitude in minOf(start.latitude, end.latitude)..maxOf(start.latitude, end.latitude)
+}
+
+internal const val MaxRecommendedPhotos = 12
+private const val KoreaCountryId = 1L
+private const val KoreanProvinceCodeLength = 2
+private const val MinimumRingPointCount = 3
+private const val BoundaryEpsilon = 0.000001f

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDetailScreen.kt
@@ -176,9 +176,12 @@ private fun TripRecordPhotoSection(
             ) { page ->
                 val photo = media[page]
                 TripPhotoImage(
-                    imageBytes = photo.originalBytes?.bytesForDecoding()
-                        ?: photo.previewBytes?.bytesForDecoding(),
-                    fallbackBytes = photo.previewBytes?.bytesForDecoding(),
+                    // Preview bytes are orientation-normalized display data. Original bytes stay
+                    // untouched for persistence/upload and may carry EXIF orientation that the
+                    // common Skia decoder does not apply consistently across platforms.
+                    imageBytes = photo.previewBytes?.bytesForDecoding()
+                        ?: photo.originalBytes?.bytesForDecoding(),
+                    fallbackBytes = photo.originalBytes?.bytesForDecoding(),
                     contentDescription = "${record.title} 사진 ${page + 1}",
                     modifier = Modifier.fillMaxSize(),
                     placeholderVariant = record.id.toInt() + page + 1,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
+import com.mapmory.shared.presentation.photo.PhotoLibraryActionsFactory
 import com.mapmory.shared.presentation.photo.SelectedPhoto
 import com.mapmory.shared.presentation.photo.rememberPhotoLibraryActions
 import com.mapmory.shared.presentation.date.PlatformDatePicker
@@ -104,6 +105,9 @@ fun TripRecordEditorScreen(
     onMapClick: () -> Unit = {},
     onRecordClick: () -> Unit = {},
     onProfileClick: () -> Unit = {},
+    photoLibraryActionsFactory: PhotoLibraryActionsFactory = { onPicked, onRecommended, onMessage ->
+        rememberPhotoLibraryActions(onPicked, onRecommended, onMessage)
+    },
     modifier: Modifier = Modifier,
 ) {
     val selectableLocations = remember(locations) {
@@ -116,17 +120,23 @@ fun TripRecordEditorScreen(
     var photoMessage by remember { mutableStateOf<String?>(null) }
     var recommendedPhotos by remember { mutableStateOf(emptyList<SelectedPhoto>()) }
     var selectedRecommendationIds by remember { mutableStateOf(emptySet<String>()) }
+    var knownRecommendationIds by remember { mutableStateOf(emptySet<String>()) }
     var showRecommendationSheet by remember { mutableStateOf(false) }
+    var isPreparingRecommendationPhotos by remember { mutableStateOf(false) }
     var datePickerTarget by rememberSaveable { mutableStateOf<String?>(null) }
     val dismissKeyboardOnTap = rememberDismissKeyboardOnTapModifier()
-    val photoLibrary = rememberPhotoLibraryActions(
-        onPhotosPicked = { photos ->
+    val photoLibrary = photoLibraryActionsFactory(
+        { photos ->
             photoMessage = null
             onPhotosAdded(photos)
         },
-        onPhotosRecommended = { photos ->
+        { photos ->
+            val incomingIds = photos.map(SelectedPhoto::id).toSet()
+            val newlyLoadedIds = incomingIds - knownRecommendationIds
             recommendedPhotos = photos
-            selectedRecommendationIds = photos.map(SelectedPhoto::id).toSet()
+            selectedRecommendationIds =
+                (selectedRecommendationIds intersect incomingIds) + newlyLoadedIds
+            knownRecommendationIds = incomingIds
             showRecommendationSheet = photos.isNotEmpty()
             photoMessage = if (photos.isEmpty()) {
                 "선택한 지역에서 촬영된 GPS 사진을 찾지 못했어요."
@@ -134,7 +144,7 @@ fun TripRecordEditorScreen(
                 null
             }
         },
-        onMessage = { photoMessage = it },
+        { photoMessage = it },
     )
     val locationResultsListState = rememberLazyListState()
     val filteredLocations = remember(locationSearchQuery, selectableLocations) {
@@ -181,6 +191,10 @@ fun TripRecordEditorScreen(
                                     photoMessage = "사진을 추천받으려면 장소를 먼저 선택해 주세요."
                                 } else {
                                     photoMessage = "${selectedLocation.name}에서 촬영된 사진을 찾고 있어요."
+                                    recommendedPhotos = emptyList()
+                                    selectedRecommendationIds = emptySet()
+                                    knownRecommendationIds = emptySet()
+                                    showRecommendationSheet = false
                                     val parentName = locations
                                         .firstOrNull { it.id == selectedLocation.parentId }
                                         ?.name
@@ -396,16 +410,33 @@ fun TripRecordEditorScreen(
                 }
                 TextButton(
                     onClick = {
-                        onPhotosAdded(
-                            recommendedPhotos.filter { it.id in selectedRecommendationIds },
-                        )
-                        showRecommendationSheet = false
-                        photoMessage = null
+                        val selectedPhotos = recommendedPhotos
+                            .filter { it.id in selectedRecommendationIds }
+                        isPreparingRecommendationPhotos = true
+                        photoLibrary.prepareForAdding(selectedPhotos) { preparedPhotos ->
+                            isPreparingRecommendationPhotos = false
+                            if (preparedPhotos.isEmpty()) {
+                                photoMessage = "선택한 사진의 원본을 읽지 못했어요."
+                            } else {
+                                onPhotosAdded(preparedPhotos)
+                                showRecommendationSheet = false
+                                photoMessage = null
+                            }
+                        }
                     },
-                    enabled = selectedRecommendationIds.isNotEmpty(),
+                    enabled = selectedRecommendationIds.isNotEmpty() &&
+                        !isPreparingRecommendationPhotos,
                     modifier = Modifier.align(Alignment.End),
                 ) {
-                    Text("선택한 사진 추가", color = TripRecordPalette.accent, fontWeight = FontWeight.Bold)
+                    Text(
+                        if (isPreparingRecommendationPhotos) {
+                            "원본 불러오는 중…"
+                        } else {
+                            "선택한 사진 추가"
+                        },
+                        color = TripRecordPalette.accent,
+                        fontWeight = FontWeight.Bold,
+                    )
                 }
                 Spacer(Modifier.height(12.dp))
             }

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryTest.kt
@@ -1,9 +1,11 @@
 package com.mapmory.shared.presentation.photo
 
-import com.mapmory.shared.domain.model.Location
-import com.mapmory.shared.domain.model.LocationType
+import com.mapmory.shared.presentation.map.data.GeneratedKoreaMapData
+import com.mapmory.shared.presentation.map.domain.GeoPoint
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class PhotoLibraryTest {
     @Test
@@ -19,107 +21,90 @@ class PhotoLibraryTest {
     }
 
     @Test
-    fun koreanDistrictSearchIncludesParentAndCountry() {
-        val district = Location(
-            id = 2,
-            countryId = 1,
-            parentId = 1,
-            regionCode = "11680",
-            name = "강남구",
-            type = LocationType.DISTRICT,
+    fun boundaryIncludesInteriorAndEdgeButRejectsOutsideCoordinates() {
+        val region = PhotoRecommendationRegion(
+            code = "test",
+            rings = listOf(square(left = 0f, bottom = 0f, right = 10f, top = 10f)),
         )
 
-        assertEquals("강남구 서울특별시 대한민국", district.recommendationSearchText("서울특별시"))
-        assertEquals(100_000.0, district.recommendationRadiusMeters())
-        assertEquals(
-            true,
-            PhotoAdministrativeArea(
-                countryCode = "KR",
-                administrativeArea = "서울특별시",
-                subAdministrativeArea = null,
-                locality = "서울특별시",
-                subLocality = "강남구",
-            ).matches(district, "서울특별시"),
-        )
-        assertEquals(
-            false,
-            PhotoAdministrativeArea(
-                countryCode = "KR",
-                administrativeArea = "서울특별시",
-                subAdministrativeArea = null,
-                locality = "서울특별시",
-                subLocality = "서초구",
-            ).matches(district, "서울특별시"),
-        )
+        assertTrue(region.contains(latitude = 5.0, longitude = 5.0))
+        assertTrue(region.contains(latitude = 5.0, longitude = 0.0))
+        assertFalse(region.contains(latitude = 5.0, longitude = 10.1))
+        assertFalse(region.contains(latitude = 91.0, longitude = 5.0))
     }
 
     @Test
-    fun fullKoreanDistrictNameMatchesSeparatedGeocoderFields() {
-        val district = Location(
-            id = 3,
-            countryId = 1,
-            parentId = 11,
-            regionCode = "41111",
-            name = "경기도 수원시장안구",
-            type = LocationType.DISTRICT,
-        )
-        val photoArea = PhotoAdministrativeArea(
-            countryCode = "KR",
-            administrativeArea = "경기도",
-            subAdministrativeArea = "수원시",
-            locality = "수원시",
-            subLocality = "장안구",
+    fun boundaryChecksEveryDisconnectedRing() {
+        val region = PhotoRecommendationRegion(
+            code = "islands",
+            rings = listOf(
+                square(left = 0f, bottom = 0f, right = 2f, top = 2f),
+                square(left = 10f, bottom = 10f, right = 12f, top = 12f),
+            ),
         )
 
-        assertEquals(true, photoArea.matches(district, "경기도"))
-        assertEquals("경기도 수원시장안구 대한민국", district.recommendationSearchText("경기도"))
+        assertTrue(region.contains(latitude = 1.0, longitude = 1.0))
+        assertTrue(region.contains(latitude = 11.0, longitude = 11.0))
+        assertFalse(region.contains(latitude = 5.0, longitude = 5.0))
     }
 
     @Test
-    fun koreanDistrictMatchesWhenGeocoderPutsDistrictInAnyAddressField() {
-        val district = Location(
-            id = 4,
-            countryId = 1,
-            parentId = 1,
-            regionCode = "11620",
-            name = "서울특별시 관악구",
-            type = LocationType.DISTRICT,
-        )
+    fun generatedSeoulBoundaryRejectsNearbyGyeonggiPhoto() {
+        val seoul = GeneratedKoreaMapData.provinces.single { it.code == "KR-11" }
+        val region = PhotoRecommendationRegion(seoul.code, seoul.rings)
 
-        assertEquals(
-            true,
-            PhotoAdministrativeArea(
-                countryCode = "KR",
-                administrativeArea = "서울특별시 관악구",
-                subAdministrativeArea = null,
-                locality = null,
-                subLocality = "신림동",
-            ).matches(district, "서울특별시"),
-        )
+        assertTrue(region.contains(latitude = 37.56, longitude = 126.98))
+        assertFalse(region.contains(latitude = 37.40, longitude = 127.20))
     }
 
     @Test
-    fun koreanDistrictAllowsMissingDistrictSuffixInGeocoderResult() {
-        val district = Location(
-            id = 5,
-            countryId = 1,
-            parentId = 1,
-            regionCode = "11680",
-            name = "강남구",
-            type = LocationType.DISTRICT,
+    fun recommendationKeepsNewestInputOrderAndStopsAtTwelveMatches() {
+        val region = PhotoRecommendationRegion(
+            code = "test",
+            rings = listOf(square(left = 0f, bottom = 0f, right = 10f, top = 10f)),
+        )
+        val candidates = sequence {
+            yield(LocatedPhoto("outside-newest", latitude = 20.0, longitude = 20.0))
+            for (index in 1..20) {
+                yield(LocatedPhoto("inside-$index", latitude = 5.0, longitude = 5.0))
+            }
+        }
+
+        val selected = selectPhotosInRegion(candidates, region)
+
+        assertEquals((1..12).map { "inside-$it" }, selected)
+    }
+
+    @Test
+    fun nonPositiveRecommendationLimitReturnsNoPhotos() {
+        val region = PhotoRecommendationRegion(
+            code = "test",
+            rings = listOf(square(left = 0f, bottom = 0f, right = 10f, top = 10f)),
         )
 
         assertEquals(
-            true,
-            PhotoAdministrativeArea(
-                countryCode = "KR",
-                administrativeArea = "서울특별시",
-                subAdministrativeArea = null,
-                locality = null,
-                subLocality = "강남",
-            ).matches(district, "서울특별시"),
+            emptyList(),
+            selectPhotosInRegion(
+                candidatesNewestFirst = sequenceOf(
+                    LocatedPhoto("inside", latitude = 5.0, longitude = 5.0),
+                ),
+                region = region,
+                limit = 0,
+            ),
         )
     }
+
+    private fun square(
+        left: Float,
+        bottom: Float,
+        right: Float,
+        top: Float,
+    ): List<GeoPoint> = listOf(
+        GeoPoint(left, bottom),
+        GeoPoint(right, bottom),
+        GeoPoint(right, top),
+        GeoPoint(left, top),
+    )
 
     private fun photo(id: String) = SelectedPhoto(
         id = id,

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
@@ -4,6 +4,7 @@ package com.mapmory.shared.presentation.photo
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import com.mapmory.shared.domain.model.Location
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.reinterpret
@@ -11,9 +12,7 @@ import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
 import platform.CoreFoundation.CFRelease
 import platform.CoreGraphics.CGImageRelease
-import platform.CoreLocation.CLGeocoder
-import platform.CoreLocation.CLPlacemark
-import platform.CoreLocation.CLLocation
+import platform.CoreGraphics.CGSizeMake
 import platform.Foundation.CFBridgingRetain
 import platform.Foundation.NSData
 import platform.Foundation.NSDate
@@ -29,12 +28,17 @@ import platform.Photos.PHAccessLevelReadWrite
 import platform.Photos.PHAsset
 import platform.Photos.PHAssetMediaTypeImage
 import platform.Photos.PHAssetResource
+import platform.Photos.PHAssetResourceManager
+import platform.Photos.PHAssetResourceRequestOptions
+import platform.Photos.PHAssetResourceTypePhoto
 import platform.Photos.PHAuthorizationStatusAuthorized
 import platform.Photos.PHAuthorizationStatusLimited
 import platform.Photos.PHAuthorizationStatusNotDetermined
 import platform.Photos.PHFetchOptions
 import platform.Photos.PHImageManager
+import platform.Photos.PHImageContentModeAspectFit
 import platform.Photos.PHImageRequestOptions
+import platform.Photos.PHImageRequestOptionsDeliveryModeHighQualityFormat
 import platform.Photos.PHImageRequestOptionsVersionCurrent
 import platform.Photos.PHPhotoLibrary
 import platform.PhotosUI.PHPickerConfiguration
@@ -50,6 +54,11 @@ import platform.UIKit.UIWindow
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 actual fun rememberPhotoLibraryActions(
@@ -57,7 +66,8 @@ actual fun rememberPhotoLibraryActions(
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
 ): PhotoLibraryActions {
-    val controller = remember { IosPhotoLibraryController() }
+    val scope = rememberCoroutineScope()
+    val controller = remember(scope) { IosPhotoLibraryController(scope) }
     controller.onPhotosPicked = onPhotosPicked
     controller.onPhotosRecommended = onPhotosRecommended
     controller.onMessage = onMessage
@@ -66,15 +76,19 @@ actual fun rememberPhotoLibraryActions(
         PhotoLibraryActions(
             pickFromGallery = controller::presentPicker,
             recommendForLocation = controller::recommend,
+            prepareForAdding = controller::prepareForAdding,
         )
     }
 }
 
-private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDelegateProtocol {
+private class IosPhotoLibraryController(
+    private val scope: CoroutineScope,
+) : NSObject(), PHPickerViewControllerDelegateProtocol {
     var onPhotosPicked: (List<SelectedPhoto>) -> Unit = {}
     var onPhotosRecommended: (List<SelectedPhoto>) -> Unit = {}
     var onMessage: (String) -> Unit = {}
-    private var geocoder: CLGeocoder? = null
+    private var recommendationJob: Job? = null
+    private var recommendationGeneration = 0
 
     fun presentPicker() {
         val presenter = topViewController() ?: run {
@@ -113,18 +127,19 @@ private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDele
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun recommend(location: Location, parentName: String?) {
         val status = PHPhotoLibrary.authorizationStatusForAccessLevel(PHAccessLevelReadWrite)
         when (status) {
             PHAuthorizationStatusAuthorized -> {
-                findRecommendations(location, parentName)
+                findRecommendations(location)
             }
             PHAuthorizationStatusLimited -> onMessage(FullGalleryAccessMessage)
             PHAuthorizationStatusNotDetermined -> {
                 PHPhotoLibrary.requestAuthorizationForAccessLevel(PHAccessLevelReadWrite) { newStatus ->
                     onMain {
                         when (newStatus) {
-                            PHAuthorizationStatusAuthorized -> findRecommendations(location, parentName)
+                            PHAuthorizationStatusAuthorized -> findRecommendations(location)
                             PHAuthorizationStatusLimited -> onMessage(FullGalleryAccessMessage)
                             else -> onMessage("장소 기반 추천을 사용하려면 사진 접근을 허용해 주세요.")
                         }
@@ -135,105 +150,63 @@ private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDele
         }
     }
 
-    private fun findRecommendations(location: Location, parentName: String?) {
-        geocoder?.cancelGeocode()
-        geocoder = CLGeocoder().also { activeGeocoder ->
-            activeGeocoder.geocodeAddressString(
-                location.recommendationSearchText(parentName),
-            ) { placemarks, _ ->
-                val targetLocation = (placemarks?.firstOrNull() as? CLPlacemark)?.location
-                if (targetLocation == null) {
-                    onMessage("선택한 장소의 위치를 확인하지 못했어요.")
-                    return@geocodeAddressString
+    private fun findRecommendations(location: Location) {
+        recommendationJob?.cancel()
+        val generation = ++recommendationGeneration
+        recommendationJob = scope.launch {
+            val region = withContext(Dispatchers.Default) {
+                runCatching { location.photoRecommendationRegion() }.getOrNull()
+            }
+            if (region == null) {
+                onMessage("선택한 장소의 경계를 확인하지 못했어요.")
+                return@launch
+            }
+            val matchingAssets = withContext(Dispatchers.Default) {
+                findAssetsInRegion(region)
+            }
+            if (generation != recommendationGeneration) return@launch
+            if (matchingAssets.isEmpty()) {
+                onPhotosRecommended(emptyList())
+            } else {
+                loadAssetPreviews(matchingAssets) { photos ->
+                    if (generation == recommendationGeneration) {
+                        onPhotosRecommended(photos)
+                    }
                 }
-                findNearbyAssets(
-                    targetLocation = targetLocation,
-                    radiusMeters = location.recommendationRadiusMeters(),
-                    target = location,
-                    parentName = parentName,
-                )
             }
         }
     }
 
-    private fun findNearbyAssets(
-        targetLocation: CLLocation,
-        radiusMeters: Double,
-        target: Location,
-        parentName: String?,
-    ) {
+    private fun findAssetsInRegion(region: PhotoRecommendationRegion): List<PHAsset> {
         val options = PHFetchOptions().apply {
             sortDescriptors = listOf(NSSortDescriptor("creationDate", ascending = false))
         }
         val result = PHAsset.fetchAssetsWithMediaType(PHAssetMediaTypeImage, options)
-        val candidates = buildList {
+        return buildList {
             for (index in 0 until result.count.toInt()) {
                 val asset = result.objectAtIndex(index.toULong()) as? PHAsset ?: continue
-                val assetLocation = asset.location ?: continue
-                val distance = assetLocation.distanceFromLocation(targetLocation)
-                if (distance <= radiusMeters) add(asset)
+                val coordinate = asset.location?.coordinate ?: continue
+                val matches = coordinate.useContents {
+                    region.contains(latitude = latitude, longitude = longitude)
+                }
+                if (matches) add(asset)
+                if (size >= MaxRecommendedPhotos) break
             }
-        }
-
-        if (candidates.isEmpty()) {
-            onPhotosRecommended(emptyList())
-            return
-        }
-        filterAssetsBySelectedRegion(
-            assets = candidates,
-            target = target,
-            parentName = parentName,
-        ) { matchingAssets ->
-            if (matchingAssets.isEmpty()) {
-                onPhotosRecommended(emptyList())
-            } else {
-                loadAssets(matchingAssets, onPhotosRecommended)
-            }
-        }
-    }
-
-    private fun filterAssetsBySelectedRegion(
-        assets: List<PHAsset>,
-        target: Location,
-        parentName: String?,
-        index: Int = 0,
-        matches: List<PHAsset> = emptyList(),
-        completion: (List<PHAsset>) -> Unit,
-    ) {
-        if (index >= assets.size || matches.size >= MaxRecommendedPhotos) {
-            completion(matches.take(MaxRecommendedPhotos))
-            return
-        }
-        val asset = assets[index]
-        val assetLocation = asset.location
-        if (assetLocation == null) {
-            filterAssetsBySelectedRegion(assets, target, parentName, index + 1, matches, completion)
-            return
-        }
-        val activeGeocoder = geocoder ?: CLGeocoder().also { geocoder = it }
-        activeGeocoder.reverseGeocodeLocation(assetLocation) { placemarks, _ ->
-            val administrativeArea = (placemarks?.firstOrNull() as? CLPlacemark)
-                ?.toAdministrativeArea()
-            val nextMatches = if (administrativeArea?.matches(target, parentName) == true) {
-                matches + asset
-            } else {
-                matches
-            }
-            filterAssetsBySelectedRegion(
-                assets = assets,
-                target = target,
-                parentName = parentName,
-                index = index + 1,
-                matches = nextMatches,
-                completion = completion,
-            )
         }
     }
 
     private fun loadPickerResult(result: PHPickerResult, completion: (SelectedPhoto?) -> Unit) {
         val asset = result.assetIdentifier?.let(::assetForIdentifier)
         if (asset != null) {
-            loadAsset(asset, completion)
+            loadAssetPreview(asset) { preview ->
+                if (preview == null) {
+                    completion(null)
+                } else {
+                    prepareForAdding(listOf(preview)) { prepared ->
+                        completion(prepared.firstOrNull())
+                    }
+                }
+            }
             return
         }
         result.itemProvider.loadDataRepresentationForTypeIdentifier("public.image") { data, _ ->
@@ -241,13 +214,14 @@ private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDele
                 onMain { completion(null) }
                 return@loadDataRepresentationForTypeIdentifier
             }
+            val originalBytes = data.toByteArray()
+            val previewBytes = data.toPreviewByteArray() ?: originalBytes
             onMain {
-                val originalBytes = data.toByteArray()
                 completion(
                     SelectedPhoto(
                         id = result.assetIdentifier ?: "ios-${data.hash}",
                         displayName = result.itemProvider.suggestedName ?: "여행 사진",
-                        previewBytes = data.toPreviewByteArray() ?: originalBytes,
+                        previewBytes = previewBytes,
                         originalBytes = originalBytes,
                     ),
                 )
@@ -255,44 +229,48 @@ private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDele
         }
     }
 
-    private fun loadAssets(assets: List<PHAsset>, completion: (List<SelectedPhoto>) -> Unit) {
+    private fun loadAssetPreviews(
+        assets: List<PHAsset>,
+        completion: (List<SelectedPhoto>) -> Unit,
+    ) {
         val loaded = MutableList<SelectedPhoto?>(assets.size) { null }
         var remaining = assets.size
         assets.forEachIndexed { index, asset ->
-            loadAsset(asset) { photo ->
+            loadAssetPreview(asset) { photo ->
                 loaded[index] = photo
                 remaining -= 1
-                if (remaining == 0) completion(loaded.filterNotNull())
+                val available = loaded.filterNotNull()
+                if (available.isNotEmpty() || remaining == 0) {
+                    completion(available)
+                }
             }
         }
     }
 
-    private fun loadAsset(asset: PHAsset, completion: (SelectedPhoto?) -> Unit) {
+    private fun loadAssetPreview(asset: PHAsset, completion: (SelectedPhoto?) -> Unit) {
         val options = PHImageRequestOptions().apply {
             version = PHImageRequestOptionsVersionCurrent
+            deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat
             networkAccessAllowed = true
         }
         var didComplete = false
-        PHImageManager.defaultManager().requestImageDataAndOrientationForAsset(
+        PHImageManager.defaultManager().requestImageForAsset(
             asset = asset,
+            targetSize = CGSizeMake(PreviewSizePx.toDouble(), PreviewSizePx.toDouble()),
+            contentMode = PHImageContentModeAspectFit,
             options = options,
-        ) { data, _, _, _ ->
+        ) { image, _ ->
             val coordinate = asset.location?.coordinate
             val latitude = coordinate?.useContents { latitude }
             val longitude = coordinate?.useContents { longitude }
-            val previewBytes = data
-                ?.takeIf { it.length > 0UL }
-                ?.toPreviewByteArray()
-            val originalBytes = data
-                ?.takeIf { it.length > 0UL }
+            val previewBytes = image
+                ?.let { UIImageJPEGRepresentation(it, PreviewJpegQuality) }
                 ?.toByteArray()
             onMain {
-                // requestImageDataAndOrientationForAsset invokes its result handler once.
-                // Keep completion serialized on the main queue with the other photo paths.
                 if (didComplete) return@onMain
                 didComplete = true
                 completion(
-                    data?.takeIf { it.length > 0UL }?.let {
+                    previewBytes?.let {
                         SelectedPhoto(
                             id = asset.localIdentifier,
                             displayName = asset.displayName(),
@@ -300,12 +278,75 @@ private class IosPhotoLibraryController : NSObject(), PHPickerViewControllerDele
                             latitude = latitude,
                             longitude = longitude,
                             capturedAt = asset.creationDate?.formattedPhotoDate(),
-                            originalBytes = originalBytes,
                         )
                     },
                 )
             }
         }
+    }
+
+    fun prepareForAdding(
+        photos: List<SelectedPhoto>,
+        completion: (List<SelectedPhoto>) -> Unit,
+    ) {
+        if (photos.isEmpty()) {
+            completion(emptyList())
+            return
+        }
+
+        val prepared = MutableList<SelectedPhoto?>(photos.size) { null }
+        var remaining = photos.size
+        fun completeOne(index: Int, photo: SelectedPhoto?) {
+            prepared[index] = photo
+            remaining -= 1
+            if (remaining == 0) {
+                val result = prepared.filterNotNull()
+                completion(result)
+                if (result.size != photos.size) {
+                    onMessage("일부 사진의 원본을 읽지 못했어요.")
+                }
+            }
+        }
+
+        photos.forEachIndexed { index, photo ->
+            if (photo.originalBytes != null) {
+                completeOne(index, photo)
+                return@forEachIndexed
+            }
+            val asset = assetForIdentifier(photo.id)
+            if (asset == null) {
+                completeOne(index, null)
+                return@forEachIndexed
+            }
+            loadOriginalBytes(asset) { bytes ->
+                completeOne(index, bytes?.let { photo.copy(originalBytes = it) })
+            }
+        }
+    }
+
+    private fun loadOriginalBytes(asset: PHAsset, completion: (ByteArray?) -> Unit) {
+        val resources = PHAssetResource.assetResourcesForAsset(asset)
+            .filterIsInstance<PHAssetResource>()
+        val resource = resources.firstOrNull { it.type == PHAssetResourceTypePhoto }
+            ?: resources.firstOrNull()
+        if (resource == null) {
+            completion(null)
+            return
+        }
+
+        val chunks = mutableListOf<ByteArray>()
+        val options = PHAssetResourceRequestOptions().apply {
+            networkAccessAllowed = true
+        }
+        PHAssetResourceManager.defaultManager().requestDataForAssetResource(
+            resource,
+            options,
+            dataReceivedHandler = { data -> data?.let { chunks += it.toByteArray() } },
+            completionHandler = { error ->
+                val bytes = if (error == null) chunks.joinToByteArray() else null
+                onMain { completion(bytes) }
+            },
+        )
     }
 
     private fun assetForIdentifier(identifier: String): PHAsset? =
@@ -317,14 +358,6 @@ private fun PHAsset.displayName(): String =
         ?.originalFilename
         ?: "여행 사진"
 
-private fun CLPlacemark.toAdministrativeArea(): PhotoAdministrativeArea = PhotoAdministrativeArea(
-    countryCode = ISOcountryCode,
-    administrativeArea = administrativeArea,
-    subAdministrativeArea = subAdministrativeArea,
-    locality = locality,
-    subLocality = subLocality,
-)
-
 private fun NSDate.formattedPhotoDate(): String = NSDateFormatter().run {
     dateFormat = "yyyy.MM.dd"
     stringFromDate(this@formattedPhotoDate)
@@ -335,6 +368,16 @@ private fun NSData.toByteArray(): ByteArray {
     return ByteArray(length.toInt()).also { bytes ->
         bytes.usePinned { pinned -> getBytes(pinned.addressOf(0), length) }
     }
+}
+
+private fun List<ByteArray>.joinToByteArray(): ByteArray {
+    val result = ByteArray(sumOf(ByteArray::size))
+    var offset = 0
+    forEach { chunk ->
+        chunk.copyInto(result, destinationOffset = offset)
+        offset += chunk.size
+    }
+    return result
 }
 
 private fun NSData.toPreviewByteArray(): ByteArray? {
@@ -385,8 +428,7 @@ private fun onMain(block: () -> Unit) {
     dispatch_async(dispatch_get_main_queue(), block)
 }
 
-private const val MaxRecommendedPhotos = 12
-private const val PreviewSizePx = 960
-private const val PreviewJpegQuality = 0.84
+private const val PreviewSizePx = 2048
+private const val PreviewJpegQuality = 0.96
 private const val FullGalleryAccessMessage =
     "위치 기반 사진 추천을 사용하려면 전체 갤러리 접근 권한을 허용해 주세요."


### PR DESCRIPTION
### 구현한 기능

1. 역지오코딩 제한 문제 해결
기존에는 사진마다 역지오코딩을 요청해 iOS의 50회/60초 제한에 걸렸습니다.
변경 후에는 앱에 포함된 행정구역 경계 데이터를 사용합니다.
- 행정구역 bounding box로 빠르게 후보 확인
- point-in-polygon으로 실제 행정구역 포함 여부 판정
- Android/iOS 모두 사진별 역지오코딩 제거
- 최신 사진순으로 최대 12장 추천
- 국내 시·도/구·군 및 해외 국가 경계 지원
기존의 “넓게 후보를 찾고 정확하게 걸러낸다”는 설계 의도는 유지했습니다.


2. iOS 사진 로딩 속도 개선
기존에는 추천 사진의 원본을 모두 읽고 미리보기를 생성한 후 결과를 표시했습니다.
변경 후에는:
- 2K 표시용 이미지를 먼저 요청
- 준비된 사진부터 점진적으로 추천 화면에 표시
- 사진 전체 원본 로딩을 기다리지 않음
- 이전 추천 요청의 늦은 콜백이 새 검색 결과를 덮어쓰지 않도록 차단
- 행정구역 경계 로딩과 사진 좌표 검색을 백그라운드에서 수행

3. 원본 화질 보존
표시용 이미지와 원본 파일의 역할을 분리했습니다.
- 표시용: 방향이 보정된 2K 이미지
- 저장·업로드용: 수정하지 않은 원본 파일 바이트
- 원본에 JPEG 재압축, 리사이징, 회전 보정을 적용하지 않음
- Android도 동일하게 원본 바이트를 그대로 보존
추천 단계에서는 미리보기만 읽고, 사용자가 선택한 사진 추가를 누를 때 선택한 사진의 원본만 불러옵니다.


4. 사진 회전 문제 해결
공통 이미지 디코더가 원본의 EXIF 방향을 일관되게 적용하지 못해 사진이 회전되어 표시되는 문제가 있었습니다.
- 화면에는 PhotoKit/플랫폼에서 방향이 보정된 표시용 이미지를 사용
- EXIF가 포함된 원본은 수정하지 않고 별도로 보존
- 상세 화면도 방향 보정된 표시 데이터를 우선 사용

5. Android 메타데이터 동기화 통합
develop의 변경과 충돌을 해결하면서 다음 구조를 유지했습니다.
- PhotoMetadataSync로 MediaStore와 Room 메타데이터 동기화
- 수정되지 않은 사진은 기존 GPS 좌표 재사용
- 변경된 사진만 EXIF 좌표 재조회
- 동기화 결과를 행정구역 경계 필터에 전달

6. 테스트 추가
플랫폼 의존성이 없는 공통 단위 테스트:
- 경계 내부·외부·경계선 좌표 판정
- 여러 섬처럼 분리된 경계 판정
- 실제 서울 경계 데이터 검증
- 최신순 유지
- 최대 12장 제한
- 잘못된 좌표와 제한값 처리

Android instrumented 테스트:
- 위치 선택 → 사진 추천 → 점진적 결과 표시 → 원본 준비 → 사진 추가
- 위치 미선택 시 안내 메시지 표시
- 사진 라이브러리가 불필요하게 호출되지 않는지 검증