### PR TITLE
fix: 대한민국 지도 이동 경계 추가

### DIFF
--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapArtwork.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapArtwork.kt
@@ -80,8 +80,13 @@ fun KoreaMapArtwork(
                     panZoomLock = true,
                 ) { _, panChange, zoomChange, _ ->
                     val transform = currentTransform.value
-                    zoom = (transform.zoom * zoomChange).coerceIn(MinZoom, MaxZoom)
-                    pan = transform.pan + panChange
+                    val nextZoom = (transform.zoom * zoomChange).coerceIn(MinZoom, MaxZoom)
+                    zoom = nextZoom
+                    pan = projection.clampPan(
+                        pan = transform.pan + panChange,
+                        zoom = nextZoom,
+                        viewportSize = viewportSize,
+                    )
                 }
             }
             .pointerInput(viewportSize, projection, zoom, pan) {
@@ -207,6 +212,8 @@ private data class KoreaProjection(
     private val scale: Float,
     private val left: Float,
     private val top: Float,
+    private val mapWidth: Float,
+    private val mapHeight: Float,
     val isValid: Boolean,
 ) {
     fun project(point: GeoPoint): Offset = Offset(
@@ -232,12 +239,22 @@ private data class KoreaProjection(
         )
     }
 
+    fun clampPan(pan: Offset, zoom: Float, viewportSize: IntSize): Offset = clampKoreaMapPan(
+        pan = pan,
+        zoom = zoom,
+        viewportSize = viewportSize,
+        mapLeft = left,
+        mapTop = top,
+        mapWidth = mapWidth,
+        mapHeight = mapHeight,
+    )
+
     companion object {
         fun from(bounds: KoreaBounds, viewportSize: IntSize): KoreaProjection {
             val longitudeSpan = bounds.maxLongitude - bounds.minLongitude
             val latitudeSpan = bounds.maxLatitude - bounds.minLatitude
             if (viewportSize.width <= 0 || viewportSize.height <= 0 || longitudeSpan <= 0f || latitudeSpan <= 0f) {
-                return KoreaProjection(bounds, 1f, 0f, 0f, 0f, false)
+                return KoreaProjection(bounds, 1f, 0f, 0f, 0f, 0f, 0f, false)
             }
 
             // Longitude degrees are physically shorter than latitude degrees in Korea.
@@ -260,9 +277,53 @@ private data class KoreaProjection(
             val left = (width - mapWidth) / 2f
             val top = ((height - mapHeight) / 2f - height * 0.07f)
                 .coerceAtLeast(verticalPadding)
-            return KoreaProjection(bounds, longitudeFactor, scale, left, top, true)
+            return KoreaProjection(bounds, longitudeFactor, scale, left, top, mapWidth, mapHeight, true)
         }
     }
+}
+
+internal fun clampKoreaMapPan(
+    pan: Offset,
+    zoom: Float,
+    viewportSize: IntSize,
+    mapLeft: Float,
+    mapTop: Float,
+    mapWidth: Float,
+    mapHeight: Float,
+): Offset {
+    if (viewportSize.width <= 0 || viewportSize.height <= 0 || zoom <= 0f) return pan
+
+    val centerX = viewportSize.width / 2f
+    val centerY = viewportSize.height / 2f
+    val transformedLeft = centerX + (mapLeft - centerX) * zoom
+    val transformedRight = centerX + (mapLeft + mapWidth - centerX) * zoom
+    val transformedTop = centerY + (mapTop - centerY) * zoom
+    val transformedBottom = centerY + (mapTop + mapHeight - centerY) * zoom
+
+    return Offset(
+        x = clampMapAxis(
+            value = pan.x,
+            leading = transformedLeft,
+            trailing = transformedRight,
+            viewportSize = viewportSize.width.toFloat(),
+        ),
+        y = clampMapAxis(
+            value = pan.y,
+            leading = transformedTop,
+            trailing = transformedBottom,
+            viewportSize = viewportSize.height.toFloat(),
+        ),
+    )
+}
+
+private fun clampMapAxis(
+    value: Float,
+    leading: Float,
+    trailing: Float,
+    viewportSize: Float,
+): Float {
+    if (trailing - leading <= viewportSize) return 0f
+    return value.coerceIn(viewportSize - trailing, -leading)
 }
 
 internal fun List<ProvincePolygon>.regionAt(point: GeoPoint): ProvincePolygon? =

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapArtwork.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapArtwork.kt
@@ -178,7 +178,8 @@ private data class MapTransform(
 )
 
 private const val MinZoom = 1f
-private const val MaxZoom = 4f
+private const val MaxZoom = 6f
+private const val PanSlackFraction = 0.1f
 
 @Composable
 fun KoreaMapStatusMessage(
@@ -306,12 +307,14 @@ internal fun clampKoreaMapPan(
             leading = transformedLeft,
             trailing = transformedRight,
             viewportSize = viewportSize.width.toFloat(),
+            slack = viewportSize.width * PanSlackFraction,
         ),
         y = clampMapAxis(
             value = pan.y,
             leading = transformedTop,
             trailing = transformedBottom,
             viewportSize = viewportSize.height.toFloat(),
+            slack = viewportSize.height * PanSlackFraction,
         ),
     )
 }
@@ -321,9 +324,10 @@ private fun clampMapAxis(
     leading: Float,
     trailing: Float,
     viewportSize: Float,
+    slack: Float,
 ): Float {
-    if (trailing - leading <= viewportSize) return 0f
-    return value.coerceIn(viewportSize - trailing, -leading)
+    if (trailing - leading <= viewportSize) return value.coerceIn(-slack, slack)
+    return value.coerceIn(viewportSize - trailing - slack, -leading + slack)
 }
 
 internal fun List<ProvincePolygon>.regionAt(point: GeoPoint): ProvincePolygon? =

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/WorldGlobe.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/WorldGlobe.kt
@@ -191,9 +191,9 @@ internal fun WorldGlobe(
 
 private val InitialLongitude = -127f * PI.toFloat() / 180f
 private const val RotationSensitivity = 1.35f
-private const val MaxTilt = 1.15f
+private const val MaxTilt = 1.3f
 private const val MinZoom = 0.75f
-private const val MaxZoom = 4f
+private const val MaxZoom = 6f
 
 
 private fun countryAtScreenPoint(

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapPanBoundsTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapPanBoundsTest.kt
@@ -1,0 +1,40 @@
+package com.mapmory.shared.presentation.map.ui
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KoreaMapPanBoundsTest {
+    @Test
+    fun `map smaller than viewport stays at its initial position`() {
+        val result = clampKoreaMapPan(
+            pan = Offset(500f, -500f),
+            zoom = 1f,
+            viewportSize = IntSize(1000, 800),
+            mapLeft = 100f,
+            mapTop = 100f,
+            mapWidth = 800f,
+            mapHeight = 600f,
+        )
+
+        assertEquals(0f, result.x, 0.001f)
+        assertEquals(0f, result.y, 0.001f)
+    }
+
+    @Test
+    fun `zoomed map cannot be dragged completely outside viewport`() {
+        val result = clampKoreaMapPan(
+            pan = Offset(10_000f, -10_000f),
+            zoom = 2f,
+            viewportSize = IntSize(1000, 800),
+            mapLeft = 100f,
+            mapTop = 100f,
+            mapWidth = 800f,
+            mapHeight = 600f,
+        )
+
+        assertEquals(300f, result.x, 0.001f)
+        assertEquals(-200f, result.y, 0.001f)
+    }
+}

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapPanBoundsTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapPanBoundsTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 
 class KoreaMapPanBoundsTest {
     @Test
-    fun `map smaller than viewport stays at its initial position`() {
+    fun `map smaller than viewport can move within the slack boundary`() {
         val result = clampKoreaMapPan(
             pan = Offset(500f, -500f),
             zoom = 1f,
@@ -18,8 +18,8 @@ class KoreaMapPanBoundsTest {
             mapHeight = 600f,
         )
 
-        assertEquals(0f, result.x, 0.001f)
-        assertEquals(0f, result.y, 0.001f)
+        assertEquals(100f, result.x, 0.001f)
+        assertEquals(-80f, result.y, 0.001f)
     }
 
     @Test
@@ -34,7 +34,7 @@ class KoreaMapPanBoundsTest {
             mapHeight = 600f,
         )
 
-        assertEquals(300f, result.x, 0.001f)
-        assertEquals(-200f, result.y, 0.001f)
+        assertEquals(400f, result.x, 0.001f)
+        assertEquals(-280f, result.y, 0.001f)
     }
 }


### PR DESCRIPTION
## 변경 내용

- 대한민국 지도 드래그 범위에 화면 크기의 10% 여유 폭을 추가했습니다.
- 지도 크기가 화면보다 작을 때도 같은 여유 범위 내에서 이동할 수 있습니다.
- 대한민국·전세계 지도 최대 확대를 4배에서 6배로 늘렸습니다.
- 전세계 지도 세로 회전 범위를 소폭 확장했습니다.
- 세계 지도 외 기존 동작은 유지했습니다.

## 테스트

- `cd client && ./gradlew :shared:jvmTest`
- `cd client && ./gradlew :androidApp:assembleDebug`

두 명령 모두 `BUILD SUCCESSFUL`을 확인했습니다.

## 참고

- 기존 미커밋 문서와 임시 파일은 포함하지 않았습니다.
