### PR TITLE
fix: 전세계 지도 확대 범위 확장

### DIFF
--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/WorldGlobe.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/WorldGlobe.kt
@@ -193,7 +193,7 @@ private val InitialLongitude = -127f * PI.toFloat() / 180f
 private const val RotationSensitivity = 1.35f
 private const val MaxTilt = 1.3f
 private const val MinZoom = 0.75f
-private const val MaxZoom = 6f
+private const val MaxZoom = 8f
 
 
 private fun countryAtScreenPoint(


### PR DESCRIPTION
## 변경 내용
- 전세계 지도 최대 확대 배율을 6배에서 8배로 확장했습니다.
- 기존 회전, 기울기, 국가 선택 동작은 변경하지 않았습니다.

## 검증
- `./gradlew :androidApp:assembleDebug`

## 참고
- 지도 확대 변경만 포함한 별도 PR입니다.