### PR TITLE
feat(map-summary): 태그 기반 기록·지도 필터

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
@@ -11,6 +11,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -25,8 +26,11 @@ public class RegionMapSummaryController {
     }
 
     @GetMapping("/roots")
-    public ApiResponse<List<RegionMapSummaryResponse>> getRootSummaries(@LoginMember Member member) {
-        return ApiResponse.from(regionMapSummaryService.getSummaries(member, null));
+    public ApiResponse<List<RegionMapSummaryResponse>> getRootSummaries(
+            @LoginMember Member member,
+            @RequestParam(required = false) @Positive Long tagId
+    ) {
+        return ApiResponse.from(regionMapSummaryService.getSummaries(member, null, tagId));
     }
 
     @GetMapping("/{regionId}/children")
@@ -34,8 +38,9 @@ public class RegionMapSummaryController {
             @LoginMember Member member,
             @PathVariable
             @Positive(message = "지역 ID는 양수여야 합니다.")
-            Long regionId
+            Long regionId,
+            @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(regionMapSummaryService.getSummaries(member, regionId));
+        return ApiResponse.from(regionMapSummaryService.getSummaries(member, regionId, tagId));
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/repository/RegionMapSummaryRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/repository/RegionMapSummaryRepository.java
@@ -28,6 +28,12 @@ public interface RegionMapSummaryRepository extends Repository<TravelRecord, Lon
                   OR summary_region.id = recorded_region.parent_id
                   OR summary_region.id = recorded_region.root_id
                 WHERE tr.member_id = :memberId
+                  AND (:tagId IS NULL OR EXISTS (
+                      SELECT 1
+                      FROM travel_record_tag trt
+                      WHERE trt.travel_record_id = tr.id
+                        AND trt.tag_id = :tagId
+                  ))
                 GROUP BY summary_region.id
             )
             SELECT summary_region.id AS regionId,
@@ -42,6 +48,7 @@ public interface RegionMapSummaryRepository extends Repository<TravelRecord, Lon
             """, nativeQuery = true)
     List<RegionMapSummaryQueryResult> findRegionMapSummaries(
             @Param("memberId") Long memberId,
-            @Param("parentRegionId") Long parentRegionId
+            @Param("parentRegionId") Long parentRegionId,
+            @Param("tagId") Long tagId
     );
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
@@ -4,6 +4,7 @@ import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
+import com.mapmory.backend.tag.TagService;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryRepository;
@@ -17,21 +18,27 @@ public class RegionMapSummaryService {
     private final RegionRepository regionRepository;
     private final RegionMapSummaryRepository regionMapSummaryRepository;
     private final LevelPolicy levelPolicy;
+    private final TagService tagService;
 
     public RegionMapSummaryService(
             RegionRepository regionRepository,
             RegionMapSummaryRepository regionMapSummaryRepository,
-            LevelPolicy levelPolicy
+            LevelPolicy levelPolicy,
+            TagService tagService
     ) {
         this.regionRepository = regionRepository;
         this.regionMapSummaryRepository = regionMapSummaryRepository;
         this.levelPolicy = levelPolicy;
+        this.tagService = tagService;
     }
 
     @Transactional(readOnly = true)
-    public List<RegionMapSummaryResponse> getSummaries(Member member, Long parentRegionId) {
+    public List<RegionMapSummaryResponse> getSummaries(Member member, Long parentRegionId, Long tagId) {
         validateParentRegion(parentRegionId);
-        return regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId).stream()
+        if (tagId != null) {
+            tagService.getOwnedTag(member, tagId);
+        }
+        return regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId, tagId).stream()
                 .map(result -> RegionMapSummaryResponse.from(result, levelPolicy))
                 .toList();
     }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
@@ -73,7 +73,7 @@ class RegionMapSummaryControllerTest {
         @Test
         @DisplayName("회원의 루트 지역별 지도 요약을 의미 기반 단계와 함께 반환한다")
         void returnsRootSummaries() throws Exception {
-            when(regionMapSummaryService.getSummaries(any(Member.class), isNull())).thenReturn(List.of(
+            when(regionMapSummaryService.getSummaries(any(Member.class), isNull(), isNull())).thenReturn(List.of(
                     new RegionMapSummaryResponse(
                             1L,
                             "KR",
@@ -96,7 +96,26 @@ class RegionMapSummaryControllerTest {
 
             verify(regionMapSummaryService).getSummaries(
                     same(member),
+                    isNull(),
                     isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("tagId를 지도 요약 서비스에 전달한다")
+        void passesTagId() throws Exception {
+            when(regionMapSummaryService.getSummaries(any(Member.class), isNull(), eq(7L)))
+                    .thenReturn(List.of());
+
+            mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/roots")
+                            .queryParam("tagId", "7")
+                            .header(HttpHeaders.AUTHORIZATION, bearer(memberId)))
+                    .andExpect(status().isOk());
+
+            verify(regionMapSummaryService).getSummaries(
+                    same(member),
+                    isNull(),
+                    eq(7L)
             );
         }
 
@@ -125,7 +144,7 @@ class RegionMapSummaryControllerTest {
         @Test
         @DisplayName("선택 지역의 직속 하위 지역별 지도 요약을 반환한다")
         void returnsChildSummaries() throws Exception {
-            when(regionMapSummaryService.getSummaries(any(Member.class), eq(1L))).thenReturn(List.of(
+            when(regionMapSummaryService.getSummaries(any(Member.class), eq(1L), isNull())).thenReturn(List.of(
                     new RegionMapSummaryResponse(
                             15L,
                             "49",
@@ -147,7 +166,8 @@ class RegionMapSummaryControllerTest {
 
             verify(regionMapSummaryService).getSummaries(
                     same(member),
-                    eq(1L)
+                    eq(1L),
+                    isNull()
             );
         }
 
@@ -163,7 +183,7 @@ class RegionMapSummaryControllerTest {
         @Test
         @DisplayName("상위 지역을 찾을 수 없으면 REGION_NOT_FOUND를 반환한다")
         void returnsRegionNotFound() throws Exception {
-            when(regionMapSummaryService.getSummaries(any(Member.class), eq(999L)))
+            when(regionMapSummaryService.getSummaries(any(Member.class), eq(999L), isNull()))
                     .thenThrow(new BusinessException(RegionErrorCode.REGION_NOT_FOUND));
 
             mockMvc.perform(get("/api/v1/travel-records/map-summary/regions/999/children")

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/repository/RegionMapSummaryRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/repository/RegionMapSummaryRepositoryTest.java
@@ -6,7 +6,9 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.support.MySqlTestContainerSupport;
+import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.travelrecordtag.TravelRecordTag;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.List;
@@ -27,6 +29,31 @@ class RegionMapSummaryRepositoryTest extends MySqlTestContainerSupport {
 
     @Autowired
     private RegionMapSummaryRepository regionMapSummaryRepository;
+
+    @Test
+    @DisplayName("선택한 태그가 연결된 기록만 지역별로 합산한다")
+    void filtersRecordsByTag() {
+        Member member = member("태그 필터 회원");
+        SavedRegion country = country("T1", "태그 테스트 국가");
+        Tag selectedTag = persist(Tag.of(member, "연인"));
+        Tag otherTag = persist(Tag.of(member, "친구"));
+        TravelRecord selectedRecord = persist(record(member, country, "선택 기록"));
+        TravelRecord otherRecord = persist(record(member, country, "다른 기록"));
+        persist(TravelRecordTag.of(selectedRecord, selectedTag));
+        persist(TravelRecordTag.of(otherRecord, otherTag));
+        flushAndClear();
+
+        List<RegionMapSummaryQueryResult> results = regionMapSummaryRepository.findRegionMapSummaries(
+                member.getId(),
+                null,
+                selectedTag.getId()
+        );
+
+        assertThat(results).singleElement().satisfies(result -> {
+            assertThat(result.getRegionId()).isEqualTo(country.id());
+            assertThat(result.getRecordCount()).isEqualTo(1L);
+        });
+    }
 
     @Nested
     @DisplayName("루트 지역별 지도 요약을 조회할 때")
@@ -181,7 +208,7 @@ class RegionMapSummaryRepositoryTest extends MySqlTestContainerSupport {
         if (parent != null) {
             parentRegionId = parent.id();
         }
-        return regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId);
+        return regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId, null);
     }
 
     private void assertSummaries(
@@ -240,6 +267,17 @@ class RegionMapSummaryRepositoryTest extends MySqlTestContainerSupport {
             ));
         }
         return count;
+    }
+
+    private TravelRecord record(Member member, SavedRegion region, String title) {
+        return TravelRecord.of(
+                member,
+                region.entity(),
+                title,
+                "내용",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
     }
 
     private void flushAndClear() {

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
@@ -11,6 +11,8 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
+import com.mapmory.backend.tag.TagService;
+import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
@@ -39,6 +41,9 @@ class RegionMapSummaryServiceTest {
     @Mock
     private RegionMapSummaryRepository regionMapSummaryRepository;
 
+    @Mock
+    private TagService tagService;
+
     private final LevelPolicy levelPolicy = LevelPolicy.standard();
 
     @Nested
@@ -50,10 +55,10 @@ class RegionMapSummaryServiceTest {
         void returnsRootCountrySummaries() {
             RegionMapSummaryService service = service();
             when(member.getId()).thenReturn(10L);
-            when(regionMapSummaryRepository.findRegionMapSummaries(10L, null))
+            when(regionMapSummaryRepository.findRegionMapSummaries(10L, null, null))
                     .thenReturn(List.of(result(1L, "KR", "대한민국", "COUNTRY", 3L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(member, null);
+            List<RegionMapSummaryResponse> responses = service.getSummaries(member, null, null);
 
             assertThat(responses).containsExactly(new RegionMapSummaryResponse(
                     1L,
@@ -82,10 +87,10 @@ class RegionMapSummaryServiceTest {
             RegionMapSummaryService service = service();
             when(member.getId()).thenReturn(10L);
             when(regionRepository.existsById(parentRegionId)).thenReturn(true);
-            when(regionMapSummaryRepository.findRegionMapSummaries(10L, parentRegionId))
+            when(regionMapSummaryRepository.findRegionMapSummaries(10L, parentRegionId, null))
                     .thenReturn(List.of(result(childRegionId, regionCode, name, regionType, 1L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(member, parentRegionId);
+            List<RegionMapSummaryResponse> responses = service.getSummaries(member, parentRegionId, null);
 
             assertThat(responses).containsExactly(new RegionMapSummaryResponse(
                     childRegionId,
@@ -103,10 +108,26 @@ class RegionMapSummaryServiceTest {
             RegionMapSummaryService service = service();
             when(regionRepository.existsById(999L)).thenReturn(false);
 
-            assertThatThrownBy(() -> service.getSummaries(member, 999L))
+            assertThatThrownBy(() -> service.getSummaries(member, 999L, null))
                     .isInstanceOfSatisfying(BusinessException.class, exception ->
                             assertThat(exception.getErrorCode()).isEqualTo(RegionErrorCode.REGION_NOT_FOUND));
-            verify(regionMapSummaryRepository, never()).findRegionMapSummaries(10L, 999L);
+            verify(regionMapSummaryRepository, never()).findRegionMapSummaries(10L, 999L, null);
+        }
+
+        @Test
+        @DisplayName("태그가 있으면 소유권을 확인하고 해당 태그로 요약을 필터링한다")
+        void filtersSummariesByOwnedTag() {
+            RegionMapSummaryService service = service();
+            Tag tag = org.mockito.Mockito.mock(Tag.class);
+            when(member.getId()).thenReturn(10L);
+            when(tagService.getOwnedTag(member, 7L)).thenReturn(tag);
+            when(regionMapSummaryRepository.findRegionMapSummaries(10L, null, 7L))
+                    .thenReturn(List.of(result(1L, "KR", "대한민국", "COUNTRY", 1L)));
+
+            List<RegionMapSummaryResponse> responses = service.getSummaries(member, null, 7L);
+
+            assertThat(responses).singleElement().extracting(RegionMapSummaryResponse::count).isEqualTo(1L);
+            verify(tagService).getOwnedTag(member, 7L);
         }
     }
 
@@ -114,7 +135,8 @@ class RegionMapSummaryServiceTest {
         return new RegionMapSummaryService(
                 regionRepository,
                 regionMapSummaryRepository,
-                levelPolicy
+                levelPolicy,
+                tagService
         );
     }
 


### PR DESCRIPTION
## 요약

- 여행 기록 목록을 선택한 사용자 태그로 필터링합니다.
- Region 지도 요약을 선택한 사용자 태그로 필터링합니다.
- 조회 전에 `tagId`가 현재 회원 소유인지 검증합니다.

## 이 PR에서 볼 범위

- 기록 목록 API의 선택적 `tagId`
- 지도 루트·하위 Region 요약 API의 선택적 `tagId`
- `travel_record_tag`를 이용한 태그별 기록 조회
- 태그가 연결된 기록만 집계하는 지도 요약 쿼리
- 컨트롤러·서비스·Repository 테스트

## Stacked PR

- 선행: #111
- 선행: 사용자 태그 CRUD와 V15
- 선행: 여행 기록-태그 연결과 V16
- 현재: 태그 기반 기록·지도 필터

바로 앞 PR이 병합되면 이 PR의 base를 `main`으로 변경합니다.

## 확인

- 전체 백엔드 테스트 135개 통과
- 실패 0, 오류 0
- `git diff --check` 통과
