### PR TITLE
feat(travel-record): 여행 기록 태그 연결과 V16 스키마

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/tag/TagRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagRepository.java
@@ -38,5 +38,5 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 
     List<Tag> findAllByMemberIdOrderByCreatedAtAscIdAsc(Long memberId);
 
-    List<Tag> findAllByMemberIdAndIdIn(Long memberId, Collection<Long> ids);
+    List<Tag> findAllByMemberIdAndIdInOrderByCreatedAtAscIdAsc(Long memberId, Collection<Long> ids);
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -9,7 +9,6 @@ import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordResponse;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.Valid;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -52,18 +51,19 @@ public class TravelRecordController {
             @RequestParam(required = false) String countryCode,
             @RequestParam(required = false) String provinceCode,
             @RequestParam(required = false) String districtCode,
+            @RequestParam(required = false) @Positive Long tagId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
-        Page<TravelRecord> travelRecords = travelRecordService.findAll(
+        TravelRecordListResponse response = travelRecordService.findAll(
                 member,
                 countryCode,
                 provinceCode,
                 districtCode,
+                tagId,
                 page,
                 size
         );
-        TravelRecordListResponse response = TravelRecordListResponse.from(travelRecords);
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordRepository.java
@@ -17,6 +17,23 @@ public interface TravelRecordRepository extends JpaRepository<TravelRecord, Long
         SELECT tr
         FROM TravelRecord tr
         WHERE tr.member.id = :memberId
+          AND (:tagId IS NULL OR EXISTS (
+              SELECT trt.id
+              FROM TravelRecordTag trt
+              WHERE trt.travelRecord.id = tr.id
+                AND trt.tag.id = :tagId
+          ))
+    """)
+    Page<TravelRecord> findByMemberIdAndOptionalTagId(
+            @Param("memberId") Long memberId,
+            @Param("tagId") Long tagId,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT tr
+        FROM TravelRecord tr
+        WHERE tr.member.id = :memberId
               AND (
                   tr.region.id = :countryId
                   OR tr.region.root.id = :countryId
@@ -25,6 +42,28 @@ public interface TravelRecordRepository extends JpaRepository<TravelRecord, Long
     Page<TravelRecord> findByMemberIdAndCountryId(@Param("memberId") Long memberId,
                                                    @Param("countryId") Long countryId,
                                                    Pageable pageable);
+
+    @Query("""
+        SELECT tr
+        FROM TravelRecord tr
+        WHERE tr.member.id = :memberId
+          AND (
+              tr.region.id = :countryId
+              OR tr.region.root.id = :countryId
+          )
+          AND (:tagId IS NULL OR EXISTS (
+              SELECT trt.id
+              FROM TravelRecordTag trt
+              WHERE trt.travelRecord.id = tr.id
+                AND trt.tag.id = :tagId
+          ))
+    """)
+    Page<TravelRecord> findByMemberIdAndCountryIdAndOptionalTagId(
+            @Param("memberId") Long memberId,
+            @Param("countryId") Long countryId,
+            @Param("tagId") Long tagId,
+            Pageable pageable
+    );
 
     @Query("""
         SELECT tr
@@ -39,5 +78,46 @@ public interface TravelRecordRepository extends JpaRepository<TravelRecord, Long
                                                    @Param("provinceId") Long provinceId,
                                                    Pageable pageable);
 
+    @Query("""
+        SELECT tr
+        FROM TravelRecord tr
+        WHERE tr.member.id = :memberId
+          AND (
+              tr.region.id = :provinceId
+              OR tr.region.parent.id = :provinceId
+          )
+          AND (:tagId IS NULL OR EXISTS (
+              SELECT trt.id
+              FROM TravelRecordTag trt
+              WHERE trt.travelRecord.id = tr.id
+                AND trt.tag.id = :tagId
+          ))
+    """)
+    Page<TravelRecord> findByMemberIdAndProvinceIdAndOptionalTagId(
+            @Param("memberId") Long memberId,
+            @Param("provinceId") Long provinceId,
+            @Param("tagId") Long tagId,
+            Pageable pageable
+    );
+
     Page<TravelRecord> findByMemberIdAndRegionId(Long memberId, Long regionId, Pageable pageable);
+
+    @Query("""
+        SELECT tr
+        FROM TravelRecord tr
+        WHERE tr.member.id = :memberId
+          AND tr.region.id = :regionId
+          AND (:tagId IS NULL OR EXISTS (
+              SELECT trt.id
+              FROM TravelRecordTag trt
+              WHERE trt.travelRecord.id = tr.id
+                AND trt.tag.id = :tagId
+          ))
+    """)
+    Page<TravelRecord> findByMemberIdAndRegionIdAndOptionalTagId(
+            @Param("memberId") Long memberId,
+            @Param("regionId") Long regionId,
+            @Param("tagId") Long tagId,
+            Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -1,13 +1,17 @@
 package com.mapmory.backend.travelrecord;
 
-import com.mapmory.backend.member.Member;
 import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
 import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
-import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
+import com.mapmory.backend.tag.TagService;
+import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
+import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
+import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
+import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,15 +34,21 @@ public class TravelRecordService {
     private final TravelRecordRepository travelRecordRepository;
     private final RegionResolver regionResolver;
     private final RecordMediaRepository recordMediaRepository;
+    private final TravelRecordTagService travelRecordTagService;
+    private final TagService tagService;
 
     public TravelRecordService(
             TravelRecordRepository travelRecordRepository,
             RegionResolver regionResolver,
-            RecordMediaRepository recordMediaRepository
+            RecordMediaRepository recordMediaRepository,
+            TravelRecordTagService travelRecordTagService,
+            TagService tagService
     ) {
         this.travelRecordRepository = travelRecordRepository;
         this.regionResolver = regionResolver;
         this.recordMediaRepository = recordMediaRepository;
+        this.travelRecordTagService = travelRecordTagService;
+        this.tagService = tagService;
     }
 
     @Transactional
@@ -59,6 +69,7 @@ public class TravelRecordService {
         );
 
         TravelRecord savedTravelRecord = travelRecordRepository.save(travelRecord);
+        travelRecordTagService.replace(member, savedTravelRecord, request.tagIds());
 
         List<String> objectKeys = request.objectKeys() == null ? List.of() : request.objectKeys();
 
@@ -84,7 +95,11 @@ public class TravelRecordService {
         List<RecordMedia> recordMedia = recordMediaRepository
                 .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
 
-        return TravelRecordDetailResponse.from(travelRecord, recordMedia);
+        return TravelRecordDetailResponse.from(
+                travelRecord,
+                recordMedia,
+                travelRecordTagService.findByTravelRecordId(travelRecordId)
+        );
     }
 
     @Transactional
@@ -111,10 +126,11 @@ public class TravelRecordService {
                 request.endDate()
         );
         List<RecordMedia> updatedMedia = synchronizeMedia(travelRecord, existingMedia, objectKeys);
+        List<TagSummaryResponse> tags = travelRecordTagService.replace(member, travelRecord, request.tagIds());
 
         travelRecordRepository.flush();
 
-        return TravelRecordDetailResponse.from(travelRecord, updatedMedia);
+        return TravelRecordDetailResponse.from(travelRecord, updatedMedia, tags);
     }
 
     @Transactional
@@ -126,39 +142,61 @@ public class TravelRecordService {
     }
 
     @Transactional(readOnly = true)
-    public Page<TravelRecord> findAll(Member member, String countryCode, String provinceCode, String districtCode, int page, int size) {
+    public TravelRecordListResponse findAll(
+            Member member,
+            String countryCode,
+            String provinceCode,
+            String districtCode,
+            Long tagId,
+            int page,
+            int size
+    ) {
         validateRegionCodeFormat(countryCode, provinceCode, districtCode);
         validateRegionFilterHierarchy(countryCode, provinceCode, districtCode);
         validatePagination(page, size);
         Long memberId = member.getId();
         Pageable pageable = createPageable(page, size);
+        if (tagId != null) {
+            tagService.getOwnedTag(member, tagId);
+        }
+
+        Page<TravelRecord> travelRecords;
 
         if (countryCode == null) {
-            return travelRecordRepository.findByMemberId(memberId, pageable);
+            travelRecords = travelRecordRepository.findByMemberIdAndOptionalTagId(memberId, tagId, pageable);
+        } else {
+            Region region = regionResolver.resolve(countryCode, provinceCode, districtCode);
+            if (provinceCode == null) {
+                travelRecords = travelRecordRepository.findByMemberIdAndCountryIdAndOptionalTagId(
+                        memberId,
+                        region.getId(),
+                        tagId,
+                        pageable
+                );
+            } else if (districtCode == null) {
+                travelRecords = travelRecordRepository.findByMemberIdAndProvinceIdAndOptionalTagId(
+                        memberId,
+                        region.getId(),
+                        tagId,
+                        pageable
+                );
+            } else {
+                travelRecords = travelRecordRepository.findByMemberIdAndRegionIdAndOptionalTagId(
+                        memberId,
+                        region.getId(),
+                        tagId,
+                        pageable
+                );
+            }
         }
 
-        Region region = regionResolver.resolve(countryCode, provinceCode, districtCode);
-
-        if (provinceCode == null) {
-            return travelRecordRepository.findByMemberIdAndCountryId(
-                    memberId,
-                    region.getId(),
-                    pageable
-            );
-        }
-
-        if (districtCode == null) {
-            return travelRecordRepository.findByMemberIdAndProvinceId(
-                    memberId,
-                    region.getId(),
-                    pageable
-            );
-        }
-
-        return travelRecordRepository.findByMemberIdAndRegionId(
-                memberId,
-                region.getId(),
-                pageable
+        Map<Long, List<TagSummaryResponse>> tagsByTravelRecordId =
+                travelRecordTagService.findByTravelRecordIds(
+                        travelRecords.getContent().stream().map(TravelRecord::getId).toList()
+                );
+        return TravelRecordListResponse.from(
+                travelRecords,
+                tagsByTravelRecordId
         );
     }
 

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -6,8 +6,8 @@ import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
+import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
@@ -126,7 +126,7 @@ public class TravelRecordService {
                 request.endDate()
         );
         List<RecordMedia> updatedMedia = synchronizeMedia(travelRecord, existingMedia, objectKeys);
-        List<TagSummaryResponse> tags = travelRecordTagService.replace(member, travelRecord, request.tagIds());
+        List<Tag> tags = travelRecordTagService.replace(member, travelRecord, request.tagIds());
 
         travelRecordRepository.flush();
 
@@ -190,7 +190,7 @@ public class TravelRecordService {
             }
         }
 
-        Map<Long, List<TagSummaryResponse>> tagsByTravelRecordId =
+        Map<Long, List<Tag>> tagsByTravelRecordId =
                 travelRecordTagService.findByTravelRecordIds(
                         travelRecords.getContent().stream().map(TravelRecord::getId).toList()
                 );

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
@@ -1,6 +1,7 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.TravelRecord;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,12 +15,28 @@ public record TravelRecordDetailResponse(
         LocalDate startDate,
         LocalDate endDate,
         List<String> objectKeys,
+        List<TagSummaryResponse> tags,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
+    public TravelRecordDetailResponse(
+            Long id,
+            String title,
+            String content,
+            RegionDetailResponse region,
+            LocalDate startDate,
+            LocalDate endDate,
+            List<String> objectKeys,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this(id, title, content, region, startDate, endDate, objectKeys, List.of(), createdAt, updatedAt);
+    }
+
     public static TravelRecordDetailResponse from(
             TravelRecord travelRecord,
-            List<RecordMedia> recordMedia
+            List<RecordMedia> recordMedia,
+            List<TagSummaryResponse> tags
     ) {
         return new TravelRecordDetailResponse(
                 travelRecord.getId(),
@@ -31,6 +48,7 @@ public record TravelRecordDetailResponse(
                 recordMedia.stream()
                         .map(RecordMedia::getObjectKey)
                         .toList(),
+                tags,
                 travelRecord.getCreatedAt(),
                 travelRecord.getUpdatedAt()
         );

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
@@ -1,6 +1,7 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.TravelRecord;
 import java.time.LocalDate;
@@ -36,7 +37,7 @@ public record TravelRecordDetailResponse(
     public static TravelRecordDetailResponse from(
             TravelRecord travelRecord,
             List<RecordMedia> recordMedia,
-            List<TagSummaryResponse> tags
+            List<Tag> tags
     ) {
         return new TravelRecordDetailResponse(
                 travelRecord.getId(),
@@ -48,7 +49,7 @@ public record TravelRecordDetailResponse(
                 recordMedia.stream()
                         .map(RecordMedia::getObjectKey)
                         .toList(),
-                tags,
+                tags.stream().map(TagSummaryResponse::from).toList(),
                 travelRecord.getCreatedAt(),
                 travelRecord.getUpdatedAt()
         );

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListItemResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListItemResponse.java
@@ -1,7 +1,9 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import java.time.LocalDate;
+import java.util.List;
 
 public record TravelRecordListItemResponse(
         Long id,
@@ -9,10 +11,12 @@ public record TravelRecordListItemResponse(
         String regionName,
         LocalDate startDate,
         LocalDate endDate,
-        String thumbnailUrl
+        String thumbnailUrl,
+        List<TagSummaryResponse> tags
 ) {
     public static TravelRecordListItemResponse from(
-            TravelRecord travelRecord
+            TravelRecord travelRecord,
+            List<TagSummaryResponse> tags
     ) {
         return new TravelRecordListItemResponse(
                 travelRecord.getId(),
@@ -20,7 +24,8 @@ public record TravelRecordListItemResponse(
                 travelRecord.getRegion().getName(),
                 travelRecord.getStartDate(),
                 travelRecord.getEndDate(),
-                null // 다음 단계에서 첫 번째 미디어의 URL을 넣는다.
+                null, // 다음 단계에서 첫 번째 미디어의 URL을 넣는다.
+                tags
         );
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListItemResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListItemResponse.java
@@ -1,7 +1,8 @@
 package com.mapmory.backend.travelrecord.dto;
 
-import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.dto.TagSummaryResponse;
+import com.mapmory.backend.travelrecord.TravelRecord;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -16,7 +17,7 @@ public record TravelRecordListItemResponse(
 ) {
     public static TravelRecordListItemResponse from(
             TravelRecord travelRecord,
-            List<TagSummaryResponse> tags
+            List<Tag> tags
     ) {
         return new TravelRecordListItemResponse(
                 travelRecord.getId(),
@@ -25,7 +26,7 @@ public record TravelRecordListItemResponse(
                 travelRecord.getStartDate(),
                 travelRecord.getEndDate(),
                 null, // 다음 단계에서 첫 번째 미디어의 URL을 넣는다.
-                tags
+                tags.stream().map(TagSummaryResponse::from).toList()
         );
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
@@ -1,7 +1,9 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 
 public record TravelRecordListResponse(
@@ -13,11 +15,15 @@ public record TravelRecordListResponse(
         boolean hasNext
 ) {
     public static TravelRecordListResponse from(
-            Page<TravelRecord> travelRecords
+            Page<TravelRecord> travelRecords,
+            Map<Long, List<TagSummaryResponse>> tagsByTravelRecordId
     ) {
         return new TravelRecordListResponse(
                 travelRecords.getContent().stream()
-                        .map(TravelRecordListItemResponse::from)
+                        .map(travelRecord -> TravelRecordListItemResponse.from(
+                                travelRecord,
+                                tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of())
+                        ))
                         .toList(),
                 travelRecords.getNumber(),
                 travelRecords.getSize(),

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
@@ -1,7 +1,7 @@
 package com.mapmory.backend.travelrecord.dto;
 
+import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.travelrecord.TravelRecord;
-import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import java.util.List;
 import java.util.Map;
 import org.springframework.data.domain.Page;
@@ -16,7 +16,7 @@ public record TravelRecordListResponse(
 ) {
     public static TravelRecordListResponse from(
             Page<TravelRecord> travelRecords,
-            Map<Long, List<TagSummaryResponse>> tagsByTravelRecordId
+            Map<Long, List<Tag>> tagsByTravelRecordId
     ) {
         return new TravelRecordListResponse(
                 travelRecords.getContent().stream()

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
@@ -15,6 +15,19 @@ public record TravelRecordRequest(
         @NotNull
         LocalDate startDate,
         LocalDate endDate,
-        List<String> objectKeys
+        List<String> objectKeys,
+        List<Long> tagIds
 ) {
+    public TravelRecordRequest(
+            String countryCode,
+            String provinceCode,
+            String districtCode,
+            String title,
+            String content,
+            LocalDate startDate,
+            LocalDate endDate,
+            List<String> objectKeys
+    ) {
+        this(countryCode, provinceCode, districtCode, title, content, startDate, endDate, objectKeys, List.of());
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTag.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTag.java
@@ -1,0 +1,55 @@
+package com.mapmory.backend.travelrecordtag;
+
+import com.mapmory.backend.tag.Tag;
+import com.mapmory.backend.travelrecord.TravelRecord;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "travel_record_tag")
+public class TravelRecordTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "travel_record_id", nullable = false)
+    private TravelRecord travelRecord;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected TravelRecordTag() {
+    }
+
+    private TravelRecordTag(TravelRecord travelRecord, Tag tag) {
+        this.travelRecord = travelRecord;
+        this.tag = tag;
+    }
+
+    public static TravelRecordTag of(TravelRecord travelRecord, Tag tag) {
+        return new TravelRecordTag(travelRecord, tag);
+    }
+
+    public Long getTravelRecordId() {
+        return travelRecord.getId();
+    }
+
+    public Tag getTag() {
+        return tag;
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagRepository.java
@@ -1,0 +1,34 @@
+package com.mapmory.backend.travelrecordtag;
+
+import com.mapmory.backend.tag.Tag;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TravelRecordTagRepository extends JpaRepository<TravelRecordTag, Long> {
+    @Modifying
+    @Query("DELETE FROM TravelRecordTag trt WHERE trt.travelRecord.id = :travelRecordId")
+    void deleteByTravelRecordId(@Param("travelRecordId") Long travelRecordId);
+
+    @Query("""
+            SELECT trt.tag
+            FROM TravelRecordTag trt
+            WHERE trt.travelRecord.id = :travelRecordId
+            ORDER BY trt.tag.createdAt ASC, trt.tag.id ASC
+            """)
+    List<Tag> findTagsByTravelRecordId(@Param("travelRecordId") Long travelRecordId);
+
+    @Query("""
+            SELECT trt
+            FROM TravelRecordTag trt
+            JOIN FETCH trt.tag
+            WHERE trt.travelRecord.id IN :travelRecordIds
+            ORDER BY trt.tag.createdAt ASC, trt.tag.id ASC
+            """)
+    List<TravelRecordTag> findAllWithTagByTravelRecordIdIn(
+            @Param("travelRecordIds") Collection<Long> travelRecordIds
+    );
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 public interface TravelRecordTagRepository extends JpaRepository<TravelRecordTag, Long> {
     @Modifying
     @Query("DELETE FROM TravelRecordTag trt WHERE trt.travelRecord.id = :travelRecordId")
-    void deleteByTravelRecordId(@Param("travelRecordId") Long travelRecordId);
+    void deleteAllByTravelRecordIdInBulk(@Param("travelRecordId") Long travelRecordId);
 
     @Query("""
             SELECT trt.tag

--- a/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagService.java
@@ -1,0 +1,139 @@
+package com.mapmory.backend.travelrecordtag;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.tag.Tag;
+import com.mapmory.backend.tag.TagErrorCode;
+import com.mapmory.backend.tag.TagRepository;
+import com.mapmory.backend.tag.dto.TagSummaryResponse;
+import com.mapmory.backend.travelrecord.TravelRecord;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TravelRecordTagService {
+    private static final int MAX_TAGS_PER_RECORD = 5;
+    private static final Comparator<Tag> TAG_ORDER = Comparator
+            .comparing(Tag::getCreatedAt)
+            .thenComparingLong(Tag::getId);
+
+    private final TagRepository tagRepository;
+    private final TravelRecordTagRepository travelRecordTagRepository;
+
+    public TravelRecordTagService(
+            TagRepository tagRepository,
+            TravelRecordTagRepository travelRecordTagRepository
+    ) {
+        this.tagRepository = tagRepository;
+        this.travelRecordTagRepository = travelRecordTagRepository;
+    }
+
+    @Transactional
+    public List<TagSummaryResponse> replace(Member member, TravelRecord travelRecord, List<Long> requestedTagIds) {
+        Set<Long> tagIds = validateAndCollectTagIds(requestedTagIds);
+        List<Tag> tags = findOwnedTags(member.getId(), tagIds);
+
+        replaceAssociations(travelRecord, tags);
+
+        return toTagSummaryResponses(tags);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagSummaryResponse> findByTravelRecordId(Long travelRecordId) {
+        return travelRecordTagRepository.findTagsByTravelRecordId(travelRecordId).stream()
+                .map(TagSummaryResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, List<TagSummaryResponse>> findByTravelRecordIds(Collection<Long> travelRecordIds) {
+        if (travelRecordIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, List<TagSummaryResponse>> result = initializeEmptyResults(travelRecordIds);
+        List<TravelRecordTag> associations =
+                travelRecordTagRepository.findAllWithTagByTravelRecordIdIn(travelRecordIds);
+        result.putAll(groupTagResponsesByTravelRecordId(associations));
+
+        return result;
+    }
+
+    private Set<Long> validateAndCollectTagIds(List<Long> requestedTagIds) {
+        List<Long> tagIds = requestedTagIds == null ? List.of() : requestedTagIds;
+        validateTagCount(tagIds);
+
+        Set<Long> uniqueTagIds = new HashSet<>(tagIds);
+        validateNoDuplicateTagIds(tagIds, uniqueTagIds);
+
+        return uniqueTagIds;
+    }
+
+    private void validateTagCount(List<Long> tagIds) {
+        if (tagIds.size() > MAX_TAGS_PER_RECORD) {
+            throw new BusinessException(TagErrorCode.TOO_MANY_TAGS);
+        }
+    }
+
+    private void validateNoDuplicateTagIds(List<Long> tagIds, Set<Long> uniqueTagIds) {
+        if (uniqueTagIds.size() != tagIds.size()) {
+            throw new BusinessException(TagErrorCode.INVALID_TAG_IDS);
+        }
+    }
+
+    private List<Tag> findOwnedTags(Long memberId, Set<Long> tagIds) {
+        List<Tag> tags = tagRepository.findAllByMemberIdAndIdIn(memberId, tagIds);
+        if (tags.size() != tagIds.size()) {
+            throw new BusinessException(TagErrorCode.TAG_NOT_FOUND);
+        }
+        return tags;
+    }
+
+    private void replaceAssociations(TravelRecord travelRecord, List<Tag> tags) {
+        travelRecordTagRepository.deleteByTravelRecordId(travelRecord.getId());
+        travelRecordTagRepository.flush();
+        travelRecordTagRepository.saveAll(createAssociations(travelRecord, tags));
+    }
+
+    private List<TravelRecordTag> createAssociations(TravelRecord travelRecord, List<Tag> tags) {
+        return tags.stream()
+                .map(tag -> TravelRecordTag.of(travelRecord, tag))
+                .toList();
+    }
+
+    private List<TagSummaryResponse> toTagSummaryResponses(List<Tag> tags) {
+        return tags.stream()
+                .sorted(TAG_ORDER)
+                .map(TagSummaryResponse::from)
+                .toList();
+    }
+
+    private Map<Long, List<TagSummaryResponse>> initializeEmptyResults(Collection<Long> travelRecordIds) {
+        Map<Long, List<TagSummaryResponse>> result = new HashMap<>();
+        travelRecordIds.forEach(id -> result.put(id, List.of()));
+        return result;
+    }
+
+    private Map<Long, List<TagSummaryResponse>> groupTagResponsesByTravelRecordId(
+            List<TravelRecordTag> associations
+    ) {
+        return associations.stream()
+                .collect(Collectors.groupingBy(
+                        TravelRecordTag::getTravelRecordId,
+                        LinkedHashMap::new,
+                        Collectors.mapping(
+                                association -> TagSummaryResponse.from(association.getTag()),
+                                Collectors.toList()
+                        )
+                ));
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagService.java
@@ -5,10 +5,8 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.TagErrorCode;
 import com.mapmory.backend.tag.TagRepository;
-import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.TravelRecord;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -22,9 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TravelRecordTagService {
     private static final int MAX_TAGS_PER_RECORD = 5;
-    private static final Comparator<Tag> TAG_ORDER = Comparator
-            .comparing(Tag::getCreatedAt)
-            .thenComparingLong(Tag::getId);
 
     private final TagRepository tagRepository;
     private final TravelRecordTagRepository travelRecordTagRepository;
@@ -38,32 +33,30 @@ public class TravelRecordTagService {
     }
 
     @Transactional
-    public List<TagSummaryResponse> replace(Member member, TravelRecord travelRecord, List<Long> requestedTagIds) {
+    public List<Tag> replace(Member member, TravelRecord travelRecord, List<Long> requestedTagIds) {
         Set<Long> tagIds = validateAndCollectTagIds(requestedTagIds);
         List<Tag> tags = findOwnedTags(member.getId(), tagIds);
 
         replaceAssociations(travelRecord, tags);
 
-        return toTagSummaryResponses(tags);
+        return tags;
     }
 
     @Transactional(readOnly = true)
-    public List<TagSummaryResponse> findByTravelRecordId(Long travelRecordId) {
-        return travelRecordTagRepository.findTagsByTravelRecordId(travelRecordId).stream()
-                .map(TagSummaryResponse::from)
-                .toList();
+    public List<Tag> findByTravelRecordId(Long travelRecordId) {
+        return travelRecordTagRepository.findTagsByTravelRecordId(travelRecordId);
     }
 
     @Transactional(readOnly = true)
-    public Map<Long, List<TagSummaryResponse>> findByTravelRecordIds(Collection<Long> travelRecordIds) {
+    public Map<Long, List<Tag>> findByTravelRecordIds(Collection<Long> travelRecordIds) {
         if (travelRecordIds.isEmpty()) {
             return Map.of();
         }
 
-        Map<Long, List<TagSummaryResponse>> result = initializeEmptyResults(travelRecordIds);
+        Map<Long, List<Tag>> result = initializeEmptyResults(travelRecordIds);
         List<TravelRecordTag> associations =
                 travelRecordTagRepository.findAllWithTagByTravelRecordIdIn(travelRecordIds);
-        result.putAll(groupTagResponsesByTravelRecordId(associations));
+        result.putAll(groupTagsByTravelRecordId(associations));
 
         return result;
     }
@@ -91,7 +84,7 @@ public class TravelRecordTagService {
     }
 
     private List<Tag> findOwnedTags(Long memberId, Set<Long> tagIds) {
-        List<Tag> tags = tagRepository.findAllByMemberIdAndIdIn(memberId, tagIds);
+        List<Tag> tags = tagRepository.findAllByMemberIdAndIdInOrderByCreatedAtAscIdAsc(memberId, tagIds);
         if (tags.size() != tagIds.size()) {
             throw new BusinessException(TagErrorCode.TAG_NOT_FOUND);
         }
@@ -99,8 +92,7 @@ public class TravelRecordTagService {
     }
 
     private void replaceAssociations(TravelRecord travelRecord, List<Tag> tags) {
-        travelRecordTagRepository.deleteByTravelRecordId(travelRecord.getId());
-        travelRecordTagRepository.flush();
+        travelRecordTagRepository.deleteAllByTravelRecordIdInBulk(travelRecord.getId());
         travelRecordTagRepository.saveAll(createAssociations(travelRecord, tags));
     }
 
@@ -110,20 +102,13 @@ public class TravelRecordTagService {
                 .toList();
     }
 
-    private List<TagSummaryResponse> toTagSummaryResponses(List<Tag> tags) {
-        return tags.stream()
-                .sorted(TAG_ORDER)
-                .map(TagSummaryResponse::from)
-                .toList();
-    }
-
-    private Map<Long, List<TagSummaryResponse>> initializeEmptyResults(Collection<Long> travelRecordIds) {
-        Map<Long, List<TagSummaryResponse>> result = new HashMap<>();
+    private Map<Long, List<Tag>> initializeEmptyResults(Collection<Long> travelRecordIds) {
+        Map<Long, List<Tag>> result = new HashMap<>();
         travelRecordIds.forEach(id -> result.put(id, List.of()));
         return result;
     }
 
-    private Map<Long, List<TagSummaryResponse>> groupTagResponsesByTravelRecordId(
+    private Map<Long, List<Tag>> groupTagsByTravelRecordId(
             List<TravelRecordTag> associations
     ) {
         return associations.stream()
@@ -131,7 +116,7 @@ public class TravelRecordTagService {
                         TravelRecordTag::getTravelRecordId,
                         LinkedHashMap::new,
                         Collectors.mapping(
-                                association -> TagSummaryResponse.from(association.getTag()),
+                                TravelRecordTag::getTag,
                                 Collectors.toList()
                         )
                 ));

--- a/backend/src/main/resources/db/migration/V16__create_travel_record_tag.sql
+++ b/backend/src/main/resources/db/migration/V16__create_travel_record_tag.sql
@@ -1,0 +1,13 @@
+CREATE TABLE travel_record_tag (
+    id               BIGINT   AUTO_INCREMENT PRIMARY KEY,
+    travel_record_id BIGINT   NOT NULL,
+    tag_id           BIGINT   NOT NULL,
+    created_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_travel_record_tag_tag_record UNIQUE (tag_id, travel_record_id),
+    CONSTRAINT fk_travel_record_tag_record
+        FOREIGN KEY (travel_record_id) REFERENCES travel_record (id) ON DELETE CASCADE,
+    CONSTRAINT fk_travel_record_tag_tag
+        FOREIGN KEY (tag_id) REFERENCES tag (id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
@@ -10,6 +10,8 @@ import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionRepository;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.support.MySqlTestContainerSupport;
+import com.mapmory.backend.tag.Tag;
+import com.mapmory.backend.travelrecordtag.TravelRecordTag;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -97,6 +99,35 @@ class TravelRecordRepositoryTest extends MySqlTestContainerSupport {
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    void 선택한_태그가_연결된_여행_일지만_조회한다() {
+        Member member = memberRepository.save(Member.of("태그 조회 회원", UUID.randomUUID()));
+        Region country = regionRepository.save(
+                Region.of(null, null, "XT", "태그 조회 국가", RegionType.COUNTRY)
+        );
+        Tag tag = Tag.of(member, "연인");
+        entityManager.persist(tag);
+        TravelRecord taggedRecord = travelRecordRepository.save(TravelRecord.of(
+                member, country, "태그 기록", "", LocalDate.of(2026, 8, 10), null
+        ));
+        travelRecordRepository.save(TravelRecord.of(
+                member, country, "태그 없는 기록", "", LocalDate.of(2026, 8, 11), null
+        ));
+        entityManager.persist(TravelRecordTag.of(taggedRecord, tag));
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<TravelRecord> result = travelRecordRepository.findByMemberIdAndOptionalTagId(
+                member.getId(),
+                tag.getId(),
+                PageRequest.of(0, 20)
+        );
+
+        assertThat(result.getContent())
+                .extracting(TravelRecord::getTitle)
+                .containsExactly("태그 기록");
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -18,8 +18,11 @@ import com.mapmory.backend.recordmedia.RecordMediaRepository;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.tag.TagService;
 import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
+import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
+import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +51,12 @@ class TravelRecordServiceTest {
     @Mock
     private RecordMediaRepository recordMediaRepository;
 
+    @Mock
+    private TravelRecordTagService travelRecordTagService;
+
+    @Mock
+    private TagService tagService;
+
     @InjectMocks
     private TravelRecordService travelRecordService;
 
@@ -63,7 +72,7 @@ class TravelRecordServiceTest {
     void 국가_단위_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
         TravelRecordRequest request = new TravelRecordRequest(
-                "JP", null, null, "일본 여행", "", LocalDate.of(2026, 8, 11), null, List.of()
+                "JP", null, null, "일본 여행", "", LocalDate.of(2026, 8, 11), null, List.of(), List.of(1L)
         );
 
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
@@ -75,6 +84,7 @@ class TravelRecordServiceTest {
         assertThat(result).isNotNull();
         verify(regionResolver).resolve("JP", null, null);
         verify(travelRecordRepository).save(any(TravelRecord.class));
+        verify(travelRecordTagService).replace(member, result, List.of(1L));
     }
 
     @Test
@@ -322,14 +332,18 @@ class TravelRecordServiceTest {
     @Test
     void 지역_필터_없이_일지_목록을_조회한다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
+        Region region = mock(Region.class);
+        when(travelRecord.getId()).thenReturn(101L);
+        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
-        when(travelRecordRepository.findByMemberId(eq(10L), any(Pageable.class))).thenReturn(expected);
+        when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
+                .thenReturn(expected);
 
-        Page<TravelRecord> result = travelRecordService.findAll(member, null, null, null, 0, 20);
+        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result).isEqualTo(expected);
+        assertThat(result.totalElements()).isEqualTo(1);
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
-        verify(travelRecordRepository).findByMemberId(eq(10L), captor.capture());
+        verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(null), captor.capture());
         assertThat(captor.getValue().getPageSize()).isEqualTo(20);
     }
 
@@ -338,10 +352,11 @@ class TravelRecordServiceTest {
         Region korea = region(1L);
         Page<TravelRecord> expected = Page.empty();
         when(regionResolver.resolve("KR", null, null)).thenReturn(korea);
-        when(travelRecordRepository.findByMemberIdAndCountryId(eq(10L), eq(1L), any(Pageable.class)))
+        when(travelRecordRepository.findByMemberIdAndCountryIdAndOptionalTagId(
+                eq(10L), eq(1L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", null, null, 0, 20)).isEqualTo(expected);
+        assertThat(travelRecordService.findAll(member, "KR", null, null, null, 0, 20).items()).isEmpty();
     }
 
     @Test
@@ -350,10 +365,11 @@ class TravelRecordServiceTest {
         Region jeju = region(2L);
         Page<TravelRecord> expected = Page.empty();
         when(regionResolver.resolve("KR", "49", null)).thenReturn(jeju);
-        when(travelRecordRepository.findByMemberIdAndProvinceId(eq(10L), eq(2L), any(Pageable.class)))
+        when(travelRecordRepository.findByMemberIdAndProvinceIdAndOptionalTagId(
+                eq(10L), eq(2L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", "49", null, 0, 20)).isEqualTo(expected);
+        assertThat(travelRecordService.findAll(member, "KR", "49", null, null, 0, 20).items()).isEmpty();
     }
 
     @Test
@@ -363,29 +379,45 @@ class TravelRecordServiceTest {
         Region jejuCity = region(3L);
         Page<TravelRecord> expected = Page.empty();
         when(regionResolver.resolve("KR", "49", "50110")).thenReturn(jejuCity);
-        when(travelRecordRepository.findByMemberIdAndRegionId(eq(10L), eq(3L), any(Pageable.class)))
+        when(travelRecordRepository.findByMemberIdAndRegionIdAndOptionalTagId(
+                eq(10L), eq(3L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", 0, 20)).isEqualTo(expected);
+        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", null, 0, 20).items()).isEmpty();
+    }
+
+    @Test
+    void 소유한_태그로_일지_목록을_필터링한다() {
+        Page<TravelRecord> expected = Page.empty();
+        when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(7L), any(Pageable.class)))
+                .thenReturn(expected);
+
+        TravelRecordListResponse result = travelRecordService.findAll(
+                member, null, null, null, 7L, 0, 20
+        );
+
+        assertThat(result.items()).isEmpty();
+        verify(tagService).getOwnedTag(member, 7L);
+        verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(7L), any(Pageable.class));
     }
 
     @Test
     void 잘못된_지역_필터_조합을_거부한다() {
-        assertError(() -> travelRecordService.findAll(member, null, "49", null, 0, 20), "REGION_REQUIRED");
-        assertError(() -> travelRecordService.findAll(member, "KR", null, "50110", 0, 20), "REGION_REQUIRED");
+        assertError(() -> travelRecordService.findAll(member, null, "49", null, null, 0, 20), "REGION_REQUIRED");
+        assertError(() -> travelRecordService.findAll(member, "KR", null, "50110", null, 0, 20), "REGION_REQUIRED");
     }
 
     @Test
     void 잘못된_지역_코드_형식을_거부한다() {
-        assertError(() -> travelRecordService.findAll(member, "kr", null, null, 0, 20), "VALIDATION_ERROR");
-        assertError(() -> travelRecordService.findAll(member, "KR", " ", null, 0, 20), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, "kr", null, null, null, 0, 20), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, "KR", " ", null, null, 0, 20), "VALIDATION_ERROR");
     }
 
     @Test
     void 잘못된_페이지네이션을_거부한다() {
-        assertError(() -> travelRecordService.findAll(member, null, null, null, -1, 20), "VALIDATION_ERROR");
-        assertError(() -> travelRecordService.findAll(member, null, null, null, 0, 0), "VALIDATION_ERROR");
-        assertError(() -> travelRecordService.findAll(member, null, null, null, 0, 101), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, null, null, null, null, -1, 20), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, null, null, null, null, 0, 0), "VALIDATION_ERROR");
+        assertError(() -> travelRecordService.findAll(member, null, null, null, null, 0, 101), "VALIDATION_ERROR");
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/travelrecordtag/TravelRecordTagServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecordtag/TravelRecordTagServiceTest.java
@@ -1,0 +1,104 @@
+package com.mapmory.backend.travelrecordtag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.tag.Tag;
+import com.mapmory.backend.tag.TagRepository;
+import com.mapmory.backend.tag.dto.TagSummaryResponse;
+import com.mapmory.backend.travelrecord.TravelRecord;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TravelRecordTagServiceTest {
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private TravelRecordTagRepository travelRecordTagRepository;
+
+    @Mock
+    private Member member;
+
+    @Mock
+    private TravelRecord travelRecord;
+
+    private TravelRecordTagService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TravelRecordTagService(tagRepository, travelRecordTagRepository);
+        lenient().when(member.getId()).thenReturn(10L);
+    }
+
+    @Test
+    void 기록당_태그가_5개를_넘으면_거부한다() {
+        assertError(
+                () -> service.replace(member, travelRecord, List.of(1L, 2L, 3L, 4L, 5L, 6L)),
+                "TOO_MANY_TAGS"
+        );
+
+        verify(tagRepository, never()).findAllByMemberIdAndIdIn(org.mockito.ArgumentMatchers.anyLong(), anyList());
+    }
+
+    @Test
+    void 중복된_태그_ID를_거부한다() {
+        assertError(() -> service.replace(member, travelRecord, List.of(1L, 1L)), "VALIDATION_ERROR");
+    }
+
+    @Test
+    void 회원이_소유하지_않은_태그를_거부한다() {
+        when(tagRepository.findAllByMemberIdAndIdIn(10L, java.util.Set.of(1L, 2L)))
+                .thenReturn(List.of(tag(1L, "연인", LocalDateTime.now())));
+
+        assertError(() -> service.replace(member, travelRecord, List.of(1L, 2L)), "TAG_NOT_FOUND");
+
+        verify(travelRecordTagRepository, never()).deleteByTravelRecordId(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void 소유한_태그로_기록의_연결을_교체한다() {
+        LocalDateTime now = LocalDateTime.now();
+        Tag later = tag(2L, "라멘맛집", now.plusSeconds(1));
+        Tag earlier = tag(1L, "연인", now);
+        when(travelRecord.getId()).thenReturn(100L);
+        when(tagRepository.findAllByMemberIdAndIdIn(10L, java.util.Set.of(1L, 2L)))
+                .thenReturn(List.of(later, earlier));
+
+        List<TagSummaryResponse> responses = service.replace(member, travelRecord, List.of(2L, 1L));
+
+        assertThat(responses).extracting(TagSummaryResponse::id).containsExactly(1L, 2L);
+        verify(travelRecordTagRepository).deleteByTravelRecordId(100L);
+        verify(travelRecordTagRepository).flush();
+        verify(travelRecordTagRepository).saveAll(anyList());
+    }
+
+    private Tag tag(Long id, String name, LocalDateTime createdAt) {
+        Tag tag = Tag.of(member, name);
+        ReflectionTestUtils.setField(tag, "id", id);
+        ReflectionTestUtils.setField(tag, "createdAt", createdAt);
+        return tag;
+    }
+
+    private void assertError(Runnable action, String code) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo(code);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecordtag/TravelRecordTagServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecordtag/TravelRecordTagServiceTest.java
@@ -12,7 +12,6 @@ import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.TagRepository;
-import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.TravelRecord;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -53,7 +52,8 @@ class TravelRecordTagServiceTest {
                 "TOO_MANY_TAGS"
         );
 
-        verify(tagRepository, never()).findAllByMemberIdAndIdIn(org.mockito.ArgumentMatchers.anyLong(), anyList());
+        verify(tagRepository, never()).findAllByMemberIdAndIdInOrderByCreatedAtAscIdAsc(
+                org.mockito.ArgumentMatchers.anyLong(), anyList());
     }
 
     @Test
@@ -63,12 +63,13 @@ class TravelRecordTagServiceTest {
 
     @Test
     void 회원이_소유하지_않은_태그를_거부한다() {
-        when(tagRepository.findAllByMemberIdAndIdIn(10L, java.util.Set.of(1L, 2L)))
+        when(tagRepository.findAllByMemberIdAndIdInOrderByCreatedAtAscIdAsc(10L, java.util.Set.of(1L, 2L)))
                 .thenReturn(List.of(tag(1L, "연인", LocalDateTime.now())));
 
         assertError(() -> service.replace(member, travelRecord, List.of(1L, 2L)), "TAG_NOT_FOUND");
 
-        verify(travelRecordTagRepository, never()).deleteByTravelRecordId(org.mockito.ArgumentMatchers.anyLong());
+        verify(travelRecordTagRepository, never())
+                .deleteAllByTravelRecordIdInBulk(org.mockito.ArgumentMatchers.anyLong());
     }
 
     @Test
@@ -77,14 +78,13 @@ class TravelRecordTagServiceTest {
         Tag later = tag(2L, "라멘맛집", now.plusSeconds(1));
         Tag earlier = tag(1L, "연인", now);
         when(travelRecord.getId()).thenReturn(100L);
-        when(tagRepository.findAllByMemberIdAndIdIn(10L, java.util.Set.of(1L, 2L)))
-                .thenReturn(List.of(later, earlier));
+        when(tagRepository.findAllByMemberIdAndIdInOrderByCreatedAtAscIdAsc(10L, java.util.Set.of(1L, 2L)))
+                .thenReturn(List.of(earlier, later));
 
-        List<TagSummaryResponse> responses = service.replace(member, travelRecord, List.of(2L, 1L));
+        List<Tag> tags = service.replace(member, travelRecord, List.of(2L, 1L));
 
-        assertThat(responses).extracting(TagSummaryResponse::id).containsExactly(1L, 2L);
-        verify(travelRecordTagRepository).deleteByTravelRecordId(100L);
-        verify(travelRecordTagRepository).flush();
+        assertThat(tags).extracting(Tag::getId).containsExactly(1L, 2L);
+        verify(travelRecordTagRepository).deleteAllByTravelRecordIdInBulk(100L);
         verify(travelRecordTagRepository).saveAll(anyList());
     }
 

--- a/backend/src/test/resources/db/cleanup-test-data.sql
+++ b/backend/src/test/resources/db/cleanup-test-data.sql
@@ -1,4 +1,5 @@
 DELETE FROM record_media;
+DELETE FROM travel_record_tag;
 DELETE FROM travel_record;
 DELETE FROM tag;
 DELETE FROM refresh_token;


### PR DESCRIPTION
## 요약

- 여행 기록 요청과 응답에 태그 ID·요약을 추가합니다.
- `TravelRecordTag` 연관 엔티티와 전용 서비스를 추가합니다.
- V16에서 `travel_record_tag` 테이블을 생성합니다.

## 이 PR에서 볼 범위

- 기록당 최대 5개 임시 제한과 중복 ID 거부
- 요청 태그 전체의 회원 소유권 일괄 검증
- 기록 생성·수정 트랜잭션 안에서 연결 저장
- 수정 시 기존 연결 삭제·flush 후 재생성
- 단일 AUTO_INCREMENT PK
- `(tag_id, travel_record_id)` UNIQUE
- 상세·목록 응답의 태그 일괄 조회

태그를 조건으로 기록과 지도 요약을 필터링하는 쿼리는 후속 PR에서 다룹니다.

## Stacked PR

- 선행: #111
- 선행: 사용자 태그 CRUD와 V15
- 현재: 여행 기록-태그 연결과 V16
- 후속: 태그 기반 기록·지도 필터

바로 앞 PR이 병합되면 이 PR의 base를 `main`으로 변경합니다.

## 확인

- `./gradlew test` 통과
- `git diff --check` 통과
