### PR TITLE
feat(tag): 사용자 태그 CRUD와 V15 스키마

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/tag/Tag.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/Tag.java
@@ -1,0 +1,135 @@
+package com.mapmory.backend.tag;
+
+import com.mapmory.backend.common.entity.BaseEntity;
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.text.Normalizer;
+import java.util.Locale;
+
+@Entity
+@Table(
+        name = "tag",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_tag_member_name_key",
+                columnNames = {"member_id", "name_key"}
+        )
+)
+public class Tag extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "name_key", nullable = false, length = 30)
+    private String nameKey;
+
+    protected Tag() {
+    }
+
+    private Tag(Member member, TagName tagName) {
+        this.member = member;
+        applyName(tagName);
+    }
+
+    public static Tag of(Member member, String rawName) {
+        return new Tag(member, TagName.from(rawName));
+    }
+
+    public void rename(String rawName) {
+        applyName(TagName.from(rawName));
+    }
+
+    static String nameKeyOf(String rawName) {
+        return TagName.from(rawName).nameKey();
+    }
+
+    private void applyName(TagName tagName) {
+        this.name = tagName.displayName();
+        this.nameKey = tagName.nameKey();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    String getNameKey() {
+        return nameKey;
+    }
+
+    private record TagName(String displayName, String nameKey) {
+        private static final int MAX_LENGTH = 30;
+        private static final String FORBIDDEN_CHARACTERS = "#";
+
+        private static TagName from(String rawName) {
+            validateNotNull(rawName);
+
+            String withoutOuterWhitespace = rawName.strip();
+            String withSingleSpaces = collapseConsecutiveWhitespace(withoutOuterWhitespace);
+            String displayName = normalizeUnicode(withSingleSpaces);
+
+            validateLength(displayName);
+            validateForbiddenCharacters(displayName);
+
+            String nameKey = createNameKey(displayName);
+            return new TagName(displayName, nameKey);
+        }
+
+        private static void validateNotNull(String rawName) {
+            if (rawName == null) {
+                throwInvalidTagName();
+            }
+        }
+
+        private static String collapseConsecutiveWhitespace(String name) {
+            return name.replaceAll("\\p{javaWhitespace}+", " ");
+        }
+
+        private static String normalizeUnicode(String name) {
+            return Normalizer.normalize(name, Normalizer.Form.NFC);
+        }
+
+        private static void validateLength(String name) {
+            int length = name.codePointCount(0, name.length());
+            if (length < 1 || length > MAX_LENGTH) {
+                throwInvalidTagName();
+            }
+        }
+
+        private static void validateForbiddenCharacters(String name) {
+            boolean containsForbiddenCharacter = name.codePoints()
+                    .anyMatch(codePoint -> FORBIDDEN_CHARACTERS.indexOf(codePoint) >= 0);
+            boolean containsControlCharacter = name.codePoints().anyMatch(Character::isISOControl);
+            if (containsForbiddenCharacter || containsControlCharacter) {
+                throwInvalidTagName();
+            }
+        }
+
+        private static String createNameKey(String displayName) {
+            return displayName.toLowerCase(Locale.ROOT);
+        }
+
+        private static void throwInvalidTagName() {
+            throw new BusinessException(TagErrorCode.INVALID_TAG_NAME);
+        }
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/tag/Tag.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/Tag.java
@@ -1,9 +1,8 @@
 package com.mapmory.backend.tag;
 
 import com.mapmory.backend.common.entity.BaseEntity;
-import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
-import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -13,8 +12,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.text.Normalizer;
-import java.util.Locale;
 
 @Entity
 @Table(
@@ -33,18 +30,15 @@ public class Tag extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(nullable = false, length = 30)
-    private String name;
-
-    @Column(name = "name_key", nullable = false, length = 30)
-    private String nameKey;
+    @Embedded
+    private TagName tagName;
 
     protected Tag() {
     }
 
     private Tag(Member member, TagName tagName) {
         this.member = member;
-        applyName(tagName);
+        this.tagName = tagName;
     }
 
     public static Tag of(Member member, String rawName) {
@@ -52,16 +46,11 @@ public class Tag extends BaseEntity {
     }
 
     public void rename(String rawName) {
-        applyName(TagName.from(rawName));
+        this.tagName = TagName.from(rawName);
     }
 
     static String nameKeyOf(String rawName) {
         return TagName.from(rawName).nameKey();
-    }
-
-    private void applyName(TagName tagName) {
-        this.name = tagName.displayName();
-        this.nameKey = tagName.nameKey();
     }
 
     public Long getId() {
@@ -69,67 +58,10 @@ public class Tag extends BaseEntity {
     }
 
     public String getName() {
-        return name;
+        return tagName.displayName();
     }
 
     String getNameKey() {
-        return nameKey;
-    }
-
-    private record TagName(String displayName, String nameKey) {
-        private static final int MAX_LENGTH = 30;
-        private static final String FORBIDDEN_CHARACTERS = "#";
-
-        private static TagName from(String rawName) {
-            validateNotNull(rawName);
-
-            String withoutOuterWhitespace = rawName.strip();
-            String withSingleSpaces = collapseConsecutiveWhitespace(withoutOuterWhitespace);
-            String displayName = normalizeUnicode(withSingleSpaces);
-
-            validateLength(displayName);
-            validateForbiddenCharacters(displayName);
-
-            String nameKey = createNameKey(displayName);
-            return new TagName(displayName, nameKey);
-        }
-
-        private static void validateNotNull(String rawName) {
-            if (rawName == null) {
-                throwInvalidTagName();
-            }
-        }
-
-        private static String collapseConsecutiveWhitespace(String name) {
-            return name.replaceAll("\\p{javaWhitespace}+", " ");
-        }
-
-        private static String normalizeUnicode(String name) {
-            return Normalizer.normalize(name, Normalizer.Form.NFC);
-        }
-
-        private static void validateLength(String name) {
-            int length = name.codePointCount(0, name.length());
-            if (length < 1 || length > MAX_LENGTH) {
-                throwInvalidTagName();
-            }
-        }
-
-        private static void validateForbiddenCharacters(String name) {
-            boolean containsForbiddenCharacter = name.codePoints()
-                    .anyMatch(codePoint -> FORBIDDEN_CHARACTERS.indexOf(codePoint) >= 0);
-            boolean containsControlCharacter = name.codePoints().anyMatch(Character::isISOControl);
-            if (containsForbiddenCharacter || containsControlCharacter) {
-                throwInvalidTagName();
-            }
-        }
-
-        private static String createNameKey(String displayName) {
-            return displayName.toLowerCase(Locale.ROOT);
-        }
-
-        private static void throwInvalidTagName() {
-            throw new BusinessException(TagErrorCode.INVALID_TAG_NAME);
-        }
+        return tagName.nameKey();
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/tag/TagController.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagController.java
@@ -1,0 +1,65 @@
+package com.mapmory.backend.tag;
+
+import com.mapmory.backend.auth.security.LoginMember;
+import com.mapmory.backend.common.dto.ApiResponse;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.tag.dto.TagRequest;
+import com.mapmory.backend.tag.dto.TagResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/tags")
+public class TagController {
+    private final TagService tagService;
+
+    public TagController(TagService tagService) {
+        this.tagService = tagService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<TagResponse>> create(
+            @LoginMember Member member,
+            @Valid @RequestBody TagRequest request
+    ) {
+        TagResponse response = tagService.create(member, request);
+        return ResponseEntity.created(URI.create("/api/v1/tags/" + response.id()))
+                .body(ApiResponse.from(response));
+    }
+
+    @GetMapping
+    public ApiResponse<List<TagResponse>> findAll(@LoginMember Member member) {
+        return ApiResponse.from(tagService.findAll(member));
+    }
+
+    @PatchMapping("/{tagId}")
+    public ApiResponse<TagResponse> update(
+            @LoginMember Member member,
+            @PathVariable @Positive Long tagId,
+            @Valid @RequestBody TagRequest request
+    ) {
+        return ApiResponse.from(tagService.update(member, tagId, request));
+    }
+
+    @DeleteMapping("/{tagId}")
+    public ResponseEntity<Void> delete(
+            @LoginMember Member member,
+            @PathVariable @Positive Long tagId
+    ) {
+        tagService.delete(member, tagId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/tag/TagErrorCode.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagErrorCode.java
@@ -1,0 +1,51 @@
+package com.mapmory.backend.tag;
+
+import com.mapmory.backend.common.exception.ErrorCode;
+import com.mapmory.backend.common.exception.ErrorKind;
+
+public enum TagErrorCode implements ErrorCode {
+    INVALID_TAG_NAME(ErrorKind.INVALID_INPUT, "VALIDATION_ERROR", "요청 값이 올바르지 않습니다.",
+            "태그 이름은 #과 제어 문자를 제외한 1자 이상 30자 이하여야 합니다."),
+    TAG_NOT_FOUND(ErrorKind.NOT_FOUND, "TAG_NOT_FOUND", "태그를 찾을 수 없습니다.",
+            "요청한 태그가 없거나 접근할 권한이 없습니다."),
+    TAG_NAME_CONFLICT(ErrorKind.CONFLICT, "TAG_NAME_CONFLICT", "같은 이름의 태그가 있습니다.",
+            "현재 회원에게 같은 이름의 태그가 이미 있습니다."),
+    TAG_LIMIT_EXCEEDED(ErrorKind.CONFLICT, "TAG_LIMIT_EXCEEDED", "태그 개수 제한을 초과했습니다.",
+            "회원은 현재 최대 10개의 태그를 만들 수 있습니다."),
+    TOO_MANY_TAGS(ErrorKind.INVALID_INPUT, "TOO_MANY_TAGS", "여행 일지의 태그 개수 제한을 초과했습니다.",
+            "여행 일지에는 현재 최대 5개의 태그를 연결할 수 있습니다."),
+    INVALID_TAG_IDS(ErrorKind.INVALID_INPUT, "VALIDATION_ERROR", "요청 값이 올바르지 않습니다.",
+            "태그 ID는 중복될 수 없습니다.");
+
+    private final ErrorKind kind;
+    private final String code;
+    private final String title;
+    private final String detail;
+
+    TagErrorCode(ErrorKind kind, String code, String title, String detail) {
+        this.kind = kind;
+        this.code = code;
+        this.title = title;
+        this.detail = detail;
+    }
+
+    @Override
+    public ErrorKind kind() {
+        return kind;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String title() {
+        return title;
+    }
+
+    @Override
+    public String detail() {
+        return detail;
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/tag/TagName.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagName.java
@@ -1,0 +1,89 @@
+package com.mapmory.backend.tag;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.text.Normalizer;
+import java.util.Locale;
+
+@Embeddable
+record TagName(
+        @Column(name = "name", nullable = false, length = 30)
+        String displayName,
+
+        @Column(name = "name_key", nullable = false, length = 30)
+        String nameKey
+) {
+    private static final int MAX_LENGTH = 30;
+    private static final String FORBIDDEN_CHARACTERS = "#";
+
+    TagName {
+        validatePersistedState(displayName, nameKey);
+    }
+
+    static TagName from(String rawName) {
+        validateNotNull(rawName);
+
+        String displayName = normalizeDisplayName(rawName);
+        validateLength(displayName);
+        validateForbiddenCharacters(displayName);
+
+        return new TagName(displayName, createNameKey(displayName));
+    }
+
+    private static void validatePersistedState(String displayName, String nameKey) {
+        validateNotNull(displayName);
+        validateLength(displayName);
+        validateForbiddenCharacters(displayName);
+
+        boolean isNormalizedDisplayName = displayName.equals(normalizeDisplayName(displayName));
+        boolean hasMatchingNameKey = createNameKey(displayName).equals(nameKey);
+        if (!isNormalizedDisplayName || !hasMatchingNameKey) {
+            throwInvalidTagName();
+        }
+    }
+
+    private static String normalizeDisplayName(String rawName) {
+        String withoutOuterWhitespace = rawName.strip();
+        String withSingleSpaces = collapseConsecutiveWhitespace(withoutOuterWhitespace);
+        return normalizeUnicode(withSingleSpaces);
+    }
+
+    private static void validateNotNull(String rawName) {
+        if (rawName == null) {
+            throwInvalidTagName();
+        }
+    }
+
+    private static String collapseConsecutiveWhitespace(String name) {
+        return name.replaceAll("\\p{javaWhitespace}+", " ");
+    }
+
+    private static String normalizeUnicode(String name) {
+        return Normalizer.normalize(name, Normalizer.Form.NFC);
+    }
+
+    private static void validateLength(String name) {
+        int length = name.codePointCount(0, name.length());
+        if (length < 1 || length > MAX_LENGTH) {
+            throwInvalidTagName();
+        }
+    }
+
+    private static void validateForbiddenCharacters(String name) {
+        boolean containsForbiddenCharacter = name.codePoints()
+                .anyMatch(codePoint -> FORBIDDEN_CHARACTERS.indexOf(codePoint) >= 0);
+        boolean containsControlCharacter = name.codePoints().anyMatch(Character::isISOControl);
+        if (containsForbiddenCharacter || containsControlCharacter) {
+            throwInvalidTagName();
+        }
+    }
+
+    private static String createNameKey(String displayName) {
+        return displayName.toLowerCase(Locale.ROOT);
+    }
+
+    private static void throwInvalidTagName() {
+        throw new BusinessException(TagErrorCode.INVALID_TAG_NAME);
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/tag/TagName.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagName.java
@@ -11,10 +11,11 @@ record TagName(
         @Column(name = "name", nullable = false, length = 30)
         String displayName,
 
-        @Column(name = "name_key", nullable = false, length = 30)
+        @Column(name = "name_key", nullable = false, length = 60)
         String nameKey
 ) {
-    private static final int MAX_LENGTH = 30;
+    private static final int MAX_DISPLAY_NAME_LENGTH = 30;
+    private static final int MAX_NAME_KEY_LENGTH = 60;
     private static final String FORBIDDEN_CHARACTERS = "#";
 
     TagName {
@@ -25,20 +26,30 @@ record TagName(
         validateNotNull(rawName);
 
         String displayName = normalizeDisplayName(rawName);
-        validateLength(displayName);
-        validateForbiddenCharacters(displayName);
-
         return new TagName(displayName, createNameKey(displayName));
     }
 
     private static void validatePersistedState(String displayName, String nameKey) {
-        validateNotNull(displayName);
-        validateLength(displayName);
-        validateForbiddenCharacters(displayName);
+        validateDisplayName(displayName);
+        validateNameKey(displayName, nameKey);
+    }
 
+    private static void validateDisplayName(String displayName) {
+        validateNotNull(displayName);
+        validateDisplayNameLength(displayName);
+        validateForbiddenCharacters(displayName);
         boolean isNormalizedDisplayName = displayName.equals(normalizeDisplayName(displayName));
+        if (!isNormalizedDisplayName) {
+            throwInvalidTagName();
+        }
+    }
+
+    private static void validateNameKey(String displayName, String nameKey) {
+        validateNotNull(nameKey);
+        validateNameKeyLength(nameKey);
+
         boolean hasMatchingNameKey = createNameKey(displayName).equals(nameKey);
-        if (!isNormalizedDisplayName || !hasMatchingNameKey) {
+        if (!hasMatchingNameKey) {
             throwInvalidTagName();
         }
     }
@@ -63,9 +74,16 @@ record TagName(
         return Normalizer.normalize(name, Normalizer.Form.NFC);
     }
 
-    private static void validateLength(String name) {
+    private static void validateDisplayNameLength(String name) {
         int length = name.codePointCount(0, name.length());
-        if (length < 1 || length > MAX_LENGTH) {
+        if (length < 1 || length > MAX_DISPLAY_NAME_LENGTH) {
+            throwInvalidTagName();
+        }
+    }
+
+    private static void validateNameKeyLength(String nameKey) {
+        int length = nameKey.codePointCount(0, nameKey.length());
+        if (length > MAX_NAME_KEY_LENGTH) {
             throwInvalidTagName();
         }
     }

--- a/backend/src/main/java/com/mapmory/backend/tag/TagRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagRepository.java
@@ -1,0 +1,20 @@
+package com.mapmory.backend.tag;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    long countByMemberId(Long memberId);
+
+    boolean existsByMemberIdAndNameKey(Long memberId, String nameKey);
+
+    boolean existsByMemberIdAndNameKeyAndIdNot(Long memberId, String nameKey, Long id);
+
+    Optional<Tag> findByIdAndMemberId(Long id, Long memberId);
+
+    List<Tag> findAllByMemberIdOrderByCreatedAtAscIdAsc(Long memberId);
+
+    List<Tag> findAllByMemberIdAndIdIn(Long memberId, Collection<Long> ids);
+}

--- a/backend/src/main/java/com/mapmory/backend/tag/TagRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagRepository.java
@@ -4,13 +4,35 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     long countByMemberId(Long memberId);
 
-    boolean existsByMemberIdAndNameKey(Long memberId, String nameKey);
+    @Query("""
+            SELECT CASE WHEN COUNT(t) > 0 THEN TRUE ELSE FALSE END
+            FROM Tag t
+            WHERE t.member.id = :memberId
+              AND t.tagName.nameKey = :nameKey
+            """)
+    boolean existsByMemberIdAndNameKey(
+            @Param("memberId") Long memberId,
+            @Param("nameKey") String nameKey
+    );
 
-    boolean existsByMemberIdAndNameKeyAndIdNot(Long memberId, String nameKey, Long id);
+    @Query("""
+            SELECT CASE WHEN COUNT(t) > 0 THEN TRUE ELSE FALSE END
+            FROM Tag t
+            WHERE t.member.id = :memberId
+              AND t.tagName.nameKey = :nameKey
+              AND t.id <> :id
+            """)
+    boolean existsByMemberIdAndNameKeyAndIdNot(
+            @Param("memberId") Long memberId,
+            @Param("nameKey") String nameKey,
+            @Param("id") Long id
+    );
 
     Optional<Tag> findByIdAndMemberId(Long id, Long memberId);
 

--- a/backend/src/main/java/com/mapmory/backend/tag/TagService.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagService.java
@@ -1,0 +1,102 @@
+package com.mapmory.backend.tag;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.tag.dto.TagRequest;
+import com.mapmory.backend.tag.dto.TagResponse;
+import java.util.List;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TagService {
+    private static final int MAX_TAGS_PER_MEMBER = 10;
+    private final TagRepository tagRepository;
+
+    public TagService(TagRepository tagRepository) {
+        this.tagRepository = tagRepository;
+    }
+
+    @Transactional
+    public TagResponse create(Member member, TagRequest request) {
+        validateTagLimit(member.getId());
+
+        Tag tag = Tag.of(member, request.name());
+        validateUniqueNameForCreate(member.getId(), tag.getNameKey());
+
+        return TagResponse.from(saveTag(tag));
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagResponse> findAll(Member member) {
+        return tagRepository.findAllByMemberIdOrderByCreatedAtAscIdAsc(member.getId()).stream()
+                .map(TagResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public TagResponse update(Member member, Long tagId, TagRequest request) {
+        Tag tag = findOwnedTag(member, tagId);
+
+        String nameKey = Tag.nameKeyOf(request.name());
+        validateUniqueNameForUpdate(member.getId(), nameKey, tagId);
+        tag.rename(request.name());
+
+        flushTagChanges();
+        return TagResponse.from(tag);
+    }
+
+    @Transactional
+    public void delete(Member member, Long tagId) {
+        tagRepository.delete(findOwnedTag(member, tagId));
+    }
+
+    @Transactional(readOnly = true)
+    public Tag getOwnedTag(Member member, Long tagId) {
+        return findOwnedTag(member, tagId);
+    }
+
+    private Tag findOwnedTag(Member member, Long tagId) {
+        return tagRepository.findByIdAndMemberId(tagId, member.getId())
+                .orElseThrow(() -> new BusinessException(TagErrorCode.TAG_NOT_FOUND));
+    }
+
+    private void validateTagLimit(Long memberId) {
+        if (tagRepository.countByMemberId(memberId) >= MAX_TAGS_PER_MEMBER) {
+            throw new BusinessException(TagErrorCode.TAG_LIMIT_EXCEEDED);
+        }
+    }
+
+    private void validateUniqueNameForCreate(Long memberId, String nameKey) {
+        boolean exists = tagRepository.existsByMemberIdAndNameKey(memberId, nameKey);
+        throwIfNameExists(exists);
+    }
+
+    private void validateUniqueNameForUpdate(Long memberId, String nameKey, Long tagId) {
+        boolean exists = tagRepository.existsByMemberIdAndNameKeyAndIdNot(memberId, nameKey, tagId);
+        throwIfNameExists(exists);
+    }
+
+    private void throwIfNameExists(boolean exists) {
+        if (exists) {
+            throw new BusinessException(TagErrorCode.TAG_NAME_CONFLICT);
+        }
+    }
+
+    private Tag saveTag(Tag tag) {
+        try {
+            return tagRepository.saveAndFlush(tag);
+        } catch (DataIntegrityViolationException exception) {
+            throw new BusinessException(TagErrorCode.TAG_NAME_CONFLICT);
+        }
+    }
+
+    private void flushTagChanges() {
+        try {
+            tagRepository.flush();
+        } catch (DataIntegrityViolationException exception) {
+            throw new BusinessException(TagErrorCode.TAG_NAME_CONFLICT);
+        }
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/tag/TagService.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagService.java
@@ -5,6 +5,7 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.tag.dto.TagRequest;
 import com.mapmory.backend.tag.dto.TagResponse;
 import java.util.List;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TagService {
     private static final int MAX_TAGS_PER_MEMBER = 10;
+    private static final String TAG_NAME_UNIQUE_CONSTRAINT = "uk_tag_member_name_key";
     private final TagRepository tagRepository;
 
     public TagService(TagRepository tagRepository) {
@@ -20,9 +22,9 @@ public class TagService {
 
     @Transactional
     public TagResponse create(Member member, TagRequest request) {
-        validateTagLimit(member.getId());
-
         Tag tag = Tag.of(member, request.name());
+
+        validateTagLimit(member.getId());
         validateUniqueNameForCreate(member.getId(), tag.getNameKey());
 
         return TagResponse.from(saveTag(tag));
@@ -88,7 +90,7 @@ public class TagService {
         try {
             return tagRepository.saveAndFlush(tag);
         } catch (DataIntegrityViolationException exception) {
-            throw new BusinessException(TagErrorCode.TAG_NAME_CONFLICT);
+            throw translateIntegrityViolation(exception);
         }
     }
 
@@ -96,7 +98,26 @@ public class TagService {
         try {
             tagRepository.flush();
         } catch (DataIntegrityViolationException exception) {
-            throw new BusinessException(TagErrorCode.TAG_NAME_CONFLICT);
+            throw translateIntegrityViolation(exception);
         }
+    }
+
+    private RuntimeException translateIntegrityViolation(DataIntegrityViolationException exception) {
+        if (isTagNameUniqueConstraintViolation(exception)) {
+            return new BusinessException(TagErrorCode.TAG_NAME_CONFLICT);
+        }
+        return exception;
+    }
+
+    private boolean isTagNameUniqueConstraintViolation(Throwable exception) {
+        Throwable cause = exception;
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException constraintViolation
+                    && TAG_NAME_UNIQUE_CONSTRAINT.equalsIgnoreCase(constraintViolation.getConstraintName())) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/tag/dto/TagRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/dto/TagRequest.java
@@ -1,0 +1,6 @@
+package com.mapmory.backend.tag.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TagRequest(@NotNull String name) {
+}

--- a/backend/src/main/java/com/mapmory/backend/tag/dto/TagRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/dto/TagRequest.java
@@ -1,6 +1,6 @@
 package com.mapmory.backend.tag.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
-public record TagRequest(@NotNull String name) {
+public record TagRequest(@NotBlank String name) {
 }

--- a/backend/src/main/java/com/mapmory/backend/tag/dto/TagResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/dto/TagResponse.java
@@ -1,0 +1,10 @@
+package com.mapmory.backend.tag.dto;
+
+import com.mapmory.backend.tag.Tag;
+import java.time.LocalDateTime;
+
+public record TagResponse(Long id, String name, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public static TagResponse from(Tag tag) {
+        return new TagResponse(tag.getId(), tag.getName(), tag.getCreatedAt(), tag.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/tag/dto/TagSummaryResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/dto/TagSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.mapmory.backend.tag.dto;
+
+import com.mapmory.backend.tag.Tag;
+
+public record TagSummaryResponse(Long id, String name) {
+    public static TagSummaryResponse from(Tag tag) {
+        return new TagSummaryResponse(tag.getId(), tag.getName());
+    }
+}

--- a/backend/src/main/resources/db/migration/V15__create_tag.sql
+++ b/backend/src/main/resources/db/migration/V15__create_tag.sql
@@ -1,0 +1,12 @@
+CREATE TABLE tag (
+    id              BIGINT      AUTO_INCREMENT PRIMARY KEY,
+    member_id       BIGINT      NOT NULL,
+    name            VARCHAR(30) NOT NULL,
+    name_key        VARCHAR(30) NOT NULL,
+    created_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_tag_member FOREIGN KEY (member_id) REFERENCES member (id),
+    CONSTRAINT uk_tag_member_name_key UNIQUE (member_id, name_key)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/backend/src/main/resources/db/migration/V15__create_tag.sql
+++ b/backend/src/main/resources/db/migration/V15__create_tag.sql
@@ -2,7 +2,7 @@ CREATE TABLE tag (
     id              BIGINT      AUTO_INCREMENT PRIMARY KEY,
     member_id       BIGINT      NOT NULL,
     name            VARCHAR(30) NOT NULL,
-    name_key        VARCHAR(30) COLLATE utf8mb4_0900_bin NOT NULL,
+    name_key        VARCHAR(60) COLLATE utf8mb4_0900_bin NOT NULL,
     created_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_tag_member FOREIGN KEY (member_id) REFERENCES member (id),

--- a/backend/src/main/resources/db/migration/V15__create_tag.sql
+++ b/backend/src/main/resources/db/migration/V15__create_tag.sql
@@ -2,7 +2,7 @@ CREATE TABLE tag (
     id              BIGINT      AUTO_INCREMENT PRIMARY KEY,
     member_id       BIGINT      NOT NULL,
     name            VARCHAR(30) NOT NULL,
-    name_key        VARCHAR(30) NOT NULL,
+    name_key        VARCHAR(30) COLLATE utf8mb4_0900_bin NOT NULL,
     created_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_tag_member FOREIGN KEY (member_id) REFERENCES member (id),

--- a/backend/src/test/java/com/mapmory/backend/tag/TagNameTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagNameTest.java
@@ -24,6 +24,14 @@ class TagNameTest {
     }
 
     @Test
+    void 소문자_변환으로_비교_키가_늘어나도_30자_표시_이름을_허용한다() {
+        TagName tagName = TagName.from("İ".repeat(30));
+
+        assertThat(tagName.displayName()).hasSize(30);
+        assertThat(tagName.nameKey().codePointCount(0, tagName.nameKey().length())).isEqualTo(60);
+    }
+
+    @Test
     void 유효하지_않은_이름을_거부한다() {
         assertInvalidName("   ");
         assertInvalidName("#연인");

--- a/backend/src/test/java/com/mapmory/backend/tag/TagNameTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagNameTest.java
@@ -1,0 +1,48 @@
+package com.mapmory.backend.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+
+class TagNameTest {
+
+    @Test
+    void 표시_이름과_중복_비교_키를_만든다() {
+        TagName tagName = TagName.from("  Date   Course  ");
+
+        assertThat(tagName.displayName()).isEqualTo("Date Course");
+        assertThat(tagName.nameKey()).isEqualTo("date course");
+    }
+
+    @Test
+    void 표시_이름을_NFC로_정규화한다() {
+        TagName tagName = TagName.from("가");
+
+        assertThat(tagName.displayName()).isEqualTo("가");
+    }
+
+    @Test
+    void 유효하지_않은_이름을_거부한다() {
+        assertInvalidName("   ");
+        assertInvalidName("#연인");
+        assertInvalidName("친구\u0000");
+        assertInvalidName("가".repeat(31));
+    }
+
+    @Test
+    void 표시_이름과_비교_키가_일치하지_않는_직접_생성을_거부한다() {
+        assertThatThrownBy(() -> new TagName("친구", "friend"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode())
+                .isEqualTo(TagErrorCode.INVALID_TAG_NAME);
+    }
+
+    private void assertInvalidName(String rawName) {
+        assertThatThrownBy(() -> TagName.from(rawName))
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode())
+                .isEqualTo(TagErrorCode.INVALID_TAG_NAME);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/tag/TagRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.mapmory.backend.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.support.MySqlTestContainerSupport;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class TagRepositoryTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void 대소문자만_다른_이름은_같은_태그로_판단한다() {
+        Member member = memberRepository.save(Member.of("태그 회원", UUID.randomUUID()));
+        tagRepository.saveAndFlush(Tag.of(member, "Cafe"));
+
+        assertThatThrownBy(() -> tagRepository.saveAndFlush(Tag.of(member, "cafe")))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 악센트가_다른_이름은_서로_다른_태그로_저장한다() {
+        Member member = memberRepository.save(Member.of("악센트 태그 회원", UUID.randomUUID()));
+        tagRepository.saveAndFlush(Tag.of(member, "cafe"));
+        tagRepository.saveAndFlush(Tag.of(member, "café"));
+
+        assertThat(tagRepository.findAllByMemberIdOrderByCreatedAtAscIdAsc(member.getId()))
+                .extracting(Tag::getName)
+                .containsExactly("cafe", "café");
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/tag/TagRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagRepositoryTest.java
@@ -40,4 +40,17 @@ class TagRepositoryTest extends MySqlTestContainerSupport {
                 .extracting(Tag::getName)
                 .containsExactly("cafe", "café");
     }
+
+    @Test
+    void 임베디드_이름의_비교_키로_중복을_조회한다() {
+        Member member = memberRepository.save(Member.of("태그 중복 조회 회원", UUID.randomUUID()));
+        Tag tag = tagRepository.saveAndFlush(Tag.of(member, "Cafe"));
+
+        assertThat(tagRepository.existsByMemberIdAndNameKey(member.getId(), "cafe")).isTrue();
+        assertThat(tagRepository.existsByMemberIdAndNameKeyAndIdNot(
+                member.getId(),
+                "cafe",
+                tag.getId()
+        )).isFalse();
+    }
 }

--- a/backend/src/test/java/com/mapmory/backend/tag/TagRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagRepositoryTest.java
@@ -53,4 +53,14 @@ class TagRepositoryTest extends MySqlTestContainerSupport {
                 tag.getId()
         )).isFalse();
     }
+
+    @Test
+    void 소문자_변환으로_늘어난_비교_키를_저장한다() {
+        Member member = memberRepository.save(Member.of("확장 태그 키 회원", UUID.randomUUID()));
+        String displayName = "İ".repeat(30);
+
+        Tag tag = tagRepository.saveAndFlush(Tag.of(member, displayName));
+
+        assertThat(tag.getName()).isEqualTo(displayName);
+    }
 }

--- a/backend/src/test/java/com/mapmory/backend/tag/TagServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagServiceTest.java
@@ -1,0 +1,95 @@
+package com.mapmory.backend.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.tag.dto.TagRequest;
+import com.mapmory.backend.tag.dto.TagResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private Member member;
+
+    private TagService tagService;
+
+    @BeforeEach
+    void setUp() {
+        tagService = new TagService(tagRepository);
+        when(member.getId()).thenReturn(10L);
+    }
+
+    @Test
+    void 이름을_정규화해_태그를_생성한다() {
+        when(tagRepository.countByMemberId(10L)).thenReturn(0L);
+        when(tagRepository.existsByMemberIdAndNameKey(10L, "date course"))
+                .thenReturn(false);
+        when(tagRepository.saveAndFlush(any(Tag.class))).thenAnswer(invocation -> {
+            Tag tag = invocation.getArgument(0);
+            ReflectionTestUtils.setField(tag, "id", 1L);
+            return tag;
+        });
+
+        TagResponse response = tagService.create(member, new TagRequest("  Date   Course  "));
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.name()).isEqualTo("Date Course");
+        verify(tagRepository).existsByMemberIdAndNameKey(10L, "date course");
+    }
+
+    @Test
+    void 회원당_태그가_10개면_생성을_거부한다() {
+        when(tagRepository.countByMemberId(10L)).thenReturn(10L);
+
+        assertError(() -> tagService.create(member, new TagRequest("연인")), "TAG_LIMIT_EXCEEDED");
+
+        verify(tagRepository, never()).saveAndFlush(any(Tag.class));
+    }
+
+    @Test
+    void 샵이_포함된_태그_이름을_거부한다() {
+        when(tagRepository.countByMemberId(10L)).thenReturn(0L);
+
+        assertError(() -> tagService.create(member, new TagRequest("#연인")), "VALIDATION_ERROR");
+    }
+
+    @Test
+    void 중복된_이름으로_수정할_때는_기존_이름을_유지한다() {
+        Tag tag = Tag.of(member, "친구");
+        ReflectionTestUtils.setField(tag, "id", 1L);
+        when(tagRepository.findByIdAndMemberId(1L, 10L)).thenReturn(Optional.of(tag));
+        when(tagRepository.existsByMemberIdAndNameKeyAndIdNot(10L, "date course", 1L))
+                .thenReturn(true);
+
+        assertError(
+                () -> tagService.update(member, 1L, new TagRequest("  Date   Course  ")),
+                "TAG_NAME_CONFLICT"
+        );
+
+        assertThat(tag.getName()).isEqualTo("친구");
+    }
+
+    private void assertError(Runnable action, String code) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo(code);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/tag/TagServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagServiceTest.java
@@ -3,8 +3,10 @@ package com.mapmory.backend.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.mapmory.backend.common.exception.BusinessException;
@@ -12,11 +14,13 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.tag.dto.TagRequest;
 import com.mapmory.backend.tag.dto.TagResponse;
 import java.util.Optional;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,11 +37,11 @@ class TagServiceTest {
     @BeforeEach
     void setUp() {
         tagService = new TagService(tagRepository);
-        when(member.getId()).thenReturn(10L);
     }
 
     @Test
     void 이름을_정규화해_태그를_생성한다() {
+        when(member.getId()).thenReturn(10L);
         when(tagRepository.countByMemberId(10L)).thenReturn(0L);
         when(tagRepository.existsByMemberIdAndNameKey(10L, "date course"))
                 .thenReturn(false);
@@ -56,6 +60,7 @@ class TagServiceTest {
 
     @Test
     void 회원당_태그가_10개면_생성을_거부한다() {
+        when(member.getId()).thenReturn(10L);
         when(tagRepository.countByMemberId(10L)).thenReturn(10L);
 
         assertError(() -> tagService.create(member, new TagRequest("연인")), "TAG_LIMIT_EXCEEDED");
@@ -65,13 +70,14 @@ class TagServiceTest {
 
     @Test
     void 샵이_포함된_태그_이름을_거부한다() {
-        when(tagRepository.countByMemberId(10L)).thenReturn(0L);
-
         assertError(() -> tagService.create(member, new TagRequest("#연인")), "VALIDATION_ERROR");
+
+        verifyNoInteractions(tagRepository);
     }
 
     @Test
     void 중복된_이름으로_수정할_때는_기존_이름을_유지한다() {
+        when(member.getId()).thenReturn(10L);
         Tag tag = Tag.of(member, "친구");
         ReflectionTestUtils.setField(tag, "id", 1L);
         when(tagRepository.findByIdAndMemberId(1L, 10L)).thenReturn(Optional.of(tag));
@@ -84,6 +90,32 @@ class TagServiceTest {
         );
 
         assertThat(tag.getName()).isEqualTo("친구");
+    }
+
+    @Test
+    void 이름_유니크_제약조건_위반을_비즈니스_예외로_변환한다() {
+        when(member.getId()).thenReturn(10L);
+        when(tagRepository.countByMemberId(10L)).thenReturn(0L);
+        when(tagRepository.existsByMemberIdAndNameKey(10L, "친구")).thenReturn(false);
+        ConstraintViolationException constraintViolation = mock(ConstraintViolationException.class);
+        when(constraintViolation.getConstraintName()).thenReturn("uk_tag_member_name_key");
+        DataIntegrityViolationException integrityViolation =
+                new DataIntegrityViolationException("이름 중복", constraintViolation);
+        when(tagRepository.saveAndFlush(any(Tag.class))).thenThrow(integrityViolation);
+
+        assertError(() -> tagService.create(member, new TagRequest("친구")), "TAG_NAME_CONFLICT");
+    }
+
+    @Test
+    void 다른_무결성_예외를_이름_중복으로_변환하지_않는다() {
+        when(member.getId()).thenReturn(10L);
+        when(tagRepository.countByMemberId(10L)).thenReturn(0L);
+        when(tagRepository.existsByMemberIdAndNameKey(10L, "친구")).thenReturn(false);
+        DataIntegrityViolationException integrityViolation = new DataIntegrityViolationException("FK 위반");
+        when(tagRepository.saveAndFlush(any(Tag.class))).thenThrow(integrityViolation);
+
+        assertThatThrownBy(() -> tagService.create(member, new TagRequest("친구")))
+                .isSameAs(integrityViolation);
     }
 
     private void assertError(Runnable action, String code) {

--- a/backend/src/test/java/com/mapmory/backend/tag/TagTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagTest.java
@@ -1,0 +1,40 @@
+package com.mapmory.backend.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TagTest {
+
+    private final Member member = Mockito.mock(Member.class);
+
+    @Test
+    void 생성할_때_이름을_정규화한다() {
+        Tag tag = Tag.of(member, "  Date   Course  ");
+
+        assertThat(tag.getName()).isEqualTo("Date Course");
+        assertThat(tag.getNameKey()).isEqualTo("date course");
+    }
+
+    @Test
+    void 이름을_바꿀_때도_정규화한다() {
+        Tag tag = Tag.of(member, "친구");
+
+        tag.rename("  RAMEN   PLACE  ");
+
+        assertThat(tag.getName()).isEqualTo("RAMEN PLACE");
+        assertThat(tag.getNameKey()).isEqualTo("ramen place");
+    }
+
+    @Test
+    void 유효하지_않은_이름으로는_생성할_수_없다() {
+        assertThatThrownBy(() -> Tag.of(member, "#연인"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode())
+                .isEqualTo(TagErrorCode.INVALID_TAG_NAME);
+    }
+}

--- a/backend/src/test/resources/db/cleanup-test-data.sql
+++ b/backend/src/test/resources/db/cleanup-test-data.sql
@@ -1,4 +1,5 @@
 DELETE FROM record_media;
 DELETE FROM travel_record;
+DELETE FROM tag;
 DELETE FROM refresh_token;
 DELETE FROM member;


### PR DESCRIPTION
## 요약

- 회원이 직접 만드는 태그 CRUD API를 추가합니다.
- 태그 이름 정규화와 검증을 `Tag` 도메인의 생성·변경 경로에 둡니다.
- V15에서 `tag` 테이블만 생성합니다.

## 이 PR에서 볼 범위

- `Tag`: 표시 이름 `name`과 중복 비교 키 `nameKey`
- 앞뒤 공백 제거, 연속 공백 축약, Unicode NFC, 대소문자 비교 키 생성
- 회원별 이름 중복 검증과 최대 10개 임시 제한
- 태그 생성·조회·수정·삭제 API
- DB UNIQUE 충돌을 도메인 오류로 변환하는 트랜잭션 경계

기록과 태그의 연결 및 태그 기반 조회는 후속 PR에서 다룹니다.

## Stacked PR

- 선행: #111
- 현재: 사용자 태그 CRUD와 V15
- 후속: 여행 기록-태그 연결과 V16
- 후속: 태그 기반 기록·지도 필터

#111 병합 후 이 PR의 base를 `main`으로 변경합니다.

## 확인

- `./gradlew test` 통과
- `git diff --check` 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag management with create, view, update, and delete operations.
  * Tags are scoped to individual members and limited to 10 per member.
  * Added tag-name validation, normalization, and duplicate prevention.
  * Tag responses include names, identifiers, and timestamps.

* **Bug Fixes**
  * Added clear handling for invalid names, missing tags, duplicates, and ownership conflicts.

* **Tests**
  * Added coverage for normalization, validation, limits, and update conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->