### PR TITLE
feat: 백엔드 로깅 및 메트릭 기반 구축

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,10 @@ DB_PASSWORD=
 # 생성: openssl rand -hex 32
 JWT_SECRET=
 
+# --- 애플리케이션 메타데이터 ---
+# 운영 배포 시 Git commit SHA 또는 릴리스 버전으로 변경한다
+APP_VERSION=unknown
+
 # --- S3 ---
 AWS_S3_BUCKET=
 AWS_REGION=ap-northeast-2

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,6 +21,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-restclient'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/docs/adr/0014-application-logging-and-metrics.md
+++ b/backend/docs/adr/0014-application-logging-and-metrics.md
@@ -2,6 +2,7 @@
 
 - 상태: 채택
 - 날짜: 2026-08-23
+- 최종 갱신: 2026-08-24
 - 관련: ADR 0001, ADR 0002, ADR 0006
 
 ---
@@ -22,6 +23,21 @@ Mapmory는 Spring Boot 기본 로깅과 Micrometer·Actuator·Prometheus Registr
 
 이 ADR은 애플리케이션이 관측 데이터를 **생성하고 노출하는 단계**까지만 결정한다.
 CloudWatch Agent, 로그 그룹, 대시보드와 알림 구성은 후속 작업으로 남긴다.
+
+## 현재 구현 요약
+
+| 영역 | 현재 구현 | 확인 위치 |
+| --- | --- | --- |
+| 외부 HTTP | Spring Boot가 자동 구성한 `RestClient.Builder`를 사용해 연결·읽기 타임아웃과 `http.client.requests`를 적용한다. | `KakaoClientConfig`, `application.yaml` |
+| 요청 추적 | 모든 요청에 UUID 형식의 `X-Request-Id`를 부여하고 MDC의 `requestId`에 저장한 뒤 요청 종료 시 제거한다. | `RequestIdFilter` |
+| 예외 로그 | 미처리 예외, 응답값 검증 실패, `SERVICE_UNAVAILABLE`을 원인 예외와 함께 `ERROR`로 기록한다. 예상 가능한 비즈니스 예외는 `DEBUG`로 기록한다. | `common/handler` |
+| 로그 형식 | 로컬은 사람이 읽는 콘솔 패턴, 운영은 Spring Boot Logstash JSON 형식을 사용한다. | `application.yaml`, `application-prod.yaml` |
+| HTTP 메트릭 | `http.server.requests`를 7개 SLO 경계로 집계하고 `uri` 태그 값은 최대 50개까지만 등록한다. | `MetricsConfiguration`, `application.yaml` |
+| 내부 작업 메트릭 | `mapmory.operation.duration`으로 미디어 동기화, 지도 요약 쿼리, S3 Presigned URL 생성 시간을 성공·실패별로 기록한다. | `OperationTimer`, `MonitoredOperation` |
+| 메트릭 노출 | `health`, `prometheus`만 읽기 전용으로 노출한다. 운영에서는 `127.0.0.1:8081`로 관리 포트를 분리한다. | `application.yaml`, `application-prod.yaml` |
+
+현재 애플리케이션이 생성하고 노출하는 단계까지 구현되어 있다. CloudWatch 수집·저장·대시보드·알림은
+아직 구현하지 않았다.
 
 ## 결정
 
@@ -56,18 +72,19 @@ Servlet Filter에서 요청별 Request ID를 결정한다.
 2. 헤더가 없거나 유효하지 않으면 서버가 UUID를 생성한다.
 3. 값을 MDC의 `requestId`에 넣어 같은 요청에서 발생하는 모든 로그에 자동으로 포함한다.
 4. 응답의 `X-Request-Id` 헤더에도 같은 값을 넣는다.
-5. 요청 처리가 끝나면 `finally`에서 MDC를 반드시 비운다. 스레드 풀에서 이전 요청의 값이
-   다음 요청으로 누출되는 것을 막기 위함이다.
+5. `MDC.putCloseable()`과 try-with-resources를 사용해 요청 처리가 끝나면 MDC 값을 제거한다.
+   정상·예외 흐름 모두에서 정리하여 스레드 풀의 다음 요청으로 값이 누출되지 않게 한다.
 
 예를 들어 여행 기록 생성 중 미디어 저장이 실패하면 다음 로그가 같은 요청임을 알 수 있다.
 
 ```text
-INFO  requestId=abc123 api=TRAVEL_RECORD_CREATE operation=REGION_RESOLVE
-ERROR requestId=abc123 api=TRAVEL_RECORD_CREATE operation=MEDIA_SAVE errorCode=DB_ERROR
+INFO  requestId=550e8400-e29b-41d4-a716-446655440000 ...
+ERROR requestId=550e8400-e29b-41d4-a716-446655440000 event=BUSINESS_EXCEPTION errorCode=SERVICE_UNAVAILABLE
 ```
 
-클라이언트가 오류와 함께 `X-Request-Id: abc123`을 전달하면 개발자는 `requestId=abc123`으로
-요청 전체를 검색할 수 있다. Request ID는 추적용 로그 필드이며 메트릭 태그로 사용하지 않는다.
+클라이언트가 오류와 함께 `X-Request-Id: 550e8400-e29b-41d4-a716-446655440000`을 전달하면
+개발자는 같은 `requestId`로 요청 로그를 검색할 수 있다. Request ID는 추적용 로그 필드이며
+메트릭 태그로 사용하지 않는다.
 
 ### 운영 로그는 구조화된 JSON으로 출력한다
 
@@ -80,14 +97,16 @@ Logstash JSON 형식을 사용한다. 별도 로깅 인코더 의존성은 추�
 | --- | --- |
 | `service`, `environment`, `version` | 실행 환경과 배포 버전 식별 |
 | `requestId` | 단일 요청 추적 |
-| `event` | `TRAVEL_RECORD_CREATED`와 같은 사건 식별 |
-| `api`, `operation` | API와 내부 처리 단계 식별 |
-| `outcome` | `SUCCESS` 또는 `FAILURE` |
-| `errorCode`, `exceptionClass` | 실패 유형 식별 |
-| `memberId`, `travelRecordId`, `mediaCount` | 필요한 최소한의 업무 문맥 |
+| `event` | `BUSINESS_EXCEPTION`, `UNHANDLED_EXCEPTION`, `RESPONSE_VALIDATION_FAILED`와 같은 사건 식별 |
+| `errorCode` | 비즈니스 실패 유형 식별 |
+| `status`, `httpMethod`, `uri` | 실패한 HTTP 요청의 최소 문맥 |
+| `stack_trace` | 원인 예외가 필요한 `ERROR` 로그의 스택 트레이스 |
 
 문장 안에 값을 섞은 비구조 로그와 달리 JSON 로그는 수집기가 정규식 없이 필드별 검색과
 집계를 할 수 있다. MDC 값과 SLF4J fluent API의 key-value를 JSON 필드로 기록한다.
+
+현재 구조화 필드는 예외 처리 경계부터 적용한다. 업무 이벤트 로그와 `memberId`,
+`travelRecordId` 같은 추가 문맥 필드는 실제 운영 검색 요구가 확인된 뒤 최소 범위로 확장한다.
 
 다음 값은 로그에 기록하지 않는다.
 
@@ -102,33 +121,50 @@ Spring MVC가 자동 생성하는 `http.server.requests`를 요청 수, HTTP 상
 기준으로 사용한다. URI는 `/travel-records/{id}`처럼 템플릿으로 집계하고 실제 ID가 포함된
 경로를 태그로 만들지 않는다.
 
-중요 API에 한해 히스토그램 또는 제한된 SLO 버킷을 활성화하여 p95 지연 시간을 계산한다.
-초기 대상은 다음과 같다.
+사전 정의된 percentile histogram은 사용하지 않고 다음 7개의 고정 SLO 누적 버킷만 노출한다.
 
-- 카카오 로그인
-- 여행 기록 생성·수정·상세·목록 조회
-- Region 지도 요약 조회
-- Presigned URL 발급
+```text
+100ms, 300ms, 500ms, 1s, 2s, 3s, 5s
+```
+
+버킷 수를 예측 가능하게 유지하는 대신 p95·p99 근사 정밀도는 이 경계의 간격에 제한된다.
+`http.server.requests`의 `uri` 태그는 `MeterFilter.maximumAllowableTags`로 서로 다른 값 50개까지만
+등록한다. 51번째 새로운 URI 값부터는 요청 자체를 막지 않고 해당 메트릭 등록과 측정만 거부한다.
+이 제한은 비정상 URI 유입으로 인한 메모리·시계열 증가를 막는 안전장치이며, URI 템플릿 집계가
+깨진 근본 원인을 대신하지 않는다.
 
 ### 중요한 내부 작업은 Micrometer Timer로 측정한다
 
-전체 API 응답 시간만으로 병목 지점을 알 수 없는 작업에 `Timer` 또는 `Observation`을 적용한다.
-측정 구간 진입 시 시간을 시작하고, 성공 또는 예외가 결정된 뒤 `finally`에서 해당 Timer를
-종료하여 실패 시에도 측정이 누락되지 않게 한다.
+전체 API 응답 시간만으로 병목 지점을 알 수 없는 작업에 공통 `OperationTimer`를 적용한다.
+`Supplier<T>`로 작업을 전달하고 `Timer.Sample`로 시간을 시작한다. 정상 반환 시 `SUCCESS`,
+`RuntimeException` 또는 `Error` 발생 시 `FAILURE` Timer를 종료한 뒤 원래 결과나 예외를 그대로
+전달한다. 따라서 계측이 기존 업무 흐름을 변경하지 않는다.
 
 공통 메트릭 이름은 `mapmory.operation.duration`으로 하고 다음의 제한된 태그만 사용한다.
 
-- `api`: `KAKAO_LOGIN`, `TRAVEL_RECORD_CREATE` 등 고정된 API 식별자
-- `operation`: `KAKAO_API`, `REGION_RESOLVE`, `TRAVEL_RECORD_SAVE`, `MEDIA_SYNC`,
-  `MAP_SUMMARY_QUERY`, `S3_PRESIGN` 등 고정된 단계
+- `operation`: `MonitoredOperation` enum의 `MEDIA_SYNC`, `MAP_SUMMARY_QUERY`, `S3_PRESIGN`
 - `outcome`: `SUCCESS`, `FAILURE`
 
-측정 대상은 외부 API 호출, DB 쿼리·저장, 트랜잭션의 중요한 단계, 성능 병목 가능성이 있는
-작업으로 제한한다. 모든 private 메서드나 단순 값 변환은 측정하지 않는다.
+현재 측정 경계는 다음과 같다.
+
+| operation | 시작과 종료 | 포함하지 않는 범위 | 주의점 |
+| --- | --- | --- | --- |
+| `MEDIA_SYNC` | 미디어 동기화 시작부터 `travelRecordRepository.flush()` 완료까지 | 앞선 여행 기록·미디어 조회와 검증, 응답 DTO 변환 | `flush()`는 현재 영속성 컨텍스트의 다른 미반영 변경도 함께 DB에 반영할 수 있다. |
+| `MAP_SUMMARY_QUERY` | 지도 요약 Repository 호출 시작부터 조회 결과 반환까지 | 부모 Region 검증, 조회 결과의 응답 DTO 변환 | DB 조회 병목만 분리해 본다. |
+| `S3_PRESIGN` | AWS SDK Presigner 호출부터 URI 생성 완료까지 | 클라이언트의 실제 S3 업로드와 네트워크 전송 | Presigned URL 생성은 서버 내부 서명 작업이다. |
+
+내부 작업에는 다음 8개의 고정 SLO 누적 버킷을 적용한다.
+
+```text
+10ms, 50ms, 100ms, 300ms, 500ms, 1s, 3s, 5s
+```
+
+새 측정 대상은 모든 private 메서드에 일괄 적용하지 않는다. 외부 시스템, DB, 중요한 업무 단계처럼
+운영 중 병목 원인을 분리할 가치가 있는 구간만 `MonitoredOperation` enum에 추가한다.
 
 Timer는 요청별 원본 시간을 저장하는 대신 호출 횟수, 총 시간, 평균, 최대값과 설정한
-히스토그램을 집계한다. 개별 실패의 상세 원인은 동일한 `api`, `operation`, `requestId`를 가진
-구조화 로그에서 확인한다.
+히스토그램을 집계한다. `operation`과 `outcome`은 메트릭 집계용이며 `requestId`는 넣지 않는다.
+개별 실패의 상세 원인은 같은 시간대의 `requestId`가 있는 구조화 로그에서 확인한다.
 
 ### 메트릭의 카디널리티를 제한한다
 
@@ -141,7 +177,7 @@ CloudWatch 요금이 발생하지 않는다. 다만 메트릭 시계열은 애�
 
 허용:
 
-- API·operation의 고정 enum 성격 값
+- `operation`의 고정 enum 값
 - `SUCCESS`·`FAILURE`
 - HTTP 메서드, 상태 코드 또는 상태 코드 그룹
 
@@ -151,9 +187,9 @@ CloudWatch 요금이 발생하지 않는다. 다만 메트릭 시계열은 애�
 - 실제 URI, 파일명, object key
 - 예외 메시지나 임의 문자열
 
-히스토그램은 p95가 실제로 필요한 중요 Timer에만 사용하고, 예상 최솟값·최댓값 또는 SLO
-버킷을 제한한다. CloudWatch 전송 전에는 노출되는 메트릭과 시계열 수를 확인하고 수집 대상
-allowlist를 별도로 정한다.
+히스토그램은 운영 판단에 필요한 HTTP 요청과 중요 내부 Timer에만 사용하고 SLO 버킷을 제한한다.
+CloudWatch 전송 전에는 노출되는 메트릭과 시계열 수를 확인하고 수집 대상 allowlist를 별도로
+정한다.
 
 ### Prometheus 서버는 현재 EC2에 설치하지 않는다
 
@@ -164,15 +200,68 @@ allowlist를 별도로 정한다.
 후속 CloudWatch 작업에서 CloudWatch Agent가 이 엔드포인트를 주기적으로 읽어 필요한 메트릭만
 전송한다.
 
-## 적용 순서
+## 확인 방법
 
-1. 로그 레벨과 민감정보 정책을 기존 예외 처리기에 반영한다.
-2. Request ID Filter와 MDC 정리 로직을 추가한다.
-3. 운영 프로필에서 JSON 구조화 로그를 활성화한다.
-4. 기존 `http.server.requests`와 Prometheus 노출 결과를 검증한다.
-5. 중요 내부 작업에 `mapmory.operation.duration` Timer를 추가한다.
-6. 히스토그램 범위와 태그 카디널리티를 테스트한다.
-7. CloudWatch Agent·대시보드·알림은 후속 작업으로 진행한다.
+### Request ID
+
+로컬 서버 실행 후 응답 헤더를 확인한다.
+
+```bash
+curl -i http://localhost:8080/health
+```
+
+응답에 UUID 형식의 `X-Request-Id`가 있어야 한다. 유효한 UUID를 요청 헤더로 전달하면 응답에도
+같은 값이 반환되어야 한다.
+
+```bash
+curl -i \
+  -H 'X-Request-Id: 550e8400-e29b-41d4-a716-446655440000' \
+  http://localhost:8080/health
+```
+
+### Prometheus 메트릭
+
+```bash
+curl -s http://localhost:8080/actuator/prometheus \
+  | grep -E 'http_server_requests_seconds|mapmory_operation_duration_seconds'
+```
+
+`mapmory.operation.duration`은 해당 업무 기능을 한 번 이상 실행한 뒤 생성된다. 주요 출력은 다음과
+같다.
+
+| Prometheus suffix | 의미 |
+| --- | --- |
+| `_count` | 작업 실행 횟수 |
+| `_sum` | 누적 실행 시간(초) |
+| `_max` | 관측 구간의 최대 실행 시간(초) |
+| `_bucket` | `le` 경계 이하로 완료된 누적 횟수 |
+
+내부 작업은 `operation`, `outcome` 태그로 구분한다.
+
+```text
+mapmory_operation_duration_seconds_count{operation="MEDIA_SYNC",outcome="SUCCESS",...} 3
+mapmory_operation_duration_seconds_count{operation="S3_PRESIGN",outcome="FAILURE",...} 1
+```
+
+### 새 내부 작업을 계측할 때
+
+1. `MonitoredOperation`에 종류가 제한된 enum 값을 추가한다.
+2. 병목을 구분할 수 있는 최소 코드 구간만 `operationTimer.record(...)`로 감싼다.
+3. 사용자 ID, 실제 URI, object key, 예외 메시지를 태그로 넣지 않는다.
+4. 성공 시 결과가 그대로 반환되고 실패 시 원래 예외가 다시 전달되는지 테스트한다.
+5. `/actuator/prometheus`에서 `operation`, `outcome`, SLO 버킷을 확인한다.
+
+## 구현 상태
+
+- [x] 로그 레벨과 민감정보 정책을 예외 처리기에 반영
+- [x] Request ID Filter와 요청 종료 시 MDC 정리
+- [x] 운영 프로필의 Logstash JSON 구조화 로그
+- [x] 자동 구성된 `RestClient` 외부 HTTP 메트릭과 타임아웃
+- [x] `http.server.requests`의 고정 SLO 버킷과 URI 태그 상한
+- [x] `mapmory.operation.duration`과 초기 3개 내부 작업 계측
+- [x] 성공·실패 Timer, SLO 설정, URI 카디널리티 테스트
+- [ ] CloudWatch Agent 수집 설정과 전송 메트릭 allowlist
+- [ ] CloudWatch 대시보드와 알림 기준
 
 ## 검토한 대안
 
@@ -201,7 +290,8 @@ allowlist를 별도로 정한다.
 
 ### 장점
 
-- 대시보드에서 이상을 발견한 뒤 같은 API·operation·Request ID의 로그로 원인을 좁힐 수 있다.
+- 메트릭의 `operation`·`outcome`으로 이상 구간을 찾고, 같은 시간대와 요청 경로의 Request ID
+  로그로 개별 실패 원인을 좁힐 수 있다.
 - 로그 레벨이 운영 의미에 맞게 통일되고 일반적인 4xx가 장애 로그를 오염시키지 않는다.
 - API 전체 지연과 내부 병목 지점을 함께 관찰할 수 있다.
 - 메트릭 태그와 히스토그램 증가를 제한해 JVM 메모리와 후속 CloudWatch 비용을 통제한다.

--- a/backend/docs/adr/0014-application-logging-and-metrics.md
+++ b/backend/docs/adr/0014-application-logging-and-metrics.md
@@ -33,7 +33,7 @@ CloudWatch Agent, 로그 그룹, 대시보드와 알림 구성은 후속 작업�
 | 예외 로그 | 미처리 예외, 응답값 검증 실패, `SERVICE_UNAVAILABLE`을 원인 예외와 함께 `ERROR`로 기록한다. 예상 가능한 비즈니스 예외는 `DEBUG`로 기록한다. | `common/handler` |
 | 로그 형식 | 로컬은 사람이 읽는 콘솔 패턴, 운영은 Spring Boot Logstash JSON 형식을 사용한다. | `application.yaml`, `application-prod.yaml` |
 | HTTP 메트릭 | `http.server.requests`를 7개 SLO 경계로 집계하고 `uri` 태그 값은 최대 50개까지만 등록한다. | `MetricsConfiguration`, `application.yaml` |
-| 내부 작업 메트릭 | `mapmory.operation.duration`으로 미디어 동기화, 지도 요약 쿼리, S3 Presigned URL 생성 시간을 성공·실패별로 기록한다. | `OperationTimer`, `MonitoredOperation` |
+| 내부 작업 메트릭 | `mapmory.operation.duration`으로 미디어 동기화와 지도 요약 쿼리 시간을 성공·실패별로 기록한다. | `OperationTimer`, `MonitoredOperation` |
 | 메트릭 노출 | `health`, `prometheus`만 읽기 전용으로 노출한다. 운영에서는 `127.0.0.1:8081`로 관리 포트를 분리한다. | `application.yaml`, `application-prod.yaml` |
 
 현재 애플리케이션이 생성하고 노출하는 단계까지 구현되어 있다. CloudWatch 수집·저장·대시보드·알림은
@@ -142,7 +142,7 @@ Spring MVC가 자동 생성하는 `http.server.requests`를 요청 수, HTTP 상
 
 공통 메트릭 이름은 `mapmory.operation.duration`으로 하고 다음의 제한된 태그만 사용한다.
 
-- `operation`: `MonitoredOperation` enum의 `MEDIA_SYNC`, `MAP_SUMMARY_QUERY`, `S3_PRESIGN`
+- `operation`: `MonitoredOperation` enum의 `MEDIA_SYNC`, `MAP_SUMMARY_QUERY`
 - `outcome`: `SUCCESS`, `FAILURE`
 
 현재 측정 경계는 다음과 같다.
@@ -151,7 +151,6 @@ Spring MVC가 자동 생성하는 `http.server.requests`를 요청 수, HTTP 상
 | --- | --- | --- | --- |
 | `MEDIA_SYNC` | 미디어 동기화 시작부터 `travelRecordRepository.flush()` 완료까지 | 앞선 여행 기록·미디어 조회와 검증, 응답 DTO 변환 | `flush()`는 현재 영속성 컨텍스트의 다른 미반영 변경도 함께 DB에 반영할 수 있다. |
 | `MAP_SUMMARY_QUERY` | 지도 요약 Repository 호출 시작부터 조회 결과 반환까지 | 부모 Region 검증, 조회 결과의 응답 DTO 변환 | DB 조회 병목만 분리해 본다. |
-| `S3_PRESIGN` | AWS SDK Presigner 호출부터 URI 생성 완료까지 | 클라이언트의 실제 S3 업로드와 네트워크 전송 | Presigned URL 생성은 서버 내부 서명 작업이다. |
 
 내부 작업에는 다음 8개의 고정 SLO 누적 버킷을 적용한다.
 
@@ -240,7 +239,7 @@ curl -s http://localhost:8080/actuator/prometheus \
 
 ```text
 mapmory_operation_duration_seconds_count{operation="MEDIA_SYNC",outcome="SUCCESS",...} 3
-mapmory_operation_duration_seconds_count{operation="S3_PRESIGN",outcome="FAILURE",...} 1
+mapmory_operation_duration_seconds_count{operation="MAP_SUMMARY_QUERY",outcome="FAILURE",...} 1
 ```
 
 ### 새 내부 작업을 계측할 때
@@ -258,7 +257,7 @@ mapmory_operation_duration_seconds_count{operation="S3_PRESIGN",outcome="FAILURE
 - [x] 운영 프로필의 Logstash JSON 구조화 로그
 - [x] 자동 구성된 `RestClient` 외부 HTTP 메트릭과 타임아웃
 - [x] `http.server.requests`의 고정 SLO 버킷과 URI 태그 상한
-- [x] `mapmory.operation.duration`과 초기 3개 내부 작업 계측
+- [x] `mapmory.operation.duration`과 초기 2개 내부 작업 계측
 - [x] 성공·실패 Timer, SLO 설정, URI 카디널리티 테스트
 - [ ] CloudWatch Agent 수집 설정과 전송 메트릭 allowlist
 - [ ] CloudWatch 대시보드와 알림 기준

--- a/backend/docs/adr/0014-application-logging-and-metrics.md
+++ b/backend/docs/adr/0014-application-logging-and-metrics.md
@@ -1,0 +1,235 @@
+# ADR 0014. 애플리케이션 로그와 메트릭에 공통 관측 규칙을 적용한다
+
+- 상태: 채택
+- 날짜: 2026-08-23
+- 관련: ADR 0001, ADR 0002, ADR 0006
+
+---
+
+## 문제
+
+Mapmory는 Spring Boot 기본 로깅과 Micrometer·Actuator·Prometheus Registry를 사용한다.
+현재 예상하지 못한 예외와 일부 비즈니스 예외는 로그로 남고, HTTP·JVM 메트릭은
+`/actuator/prometheus`에 노출된다.
+
+그러나 다음 운영 질문에 일관되게 답하기에는 정보가 부족하다.
+
+- 같은 HTTP 요청에서 발생한 여러 로그를 어떻게 연결하는가?
+- 어떤 사건을 `ERROR`, `WARN`, `INFO`, `DEBUG`로 기록하는가?
+- 어떤 API와 내부 작업이 느리거나 실패했는가?
+- 메트릭 태그가 무제한으로 늘어나는 것을 어떻게 방지하는가?
+- 로그와 메트릭을 이후 CloudWatch에서 안정적으로 검색·집계하려면 어떤 형식이 필요한가?
+
+이 ADR은 애플리케이션이 관측 데이터를 **생성하고 노출하는 단계**까지만 결정한다.
+CloudWatch Agent, 로그 그룹, 대시보드와 알림 구성은 후속 작업으로 남긴다.
+
+## 결정
+
+### 로그와 메트릭의 책임을 분리한다
+
+- **로그**는 개별 사건의 문맥과 실패 원인을 조사하는 데 사용한다.
+- **메트릭**은 요청 수, 오류율, 지연 시간처럼 시간에 따른 수치를 집계하는 데 사용한다.
+- **Prometheus 엔드포인트**는 Micrometer가 만든 메트릭을 외부 수집기가 읽을 수 있는
+  형식으로 노출한다. Prometheus 서버를 EC2에 설치하거나 데이터를 저장하는 역할은 하지 않는다.
+
+정상 요청마다 시작·종료 로그를 남겨 응답 시간을 계산하지 않는다. 전체 요청의 응답 시간과
+성공률은 메트릭으로 측정하고, 로그는 중요한 상태 변경과 실패에 집중한다.
+
+### 로그 레벨 경계를 통일한다
+
+| 레벨 | 경계 | Mapmory 예시 |
+| --- | --- | --- |
+| `ERROR` | 요청이 서버 내부 또는 의존 시스템 문제로 완료되지 못했고 개발자 조치가 필요하다. 원인 예외를 함께 기록한다. | 미처리 예외, DB·S3 실패, 컨트롤러 반환값 검증 실패, 카카오 장애로 인한 503 |
+| `WARN` | 서버는 동작하지만 보안·용량·반복 발생 여부를 관찰해야 한다. | 폐기된 refresh 토큰 재사용, 재시도 발생, DB 연결 대기 |
+| `INFO` | 정상 흐름 중 운영상 의미 있는 상태 변경이다. | 여행 기록 생성·수정·삭제, 신규 회원 생성, 서버 시작·종료 |
+| `DEBUG` | 예상 가능한 실패 또는 개발 중 필요한 상세 정보다. 운영 기본 설정에서는 출력하지 않는다. | 입력 오류, 리소스 없음, 일반적인 토큰 만료, 내부 분기 결과 |
+
+HTTP 상태만으로 로그 레벨을 기계적으로 정하지 않는다. 일반적인 4xx는 서버 장애가 아니므로
+`WARN`이나 `ERROR`로 남기지 않는다. 같은 예외의 스택 트레이스는 최종 처리 경계에서 한 번만
+기록한다.
+
+### 모든 HTTP 요청에 Request ID를 부여한다
+
+Servlet Filter에서 요청별 Request ID를 결정한다.
+
+1. 요청의 `X-Request-Id`가 허용된 길이와 형식이면 사용한다.
+2. 헤더가 없거나 유효하지 않으면 서버가 UUID를 생성한다.
+3. 값을 MDC의 `requestId`에 넣어 같은 요청에서 발생하는 모든 로그에 자동으로 포함한다.
+4. 응답의 `X-Request-Id` 헤더에도 같은 값을 넣는다.
+5. 요청 처리가 끝나면 `finally`에서 MDC를 반드시 비운다. 스레드 풀에서 이전 요청의 값이
+   다음 요청으로 누출되는 것을 막기 위함이다.
+
+예를 들어 여행 기록 생성 중 미디어 저장이 실패하면 다음 로그가 같은 요청임을 알 수 있다.
+
+```text
+INFO  requestId=abc123 api=TRAVEL_RECORD_CREATE operation=REGION_RESOLVE
+ERROR requestId=abc123 api=TRAVEL_RECORD_CREATE operation=MEDIA_SAVE errorCode=DB_ERROR
+```
+
+클라이언트가 오류와 함께 `X-Request-Id: abc123`을 전달하면 개발자는 `requestId=abc123`으로
+요청 전체를 검색할 수 있다. Request ID는 추적용 로그 필드이며 메트릭 태그로 사용하지 않는다.
+
+### 운영 로그는 구조화된 JSON으로 출력한다
+
+로컬 환경은 사람이 읽기 쉬운 기본 콘솔 형식을 유지하고, 운영 환경은 Spring Boot가 지원하는
+Logstash JSON 형식을 사용한다. 별도 로깅 인코더 의존성은 추가하지 않는다.
+
+공통 필드는 다음과 같다.
+
+| 필드 | 용도 |
+| --- | --- |
+| `service`, `environment`, `version` | 실행 환경과 배포 버전 식별 |
+| `requestId` | 단일 요청 추적 |
+| `event` | `TRAVEL_RECORD_CREATED`와 같은 사건 식별 |
+| `api`, `operation` | API와 내부 처리 단계 식별 |
+| `outcome` | `SUCCESS` 또는 `FAILURE` |
+| `errorCode`, `exceptionClass` | 실패 유형 식별 |
+| `memberId`, `travelRecordId`, `mediaCount` | 필요한 최소한의 업무 문맥 |
+
+문장 안에 값을 섞은 비구조 로그와 달리 JSON 로그는 수집기가 정규식 없이 필드별 검색과
+집계를 할 수 있다. MDC 값과 SLF4J fluent API의 key-value를 JSON 필드로 기록한다.
+
+다음 값은 로그에 기록하지 않는다.
+
+- access token, refresh token, 카카오 access token
+- Presigned URL과 요청·응답 전체 본문
+- 여행 제목·본문, 닉네임과 같은 불필요한 개인정보
+- 비밀번호, DB 연결 문자열, 암호화 키
+
+### HTTP 메트릭은 기존 자동 계측을 사용한다
+
+Spring MVC가 자동 생성하는 `http.server.requests`를 요청 수, HTTP 상태, 전체 응답 시간의
+기준으로 사용한다. URI는 `/travel-records/{id}`처럼 템플릿으로 집계하고 실제 ID가 포함된
+경로를 태그로 만들지 않는다.
+
+중요 API에 한해 히스토그램 또는 제한된 SLO 버킷을 활성화하여 p95 지연 시간을 계산한다.
+초기 대상은 다음과 같다.
+
+- 카카오 로그인
+- 여행 기록 생성·수정·상세·목록 조회
+- Region 지도 요약 조회
+- Presigned URL 발급
+
+### 중요한 내부 작업은 Micrometer Timer로 측정한다
+
+전체 API 응답 시간만으로 병목 지점을 알 수 없는 작업에 `Timer` 또는 `Observation`을 적용한다.
+측정 구간 진입 시 시간을 시작하고, 성공 또는 예외가 결정된 뒤 `finally`에서 해당 Timer를
+종료하여 실패 시에도 측정이 누락되지 않게 한다.
+
+공통 메트릭 이름은 `mapmory.operation.duration`으로 하고 다음의 제한된 태그만 사용한다.
+
+- `api`: `KAKAO_LOGIN`, `TRAVEL_RECORD_CREATE` 등 고정된 API 식별자
+- `operation`: `KAKAO_API`, `REGION_RESOLVE`, `TRAVEL_RECORD_SAVE`, `MEDIA_SYNC`,
+  `MAP_SUMMARY_QUERY`, `S3_PRESIGN` 등 고정된 단계
+- `outcome`: `SUCCESS`, `FAILURE`
+
+측정 대상은 외부 API 호출, DB 쿼리·저장, 트랜잭션의 중요한 단계, 성능 병목 가능성이 있는
+작업으로 제한한다. 모든 private 메서드나 단순 값 변환은 측정하지 않는다.
+
+Timer는 요청별 원본 시간을 저장하는 대신 호출 횟수, 총 시간, 평균, 최대값과 설정한
+히스토그램을 집계한다. 개별 실패의 상세 원인은 동일한 `api`, `operation`, `requestId`를 가진
+구조화 로그에서 확인한다.
+
+### 메트릭의 카디널리티를 제한한다
+
+Micrometer가 JVM 안에서 메트릭을 계산하거나 `/actuator/prometheus`로 노출하는 것 자체에는
+CloudWatch 요금이 발생하지 않는다. 다만 메트릭 시계열은 애플리케이션 메모리를 사용하고,
+후속 단계에서 CloudWatch로 전송하면 커스텀 메트릭과 데이터 수집 비용이 발생할 수 있다.
+
+메트릭 시계열은 대략 `메트릭 이름 × 태그 값 조합 × 히스토그램 버킷`만큼 늘어난다.
+따라서 값의 종류가 제한된 low-cardinality 태그만 허용한다.
+
+허용:
+
+- API·operation의 고정 enum 성격 값
+- `SUCCESS`·`FAILURE`
+- HTTP 메서드, 상태 코드 또는 상태 코드 그룹
+
+금지:
+
+- `requestId`, `memberId`, `travelRecordId`
+- 실제 URI, 파일명, object key
+- 예외 메시지나 임의 문자열
+
+히스토그램은 p95가 실제로 필요한 중요 Timer에만 사용하고, 예상 최솟값·최댓값 또는 SLO
+버킷을 제한한다. CloudWatch 전송 전에는 노출되는 메트릭과 시계열 수를 확인하고 수집 대상
+allowlist를 별도로 정한다.
+
+### Prometheus 서버는 현재 EC2에 설치하지 않는다
+
+운영 EC2는 `t4g.small` 한 대에서 Nginx와 Spring Boot를 실행할 계획이다. Prometheus 서버는
+수집뿐 아니라 로컬 시계열 DB와 WAL을 관리하므로 같은 인스턴스에 추가하지 않는다.
+
+애플리케이션은 현재처럼 운영 관리 포트의 `/actuator/prometheus`만 로컬 주소에 노출한다.
+후속 CloudWatch 작업에서 CloudWatch Agent가 이 엔드포인트를 주기적으로 읽어 필요한 메트릭만
+전송한다.
+
+## 적용 순서
+
+1. 로그 레벨과 민감정보 정책을 기존 예외 처리기에 반영한다.
+2. Request ID Filter와 MDC 정리 로직을 추가한다.
+3. 운영 프로필에서 JSON 구조화 로그를 활성화한다.
+4. 기존 `http.server.requests`와 Prometheus 노출 결과를 검증한다.
+5. 중요 내부 작업에 `mapmory.operation.duration` Timer를 추가한다.
+6. 히스토그램 범위와 태그 카디널리티를 테스트한다.
+7. CloudWatch Agent·대시보드·알림은 후속 작업으로 진행한다.
+
+## 검토한 대안
+
+### 모든 API의 시작과 종료를 INFO 로그로 남긴다
+
+채택하지 않았다. 정상 요청량에 비례해 로그 용량이 증가하고 중요한 사건이 묻힌다. 요청 수와
+응답 시간은 메트릭으로 집계한다.
+
+### Request ID와 사용자 ID를 메트릭 태그로 사용한다
+
+채택하지 않았다. 요청과 사용자 수만큼 시계열이 증가해 애플리케이션 메모리와 후속 수집 비용이
+통제되지 않는다. 고유 식별자는 로그에서만 검색한다.
+
+### 모든 메서드 실행 시간을 AOP로 자동 측정한다
+
+채택하지 않았다. 의미 없는 Timer와 태그 조합이 증가하고 병목 분석에 필요한 경계가 흐려진다.
+외부 시스템, DB, 중요한 업무 단계만 명시적으로 측정한다.
+
+### Prometheus와 Grafana를 운영 EC2에 함께 설치한다
+
+채택하지 않았다. 단일 2 GiB EC2에서 애플리케이션과 모니터링 저장소가 메모리·디스크를
+경쟁하고 운영 복잡도가 증가한다. Prometheus 형식만 유지하고 수집·저장은 관리형 CloudWatch로
+분리한다.
+
+## 결과
+
+### 장점
+
+- 대시보드에서 이상을 발견한 뒤 같은 API·operation·Request ID의 로그로 원인을 좁힐 수 있다.
+- 로그 레벨이 운영 의미에 맞게 통일되고 일반적인 4xx가 장애 로그를 오염시키지 않는다.
+- API 전체 지연과 내부 병목 지점을 함께 관찰할 수 있다.
+- 메트릭 태그와 히스토그램 증가를 제한해 JVM 메모리와 후속 CloudWatch 비용을 통제한다.
+- 애플리케이션 관측 규칙과 CloudWatch 인프라 구성을 분리해 단계적으로 도입할 수 있다.
+
+### 비용과 주의점
+
+- Filter, MDC, 구조화 로그와 내부 Timer 구현 및 테스트가 추가된다.
+- 비동기 실행으로 요청 문맥을 넘길 경우 MDC 전파를 별도로 처리해야 한다.
+- 로그에 내부 ID를 포함할 때도 접근 권한과 보관 기간을 제한해야 한다.
+- p95를 위한 히스토그램은 메모리와 시계열 수를 늘리므로 대상과 버킷을 제한해야 한다.
+- 로그만으로 완전한 감사 이력을 보장하지 않는다. 감사 로그 요구사항은 별도로 결정한다.
+
+## 검증 원칙
+
+- 요청에 `X-Request-Id`가 없으면 생성하고, 있으면 유효한 값만 수용한다.
+- 정상·예외 응답 모두 동일한 Request ID를 응답하고 요청 종료 후 MDC를 비운다.
+- 미처리 예외에는 Request ID와 원인 예외가 남고, 응답에는 내부 정보가 노출되지 않는다.
+- 운영 로그가 한 사건당 하나의 JSON 객체로 출력되며 민감정보를 포함하지 않는다.
+- 성공과 실패 모두 내부 Timer에 기록된다.
+- 메트릭 태그에 고유 식별자나 실제 URI가 포함되지 않는다.
+- `/actuator/prometheus`는 외부에 공개하지 않고 운영 관리 포트의 로컬 주소에서만 접근한다.
+
+## 참고
+
+- [Spring Boot: Logging](https://docs.spring.io/spring-boot/reference/features/logging.html)
+- [Spring Boot Actuator: Metrics](https://docs.spring.io/spring-boot/reference/actuator/metrics.html)
+- [Micrometer: Timers](https://docs.micrometer.io/micrometer/reference/concepts/timers.html)
+- [Prometheus: Storage](https://prometheus.io/docs/prometheus/latest/storage/)
+- [Amazon CloudWatch: Metrics concepts](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html)
+- [Amazon CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/)

--- a/backend/docs/adr/README.md
+++ b/backend/docs/adr/README.md
@@ -17,3 +17,4 @@ Mapmory 백엔드의 주요 설계 결정을 기록한다.
 | [0011](0010-social-login-and-member-identifier.md) | 소셜 로그인(카카오 토큰 검증)과 회원 식별자 분리 | 채택 |
 | [0012](0011-refresh-token-rotation.md) | refresh 토큰 해시 저장·회전·폐기와 재사용 감지 | 채택 |
 | [0013](0013-user-created-tags-and-travel-record-association.md) | 사용자 생성 태그와 여행 기록 연결 설계 | 채택 |
+| [0014](0014-application-logging-and-metrics.md) | 애플리케이션 로그와 메트릭 공통 관측 규칙 | 채택 |

--- a/backend/docs/logging-monitoring-team-guide.md
+++ b/backend/docs/logging-monitoring-team-guide.md
@@ -204,14 +204,13 @@ http.server.requests
 
 ### 직접 추가한 중요 작업 메트릭
 
-API 전체 시간만 보면 어느 내부 작업이 느린지 알기 어렵다. 그래서 다음 세 작업만 별도로
+API 전체 시간만 보면 어느 내부 작업이 느린지 알기 어렵다. 그래서 다음 두 작업만 별도로
 측정한다.
 
 | operation | 측정하는 작업 |
 | --- | --- |
 | `MEDIA_SYNC` | 여행 기록의 미디어 목록 동기화와 DB 반영 |
 | `MAP_SUMMARY_QUERY` | 지역별 지도 요약 DB 조회 |
-| `S3_PRESIGN` | S3 Presigned URL 생성 |
 
 공통 메트릭 이름은 다음과 같다.
 
@@ -399,7 +398,7 @@ curl -s http://localhost:8080/actuator/prometheus \
 - [x] Actuator Health와 Prometheus 엔드포인트
 - [x] HTTP 서버, JVM, HikariCP 자동 메트릭
 - [x] 카카오 RestClient 외부 요청 메트릭과 타임아웃
-- [x] 중요 내부 작업 3종의 성공·실패 시간 측정
+- [x] 중요 내부 작업 2종의 성공·실패 시간 측정
 - [x] 메트릭 공통 태그와 URI 태그 개수 제한
 - [x] 관련 단위·통합 테스트
 

--- a/backend/docs/logging-monitoring-team-guide.md
+++ b/backend/docs/logging-monitoring-team-guide.md
@@ -1,0 +1,434 @@
+# 팀원을 위한 Mapmory 로깅·모니터링 안내
+
+## 30초 요약
+
+Mapmory의 관측 기능은 다음 네 가지 역할로 나뉜다.
+
+| 기능 | 쉬운 비유 | 답할 수 있는 질문 |
+| --- | --- | --- |
+| 로그 | 사건 기록 | 이 요청은 왜 실패했나? |
+| Request ID | 요청마다 붙는 번호표 | 섞여 있는 로그 중 같은 요청은 무엇인가? |
+| 메트릭 | 숫자로 된 계기판 | 요청이 얼마나 많고, 느리고, 자주 실패하는가? |
+| Health Check | 생존 신호 | 애플리케이션과 연결된 구성요소가 살아 있는가? |
+
+애플리케이션이 로그와 메트릭을 **만드는 코드**는 구현되어 있다. 운영 로그는 파일로 남고,
+메트릭은 `/actuator/prometheus`에 노출된다.
+
+CloudWatch Agent, 로그 그룹, 대시보드와 알림 같은 **AWS 수집 환경은 아직 연결 전**이다.
+따라서 현재 상태를 “CloudWatch 모니터링이 완성됐다”고 이해하면 안 된다.
+
+## 먼저 알아둘 개념
+
+| 개념 | 짧은 설명 |
+| --- | --- |
+| 관측 가능성(Observability) | 외부로 드러나는 로그와 메트릭을 이용해 서비스 내부 상태를 이해하는 능력이다. |
+| 로그(Log) | 특정 시점에 발생한 사건을 문장과 필드로 기록한 데이터다. 개별 오류의 원인을 조사할 때 사용한다. |
+| 메트릭(Metric) | 요청 수, 오류 수, 실행 시간처럼 시간에 따라 변하는 숫자다. 서비스 전체 상태와 추세를 볼 때 사용한다. |
+| Request ID | HTTP 요청 하나에 붙이는 고유 번호다. 같은 요청에서 발생한 여러 로그를 연결한다. |
+| MDC | 현재 요청의 Request ID 같은 값을 잠시 보관해 같은 스레드에서 출력되는 로그에 자동으로 붙이는 저장 공간이다. |
+| 구조화 로그 | 로그를 단순 문장이 아니라 `requestId`, `status` 같은 필드가 있는 JSON으로 기록하는 방식이다. 필드별 검색이 쉽다. |
+| 로그 레벨 | 로그의 중요도를 나타내는 `ERROR`, `WARN`, `INFO`, `DEBUG` 구분이다. 운영에서는 중요한 로그만 남도록 조절한다. |
+| Spring Boot Actuator | Health와 메트릭처럼 운영에 필요한 정보를 제공하는 Spring Boot 기능이다. |
+| Micrometer | Java 코드와 라이브러리에서 메트릭을 측정하고 공통 형식으로 관리하는 도구다. |
+| Prometheus 형식 | Micrometer 메트릭을 외부 수집기가 읽을 수 있도록 표현하는 텍스트 형식이다. Mapmory는 `/actuator/prometheus`로 노출한다. |
+| Timer | 작업 실행 횟수와 걸린 시간을 함께 기록하는 Micrometer 메트릭이다. API와 중요 내부 작업의 지연 시간을 측정한다. |
+| 태그(Tag)·라벨(Label) | 메트릭을 `operation=MEDIA_SYNC`, `outcome=SUCCESS`처럼 분류하는 값이다. Prometheus에서는 주로 라벨이라고 부른다. |
+| 카디널리티 | 서로 다른 태그 값 조합의 개수다. 값이 무제한으로 늘면 메모리와 모니터링 비용도 커진다. |
+| 히스토그램·버킷 | 실행 시간을 `100ms 이하`, `500ms 이하`, `1초 이하` 같은 구간별 개수로 모으는 방식이다. |
+| p95 | 전체 요청 중 약 95%가 이 시간 안에 끝났다는 뜻이다. 평균으로 가려지는 느린 요청을 찾는 데 사용한다. |
+| Health Check | 애플리케이션이나 연결된 구성요소가 정상인지 간단한 상태로 확인하는 기능이다. |
+| CloudWatch | AWS의 메트릭·로그 저장, 검색, 대시보드와 알림 서비스다. 애플리케이션이 만든 데이터를 운영자가 보는 곳이다. |
+| CloudWatch Agent | EC2 안에서 시스템 메트릭과 로그 파일을 읽어 CloudWatch로 보내는 프로그램이다. |
+| SNS | CloudWatch 알람이 발생했을 때 이메일 같은 채널로 알림을 전달하는 AWS 서비스다. |
+
+도구의 관계만 간단히 정리하면 다음과 같다.
+
+```text
+Spring Boot Actuator + Micrometer
+    └─ 애플리케이션 메트릭을 만들고 노출
+
+RequestIdFilter + MDC + Logger
+    └─ 요청별 로그를 만들고 파일에 기록
+
+CloudWatch Agent
+    └─ EC2의 메트릭과 로그를 CloudWatch로 전송
+
+CloudWatch + SNS
+    └─ 저장·검색·대시보드·장애 알림
+```
+
+## 전체 흐름
+
+```text
+사용자 요청
+    │
+    ▼
+RequestIdFilter
+    ├─ 요청마다 Request ID 생성
+    ├─ 응답 헤더에 X-Request-Id 추가
+    └─ 같은 요청의 모든 로그에 Request ID 추가
+    │
+    ▼
+Controller → Service → Repository / Kakao / S3
+    │                    │
+    │                    └─ 중요한 작업 시간을 메트릭으로 기록
+    │
+    ├─ 정상 응답
+    └─ 예외 → ExceptionHandler가 오류 로그와 안전한 오류 응답 생성
+
+동시에 Micrometer가 요청 수·상태 코드·응답 시간을 집계
+    │
+    ▼
+/actuator/prometheus에서 메트릭 노출
+
+운영 로그 파일과 메트릭
+    │
+    └─ 추후 CloudWatch가 수집 → 대시보드·검색·알림
+```
+
+## 로그: 개별 사건의 원인을 찾는다
+
+로그는 특정 요청에서 실제로 무슨 일이 있었는지 확인할 때 사용한다.
+
+서버에서는 여러 요청을 동시에 처리하므로 로그가 다음처럼 섞일 수 있다.
+
+```text
+14:00:01 [requestId:REQ-123] 여행 기록 수정 요청
+14:00:01 [requestId:REQ-456] 지도 요약 조회 요청
+14:00:02 [requestId:REQ-456] 지도 요약 조회 완료
+14:00:02 [requestId:REQ-123] ERROR 미디어 저장 실패
+```
+
+`REQ-123`으로 검색하면 여행 기록 수정 요청만 분리할 수 있다.
+
+```text
+[requestId:REQ-123] 여행 기록 수정 요청
+[requestId:REQ-123] ERROR 미디어 저장 실패
+```
+
+문서의 `REQ-123`은 이해를 위한 짧은 예시다. 실제 Mapmory에서는 중복 가능성이 매우 낮은
+UUID를 사용한다.
+
+### Request ID가 붙는 과정
+
+1. 클라이언트가 유효한 `X-Request-Id`를 보내면 그대로 사용한다.
+2. 헤더가 없거나 UUID 형식이 아니면 서버가 새 UUID를 만든다.
+3. Request ID를 MDC에 넣는다.
+4. 요청 처리 중 발생하는 로그에 같은 Request ID가 자동으로 붙는다.
+5. 응답의 `X-Request-Id` 헤더에도 같은 값을 넣는다.
+6. 요청이 끝나면 MDC 값을 제거한다.
+
+```http
+HTTP/1.1 500 Internal Server Error
+X-Request-Id: 550e8400-e29b-41d4-a716-446655440000
+```
+
+사용자가 이 값을 제보하면 해당 요청 로그를 바로 찾을 수 있다. 더 자세한 예시는
+[Request ID 로그 안내](request-id-logging-guide.md)에 있다.
+
+### 어떤 오류를 어떤 레벨로 남기는가
+
+| 상황 | 현재 로그 레벨 | 이유 |
+| --- | --- | --- |
+| 예상하지 못한 서버 예외 | `ERROR` | 개발자가 원인과 스택 트레이스를 확인해야 한다. |
+| 컨트롤러 반환값 검증 실패 | `ERROR` | 서버가 잘못된 응답을 만들었다. |
+| 카카오 등 의존 시스템 사용 불가 | `ERROR` | 사용자 입력이 아니라 외부 시스템 문제다. |
+| 일반적인 잘못된 입력·리소스 없음·토큰 만료 | `DEBUG` | 예상 가능한 사용자 요청 실패다. |
+
+일반적인 4xx를 모두 `ERROR`로 남기지 않는다. 그렇게 하면 실제 서버 장애가 정상적인 사용자
+실수 로그에 묻히기 때문이다.
+
+현재는 모든 정상 요청의 시작과 종료를 로그로 남기지 않는다. 요청 수와 응답 시간은 메트릭이
+더 적합하며, 모든 요청을 INFO 로그로 남기면 로그 저장량이 크게 증가한다.
+
+### 로컬 로그와 운영 로그
+
+로컬에서는 사람이 읽기 쉬운 문자열 로그를 사용한다.
+
+```text
+ERROR [requestId:550e8400-...] Unhandled exception while processing POST /api/...
+```
+
+운영에서는 프로그램이 필드별로 검색하기 쉬운 JSON 로그를 사용하며 다음 파일에 기록한다.
+
+```text
+/var/log/mapmory/application.log
+```
+
+개념상 다음과 같은 정보가 한 로그에 들어간다.
+
+```json
+{
+  "service": "mapmory-backend",
+  "environment": "prod",
+  "version": "배포 버전",
+  "requestId": "550e8400-...",
+  "event": "UNHANDLED_EXCEPTION",
+  "status": 500,
+  "httpMethod": "POST",
+  "uri": "/api/v1/travel-records",
+  "message": "Unhandled exception while processing POST /api/v1/travel-records"
+}
+```
+
+JSON 로그가 CloudWatch에 들어가면 정규식 대신 `requestId`, `event`, `status` 같은 필드로 검색할
+수 있다.
+
+## 메트릭: 서비스 전체 상태를 숫자로 본다
+
+메트릭은 개별 요청의 상세 이야기가 아니라 많은 요청을 숫자로 합친 결과다.
+
+```text
+로그:    REQ-123 요청이 DB 오류로 실패했다.
+메트릭:  최근 5분 동안 요청 1,000건 중 5xx가 30건 발생했다.
+```
+
+### 자동으로 수집되는 주요 메트릭
+
+| 메트릭 | 알 수 있는 것 |
+| --- | --- |
+| `http.server.requests` | API 요청 수, 상태 코드, 전체 응답 시간 |
+| `http.client.requests` | 백엔드에서 카카오 API로 보낸 요청의 수와 응답 시간 |
+| JVM 메트릭 | Heap 메모리, GC, 스레드 등 Java 프로세스 상태 |
+| HikariCP 메트릭 | 사용 중·대기 중인 DB 커넥션 상태 |
+
+Spring Boot 코드에서는 점(`.`)이 들어간 이름을 사용하지만 Prometheus 출력에서는 밑줄(`_`)과
+단위가 붙는다.
+
+```text
+http.server.requests
+→ http_server_requests_seconds_count
+→ http_server_requests_seconds_sum
+→ http_server_requests_seconds_bucket
+```
+
+### 직접 추가한 중요 작업 메트릭
+
+API 전체 시간만 보면 어느 내부 작업이 느린지 알기 어렵다. 그래서 다음 세 작업만 별도로
+측정한다.
+
+| operation | 측정하는 작업 |
+| --- | --- |
+| `MEDIA_SYNC` | 여행 기록의 미디어 목록 동기화와 DB 반영 |
+| `MAP_SUMMARY_QUERY` | 지역별 지도 요약 DB 조회 |
+| `S3_PRESIGN` | S3 Presigned URL 생성 |
+
+공통 메트릭 이름은 다음과 같다.
+
+```text
+mapmory.operation.duration
+```
+
+각 실행은 성공과 실패로 나뉜다.
+
+```text
+operation=MEDIA_SYNC, outcome=SUCCESS
+operation=MEDIA_SYNC, outcome=FAILURE
+```
+
+예를 들어 지도 API가 느릴 때 `MAP_SUMMARY_QUERY`도 느리면 DB 조회가 원인일 가능성이 높다.
+API 전체는 느리지만 이 작업은 빠르다면 인증, DTO 변환 또는 다른 구간을 조사한다.
+
+### 응답시간 버킷을 쉽게 이해하기
+
+HTTP 요청은 다음 구간별로 누적 집계된다.
+
+```text
+100ms 이하
+300ms 이하
+500ms 이하
+1초 이하
+2초 이하
+3초 이하
+5초 이하
+```
+
+원본 요청 시간을 모두 저장하지 않고 구간별 개수를 저장한다. 이를 이용해 “요청의 약 95%가
+몇 초 안에 끝났는가?” 같은 p95 값을 계산할 수 있다.
+
+## 로그와 메트릭을 함께 보는 방법
+
+### 상황 1: 사용자가 500 오류를 제보했다
+
+1. 응답의 `X-Request-Id`를 확인한다.
+2. CloudWatch Logs에서 같은 `requestId`를 검색한다.
+3. `event`, `errorCode`, 스택 트레이스로 실패 원인을 찾는다.
+
+```sql
+fields @timestamp, requestId, event, @message
+| filter requestId = "550e8400-e29b-41d4-a716-446655440000"
+| sort @timestamp asc
+```
+
+### 상황 2: 전체적으로 API가 느리다
+
+1. `http.server.requests`에서 느린 URI와 p95를 확인한다.
+2. `mapmory.operation.duration`에서 어떤 내부 작업이 느린지 확인한다.
+3. 같은 시간대의 ERROR 로그를 확인한다.
+
+### 상황 3: DB 연결이 부족해 보인다
+
+1. HikariCP 활성·대기 커넥션 메트릭을 확인한다.
+2. RDS의 CPU, 연결 수와 메모리 메트릭을 함께 확인한다.
+3. 커넥션 부족이 발생한 시간대의 애플리케이션 오류 로그를 확인한다.
+
+핵심 순서는 다음과 같다.
+
+```text
+메트릭으로 이상 위치 찾기 → Request ID 로그로 구체적인 원인 찾기
+```
+
+## Health 엔드포인트 구분
+
+Mapmory에는 이름이 비슷한 두 엔드포인트가 있다.
+
+| 주소 | 역할 |
+| --- | --- |
+| `/health` | 현재 애플리케이션의 단순 실행 확인 페이지 |
+| `/actuator/health` | Spring Boot Actuator가 제공하는 상태 확인 |
+
+운영에서는 Actuator가 일반 API와 다른 로컬 관리 포트를 사용한다.
+
+```text
+일반 API: 0.0.0.0:8080
+Actuator: 127.0.0.1:8081
+```
+
+따라서 외부 사용자가 8081에 접근하도록 보안 그룹이나 Nginx를 열면 안 된다. 같은 서버에서
+실행되는 수집기만 접근하는 구조다.
+
+## 메트릭 태그에 넣어도 되는 값
+
+메트릭은 `이름 + 모든 태그 값의 조합`마다 새로운 시계열이 만들어진다.
+
+허용되는 값:
+
+- `SUCCESS`, `FAILURE`처럼 종류가 고정된 값
+- HTTP 메서드와 상태 코드
+- `MEDIA_SYNC`처럼 enum으로 제한된 작업 이름
+
+넣으면 안 되는 값:
+
+- `requestId`
+- `memberId`, `travelRecordId`
+- 실제 파일명, S3 object key
+- 예외 메시지, 토큰, 실제 사용자 입력
+
+Request ID를 메트릭 태그로 넣으면 요청 수만큼 시계열이 생긴다. Request ID는 로그에서만
+사용한다. HTTP URI 태그도 비정상적으로 늘어나는 것을 막기 위해 최대 50종까지만 등록한다.
+
+## 민감정보 로그 금지
+
+다음 값은 디버깅이 필요해도 로그에 남기지 않는다.
+
+- access token, refresh token, 카카오 access token
+- JWT secret, AWS 키, DB 비밀번호
+- Presigned URL 전체
+- 요청·응답 본문 전체
+- 여행 제목과 본문 등 불필요한 개인정보
+
+필요한 경우에도 원문 대신 내부 오류 코드나 값의 존재 여부처럼 최소 정보만 기록한다.
+
+## 팀원이 새 로그를 추가할 때
+
+1. 이 로그가 운영 중 실제로 검색할 사건인지 확인한다.
+2. 정상 상태 변경은 `INFO`, 조치가 필요한 실패는 `ERROR`를 사용한다.
+3. 요청마다 발생하는 정상 시작·종료 로그는 가능하면 메트릭으로 대체한다.
+4. 검색할 값은 SLF4J key-value 필드로 추가한다.
+5. 토큰, 개인정보, 요청 본문을 기록하지 않는다.
+6. 같은 예외의 스택 트레이스를 여러 계층에서 반복 기록하지 않는다.
+
+```java
+log.atError()
+        .addKeyValue("event", "UNHANDLED_EXCEPTION")
+        .addKeyValue("status", 500)
+        .addKeyValue("httpMethod", request.getMethod())
+        .addKeyValue("uri", request.getRequestURI())
+        .setCause(exception)
+        .log("Unhandled exception while processing request");
+```
+
+`requestId`는 Filter와 MDC가 자동으로 추가하므로 위 코드에서 다시 넣지 않는다.
+
+## 팀원이 새 메트릭을 추가할 때
+
+새 메트릭은 다음 조건을 만족할 때만 추가한다.
+
+- API 전체 시간만으로 병목을 구분할 수 없다.
+- DB 또는 외부 시스템처럼 운영 중 따로 확인할 가치가 있다.
+- 태그 값의 종류를 작고 고정된 범위로 제한할 수 있다.
+
+중요 내부 작업을 추가할 때는 다음 순서를 사용한다.
+
+1. `MonitoredOperation` enum에 작업을 추가한다.
+2. 측정할 최소 구간을 `operationTimer.record(...)`로 감싼다.
+3. 성공 결과와 실패 예외가 계측 전과 동일하게 전달되는지 테스트한다.
+4. ID나 임의 문자열을 태그로 넣지 않는다.
+
+```java
+return operationTimer.record(
+        MonitoredOperation.MAP_SUMMARY_QUERY,
+        () -> repository.findRegionMapSummaries(...)
+);
+```
+
+## 로컬에서 확인하기
+
+백엔드를 실행한 후 Health와 Request ID를 확인한다.
+
+```bash
+curl -i http://localhost:8080/actuator/health
+```
+
+메트릭을 확인한다.
+
+```bash
+curl -s http://localhost:8080/actuator/prometheus \
+  | grep -E 'http_server_requests|http_client_requests|jvm_memory|hikaricp|mapmory_operation'
+```
+
+`mapmory_operation` 메트릭은 해당 기능을 한 번 이상 실행해야 나타난다.
+
+## 구현 완료와 남은 작업
+
+### 애플리케이션에서 완료된 것
+
+- [x] Request ID 생성·응답·MDC 정리
+- [x] 예외 종류에 따른 로그 레벨과 구조화 필드
+- [x] 운영 JSON 로그와 파일 출력
+- [x] Actuator Health와 Prometheus 엔드포인트
+- [x] HTTP 서버, JVM, HikariCP 자동 메트릭
+- [x] 카카오 RestClient 외부 요청 메트릭과 타임아웃
+- [x] 중요 내부 작업 3종의 성공·실패 시간 측정
+- [x] 메트릭 공통 태그와 URI 태그 개수 제한
+- [x] 관련 단위·통합 테스트
+
+### AWS에서 아직 해야 하는 것
+
+- [ ] EC2 IAM Role과 CloudWatch Agent 설정
+- [ ] `/var/log/mapmory/application.log`를 CloudWatch Logs에 전송
+- [ ] 로그 그룹 보존 기간 설정
+- [ ] EC2·RDS 기본 메트릭과 애플리케이션 로그 대시보드 구성
+- [ ] 장애 알람과 SNS 알림 채널 구성
+- [ ] 전송할 애플리케이션 메트릭 범위와 방법 결정
+
+## 코드 위치
+
+| 내용 | 코드 |
+| --- | --- |
+| Request ID | [`RequestIdFilter`](../src/main/java/com/mapmory/backend/common/logging/RequestIdFilter.java) |
+| 예외 로그 | [`common/handler`](../src/main/java/com/mapmory/backend/common/handler) |
+| 메트릭 공통 설정 | [`MetricsConfiguration`](../src/main/java/com/mapmory/backend/common/monitoring/MetricsConfiguration.java) |
+| 내부 작업 시간 측정 | [`OperationTimer`](../src/main/java/com/mapmory/backend/common/monitoring/OperationTimer.java) |
+| 측정 대상 작업 목록 | [`MonitoredOperation`](../src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java) |
+| 공통 설정 | [`application.yaml`](../src/main/resources/application.yaml) |
+| 운영 로그·관리 포트 | [`application-prod.yaml`](../src/main/resources/application-prod.yaml) |
+| 상세 결정 기록 | [ADR 0014](adr/0014-application-logging-and-metrics.md) |
+
+## 마지막으로 기억할 문장
+
+```text
+메트릭은 “어디가 이상한가?”를 찾고,
+로그는 “왜 이상한가?”를 찾으며,
+Request ID는 “이 로그들이 같은 요청인가?”를 연결한다.
+```

--- a/backend/docs/request-id-logging-guide.md
+++ b/backend/docs/request-id-logging-guide.md
@@ -1,0 +1,154 @@
+# Request ID로 하나의 요청 로그 찾기
+
+## 한 줄 설명
+
+Request ID는 서버에 들어온 요청 하나에 붙이는 **번호표**다.
+
+실제 서버에서는 여러 사용자의 요청을 동시에 처리하기 때문에 로그가 서로 섞인다. 각 로그에
+같은 Request ID를 붙이면, 나중에 특정 요청에서 발생한 로그만 골라서 볼 수 있다.
+
+이 문서에서는 이해하기 쉽도록 짧은 값인 `REQ-123`을 사용한다. 현재 Mapmory의 실제 구현은
+충돌 가능성을 줄이기 위해 UUID를 사용한다.
+
+## 요청 처리 예시
+
+사용자가 여행 기록 생성을 요청한다고 가정한다.
+
+```http
+POST /api/v1/travel-records
+X-Request-Id: REQ-123
+```
+
+서버는 이 요청을 처리하면서 만들어지는 모든 로그에 같은 번호표를 붙인다.
+
+```text
+14:00:01 [requestId:REQ-123] 여행 기록 생성 요청
+14:00:01 [requestId:REQ-123] 회원 조회 완료
+14:00:02 [requestId:REQ-123] 이미지 URL 저장 시작
+14:00:02 [requestId:REQ-123] ERROR 데이터베이스 저장 실패
+```
+
+응답에도 같은 Request ID를 넣는다.
+
+```http
+HTTP/1.1 500 Internal Server Error
+X-Request-Id: REQ-123
+```
+
+사용자가 오류를 제보할 때 다음과 같이 Request ID를 전달할 수 있다.
+
+```text
+여행 기록 저장에 실패했습니다. 응답의 Request ID는 REQ-123입니다.
+```
+
+개발자는 `REQ-123`을 검색해서 해당 요청의 처리 과정과 실패 원인을 찾는다.
+
+## Request ID가 필요한 이유
+
+두 사용자의 요청이 동시에 들어오면 실제 로그는 다음처럼 섞인다.
+
+```text
+14:00:01 [requestId:REQ-123] 여행 기록 생성 요청
+14:00:01 [requestId:REQ-456] 지도 조회 요청
+14:00:01 [requestId:REQ-123] 회원 조회 완료
+14:00:02 [requestId:REQ-456] 지도 조회 완료
+14:00:02 [requestId:REQ-123] ERROR DB 저장 실패
+```
+
+여기서 `REQ-123`만 검색하면 여행 기록 생성 요청의 로그만 남는다.
+
+```text
+[requestId:REQ-123] 여행 기록 생성 요청
+[requestId:REQ-123] 회원 조회 완료
+[requestId:REQ-123] ERROR DB 저장 실패
+```
+
+이를 통해 다음 흐름을 확인할 수 있다.
+
+```text
+요청 도착 → 회원 조회 → 이미지 저장 시도 → DB 저장 실패
+```
+
+## Mapmory 코드에서의 동작
+
+Mapmory의 `RequestIdFilter`가 요청 시작 시 Request ID를 MDC에 넣는다.
+
+```java
+try (MDC.MDCCloseable ignored = MDC.putCloseable("requestId", requestId)) {
+    filterChain.doFilter(request, response);
+}
+```
+
+요청 처리 중에는 평소처럼 로그만 작성하면 된다.
+
+```java
+log.info("여행 기록 생성 요청");
+log.error("데이터베이스 저장 실패", exception);
+```
+
+개발자가 로그를 작성할 때마다 Request ID를 직접 넘길 필요는 없다. MDC에 저장된 값이 로그
+설정에 의해 자동으로 추가된다.
+
+```yaml
+logging:
+  pattern:
+    level: "%5p [requestId:%X{requestId:-}]"
+```
+
+요청 처리가 끝나면 `MDC.putCloseable()`이 값을 제거한다. 이를 제거하지 않으면 서버가 같은
+스레드를 다음 요청에 재사용할 때 이전 Request ID가 다음 사용자의 로그에 잘못 붙을 수 있다.
+
+## CloudWatch에서 검색하기
+
+사용자가 알려준 Request ID가 `REQ-123`이라면 CloudWatch Logs Insights에서 다음과 같이
+검색한다.
+
+```sql
+fields @timestamp, @message
+| filter @message like /REQ-123/
+| sort @timestamp asc
+```
+
+검색 결과를 시간순으로 읽으면 요청이 어느 단계까지 성공했고 어디에서 실패했는지 확인할 수
+있다.
+
+운영 로그가 JSON 형식으로 수집되어 `requestId`가 별도 필드로 인식되는 경우에는 다음처럼 더
+정확하게 검색할 수 있다.
+
+```sql
+fields @timestamp, requestId, @message
+| filter requestId = "REQ-123"
+| sort @timestamp asc
+```
+
+## 로그와 메트릭에서의 차이
+
+Request ID는 개별 요청을 찾기 위한 **로그 검색용 값**이다.
+
+```text
+로그:    requestId 사용 가능
+메트릭:  requestId 사용 금지
+```
+
+Request ID는 요청마다 값이 달라진다. 이를 Micrometer나 Prometheus 메트릭 태그에 넣으면 요청
+수만큼 시계열이 만들어져 메모리 사용량과 모니터링 비용이 크게 늘어난다.
+
+```java
+// 잘못된 예: 요청마다 새로운 메트릭 시계열이 만들어진다.
+counter.tag("requestId", requestId);
+```
+
+메트릭에서는 HTTP 메서드, 상태 코드, 정해진 작업 이름처럼 값의 종류가 제한된 태그만 사용한다.
+
+## 현재 구현에서 확인할 점
+
+이 문서의 `REQ-123`은 이해를 돕기 위한 예시다. 현재 Mapmory는 `X-Request-Id`로 UUID만
+허용한다.
+
+```text
+예시용 값: REQ-123
+실제 값:   550e8400-e29b-41d4-a716-446655440000
+```
+
+실제 서버에 `REQ-123`을 전달하면 유효하지 않은 값으로 판단하고 새로운 UUID를 만들어
+응답한다. 운영에서는 중복 가능성이 매우 낮은 현재 UUID 방식을 유지한다.

--- a/backend/src/main/java/com/mapmory/backend/auth/kakao/KakaoApiClient.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/kakao/KakaoApiClient.java
@@ -37,12 +37,20 @@ public class KakaoApiClient {
                     .body(KakaoUserResponse.class);
         } catch (RestClientResponseException exception) {
             if (exception.getStatusCode().is5xxServerError()) {
-                throw new BusinessException(AuthErrorCode.KAKAO_UNAVAILABLE);
+                throw kakaoUnavailable(exception);
             }
             throw new BusinessException(AuthErrorCode.INVALID_KAKAO_TOKEN);
         } catch (RestClientException exception) {
             // 연결 실패 등 응답 자체를 받지 못한 경우도 카카오 장애로 취급한다.
-            throw new BusinessException(AuthErrorCode.KAKAO_UNAVAILABLE);
+            throw kakaoUnavailable(exception);
         }
+    }
+
+    private static BusinessException kakaoUnavailable(RestClientException cause) {
+        return new BusinessException(
+                AuthErrorCode.KAKAO_UNAVAILABLE,
+                AuthErrorCode.KAKAO_UNAVAILABLE.detail(),
+                cause
+        );
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/auth/kakao/KakaoClientConfig.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/kakao/KakaoClientConfig.java
@@ -10,13 +10,12 @@ import org.springframework.web.client.RestClient;
 public class KakaoClientConfig {
 
     /**
-     * 카카오 호출 전용 RestClient.
-     *
-     * 앱 전역 자동 구성 빌더에 의존하지 않고 직접 생성한다. (외부 호출에 앱의 인터셉터·컨버터를
-     * 얹지 않고, 자동 구성 여부와 무관하게 동작하게 하기 위함)
+     * Spring Boot가 자동 구성한 Builder를 사용한다.
+     * 이를 통해 HTTP 메시지 변환, 타임아웃 설정과 관측 기능이 적용된다.
+     * 자동 빌더를 사용하지 않으면 외부 api 관측이 불가능하다고 한다.
      */
     @Bean
-    public RestClient kakaoRestClient() {
-        return RestClient.create();
+    public RestClient kakaoRestClient(RestClient.Builder builder) {
+        return builder.build();
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/auth/security/SecurityConfig.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.mapmory.backend.auth.security;
 
 import jakarta.servlet.DispatcherType;
+import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -42,6 +43,7 @@ public class SecurityConfig {
                         // permitAll 경로에서 예외가 나 /error로 재디스패치될 때 401로 덮여
                         // 원래 에러 응답(404/500 등)이 가려진다.
                         .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
+                        .requestMatchers(EndpointRequest.to("health", "prometheus")).permitAll()
                         .requestMatchers("/health").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated())

--- a/backend/src/main/java/com/mapmory/backend/common/handler/BusinessExceptionHandler.java
+++ b/backend/src/main/java/com/mapmory/backend/common/handler/BusinessExceptionHandler.java
@@ -2,6 +2,7 @@ package com.mapmory.backend.common.handler;
 
 import com.mapmory.backend.common.ProblemDetailFactory;
 import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.common.exception.ErrorCode;
 import com.mapmory.backend.common.exception.ErrorKind;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -33,11 +34,7 @@ public class BusinessExceptionHandler {
     ) {
         HttpStatus status = toHttpStatus(exception.getErrorCode().kind());
 
-        log.debug("Business exception: code={}, status={}, method={}, uri={}",
-                exception.getErrorCode().code(),
-                status.value(),
-                request.getMethod(),
-                request.getRequestURI());
+        log(exception, status, request);
 
         return problemDetailFactory.from(
                 status,
@@ -45,6 +42,30 @@ public class BusinessExceptionHandler {
                 exception.getDetail(),
                 request
         );
+    }
+
+    private static void log(
+            BusinessException exception,
+            HttpStatus status,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = exception.getErrorCode();
+        // TODO: SERVICE_UNAVAILABLE 전체를 ERROR로 기록할지, KAKAO_UNAVAILABLE만 대상으로 할지 논의 필요
+        if (errorCode.kind() == ErrorKind.SERVICE_UNAVAILABLE) {
+            log.error("Business exception: code={}, status={}, method={}, uri={}",
+                    errorCode.code(),
+                    status.value(),
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    exception);
+            return;
+        }
+
+        log.debug("Business exception: code={}, status={}, method={}, uri={}",
+                errorCode.code(),
+                status.value(),
+                request.getMethod(),
+                request.getRequestURI());
     }
 
     private static HttpStatus toHttpStatus(ErrorKind kind) {

--- a/backend/src/main/java/com/mapmory/backend/common/handler/BusinessExceptionHandler.java
+++ b/backend/src/main/java/com/mapmory/backend/common/handler/BusinessExceptionHandler.java
@@ -7,6 +7,7 @@ import com.mapmory.backend.common.exception.ErrorKind;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.spi.LoggingEventBuilder;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -51,17 +52,19 @@ public class BusinessExceptionHandler {
     ) {
         ErrorCode errorCode = exception.getErrorCode();
         // TODO: SERVICE_UNAVAILABLE 전체를 ERROR로 기록할지, KAKAO_UNAVAILABLE만 대상으로 할지 논의 필요
-        if (errorCode.kind() == ErrorKind.SERVICE_UNAVAILABLE) {
-            log.error("Business exception: code={}, status={}, method={}, uri={}",
-                    errorCode.code(),
-                    status.value(),
-                    request.getMethod(),
-                    request.getRequestURI(),
-                    exception);
-            return;
+        boolean serviceUnavailable = errorCode.kind() == ErrorKind.SERVICE_UNAVAILABLE;
+        LoggingEventBuilder event = serviceUnavailable ? log.atError() : log.atDebug();
+
+        event.addKeyValue("event", "BUSINESS_EXCEPTION")
+                .addKeyValue("errorCode", errorCode.code())
+                .addKeyValue("status", status.value())
+                .addKeyValue("httpMethod", request.getMethod())
+                .addKeyValue("uri", request.getRequestURI());
+        if (serviceUnavailable) {
+            event.setCause(exception);
         }
 
-        log.debug("Business exception: code={}, status={}, method={}, uri={}",
+        event.log("Business exception: code={}, status={}, method={}, uri={}",
                 errorCode.code(),
                 status.value(),
                 request.getMethod(),

--- a/backend/src/main/java/com/mapmory/backend/common/handler/UnexpectedExceptionHandler.java
+++ b/backend/src/main/java/com/mapmory/backend/common/handler/UnexpectedExceptionHandler.java
@@ -28,8 +28,14 @@ public class UnexpectedExceptionHandler {
             Exception exception,
             HttpServletRequest request
     ) {
-        log.error("Unhandled exception while processing {} {}",
-                request.getMethod(), request.getRequestURI(), exception);
+        log.atError()
+                .addKeyValue("event", "UNHANDLED_EXCEPTION")
+                .addKeyValue("status", 500)
+                .addKeyValue("httpMethod", request.getMethod())
+                .addKeyValue("uri", request.getRequestURI())
+                .setCause(exception)
+                .log("Unhandled exception while processing {} {}",
+                        request.getMethod(), request.getRequestURI());
         return problemDetailFactory.internalServerError(request);
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/common/handler/ValidationExceptionHandler.java
+++ b/backend/src/main/java/com/mapmory/backend/common/handler/ValidationExceptionHandler.java
@@ -50,8 +50,14 @@ public class ValidationExceptionHandler {
             HttpServletRequest request
     ) {
         if (exception.isForReturnValue()) {
-            log.error("Controller return value validation failed: method={}, uri={}",
-                    request.getMethod(), request.getRequestURI(), exception);
+            log.atError()
+                    .addKeyValue("event", "RESPONSE_VALIDATION_FAILED")
+                    .addKeyValue("status", 500)
+                    .addKeyValue("httpMethod", request.getMethod())
+                    .addKeyValue("uri", request.getRequestURI())
+                    .setCause(exception)
+                    .log("Controller return value validation failed: method={}, uri={}",
+                            request.getMethod(), request.getRequestURI());
             return problemDetailFactory.internalServerError(request);
         }
 

--- a/backend/src/main/java/com/mapmory/backend/common/logging/RequestIdFilter.java
+++ b/backend/src/main/java/com/mapmory/backend/common/logging/RequestIdFilter.java
@@ -1,0 +1,49 @@
+package com.mapmory.backend.common.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String REQUEST_ID_MDC_KEY = "requestId";
+
+    private static final int UUID_STRING_LENGTH = 36;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = resolveRequestId(request.getHeader(REQUEST_ID_HEADER));
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+
+        try (MDC.MDCCloseable ignored = MDC.putCloseable(REQUEST_ID_MDC_KEY, requestId)) {
+            filterChain.doFilter(request, response);
+        }
+    }
+
+    private static String resolveRequestId(String candidate) {
+        if (candidate == null || candidate.length() != UUID_STRING_LENGTH) {
+            return UUID.randomUUID().toString();
+        }
+
+        try {
+            return UUID.fromString(candidate).toString();
+        } catch (IllegalArgumentException exception) {
+            return UUID.randomUUID().toString();
+        }
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/common/monitoring/MetricsConfiguration.java
+++ b/backend/src/main/java/com/mapmory/backend/common/monitoring/MetricsConfiguration.java
@@ -1,0 +1,21 @@
+package com.mapmory.backend.common.monitoring;
+
+import io.micrometer.core.instrument.config.MeterFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class MetricsConfiguration {
+
+    static final int MAX_HTTP_SERVER_URI_TAG_VALUES = 50;
+
+    @Bean
+    MeterFilter httpServerUriCardinalityLimit() {
+        return MeterFilter.maximumAllowableTags(
+                "http.server.requests",
+                "uri",
+                MAX_HTTP_SERVER_URI_TAG_VALUES,
+                MeterFilter.deny()
+        );
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
+++ b/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
@@ -2,6 +2,5 @@ package com.mapmory.backend.common.monitoring;
 
 public enum MonitoredOperation {
     MEDIA_SYNC,
-    MAP_SUMMARY_QUERY,
-    S3_PRESIGN
+    MAP_SUMMARY_QUERY
 }

--- a/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
+++ b/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
@@ -1,0 +1,7 @@
+package com.mapmory.backend.common.monitoring;
+
+public enum MonitoredOperation {
+    MEDIA_SYNC,
+    MAP_SUMMARY_QUERY,
+    S3_PRESIGN
+}

--- a/backend/src/main/java/com/mapmory/backend/common/monitoring/OperationTimer.java
+++ b/backend/src/main/java/com/mapmory/backend/common/monitoring/OperationTimer.java
@@ -1,0 +1,47 @@
+package com.mapmory.backend.common.monitoring;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OperationTimer {
+
+    public static final String METRIC_NAME = "mapmory.operation.duration";
+
+    private final MeterRegistry meterRegistry;
+
+    public OperationTimer(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public <T> T record(MonitoredOperation operation, Supplier<T> action) {
+        Objects.requireNonNull(operation, "operation must not be null");
+        Objects.requireNonNull(action, "action must not be null");
+
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            T result = action.get();
+            sample.stop(timer(operation, Outcome.SUCCESS));
+            return result;
+        } catch (RuntimeException | Error exception) {
+            sample.stop(timer(operation, Outcome.FAILURE));
+            throw exception;
+        }
+    }
+
+    private Timer timer(MonitoredOperation operation, Outcome outcome) {
+        return Timer.builder(METRIC_NAME)
+                .description("Duration of important Mapmory internal operations")
+                .tag("operation", operation.name())
+                .tag("outcome", outcome.name())
+                .register(meterRegistry);
+    }
+
+    private enum Outcome {
+        SUCCESS,
+        FAILURE
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -1,6 +1,8 @@
 package com.mapmory.backend.travelrecord;
 
 import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.common.monitoring.MonitoredOperation;
+import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
@@ -36,19 +38,22 @@ public class TravelRecordService {
     private final RecordMediaRepository recordMediaRepository;
     private final TravelRecordTagService travelRecordTagService;
     private final TagService tagService;
+    private final OperationTimer operationTimer;
 
     public TravelRecordService(
             TravelRecordRepository travelRecordRepository,
             RegionResolver regionResolver,
             RecordMediaRepository recordMediaRepository,
             TravelRecordTagService travelRecordTagService,
-            TagService tagService
+            TagService tagService,
+            OperationTimer operationTimer
     ) {
         this.travelRecordRepository = travelRecordRepository;
         this.regionResolver = regionResolver;
         this.recordMediaRepository = recordMediaRepository;
         this.travelRecordTagService = travelRecordTagService;
         this.tagService = tagService;
+        this.operationTimer = operationTimer;
     }
 
     @Transactional
@@ -125,10 +130,19 @@ public class TravelRecordService {
                 request.startDate(),
                 request.endDate()
         );
-        List<RecordMedia> updatedMedia = synchronizeMedia(travelRecord, existingMedia, objectKeys);
         List<Tag> tags = travelRecordTagService.replace(member, travelRecord, request.tagIds());
-
-        travelRecordRepository.flush();
+        List<RecordMedia> updatedMedia = operationTimer.record(
+                MonitoredOperation.MEDIA_SYNC,
+                () -> {
+                    List<RecordMedia> synchronizedMedia = synchronizeMedia(
+                            travelRecord,
+                            existingMedia,
+                            objectKeys
+                    );
+                    travelRecordRepository.flush();
+                    return synchronizedMedia;
+                }
+        );
 
         return TravelRecordDetailResponse.from(travelRecord, updatedMedia, tags);
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
@@ -1,12 +1,15 @@
 package com.mapmory.backend.travelrecord.mapsummary.service;
 
 import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.common.monitoring.MonitoredOperation;
+import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
 import com.mapmory.backend.tag.TagService;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
+import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryQueryResult;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -19,17 +22,20 @@ public class RegionMapSummaryService {
     private final RegionMapSummaryRepository regionMapSummaryRepository;
     private final LevelPolicy levelPolicy;
     private final TagService tagService;
+    private final OperationTimer operationTimer;
 
     public RegionMapSummaryService(
             RegionRepository regionRepository,
             RegionMapSummaryRepository regionMapSummaryRepository,
             LevelPolicy levelPolicy,
-            TagService tagService
+            TagService tagService,
+            OperationTimer operationTimer
     ) {
         this.regionRepository = regionRepository;
         this.regionMapSummaryRepository = regionMapSummaryRepository;
         this.levelPolicy = levelPolicy;
         this.tagService = tagService;
+        this.operationTimer = operationTimer;
     }
 
     @Transactional(readOnly = true)
@@ -38,7 +44,11 @@ public class RegionMapSummaryService {
         if (tagId != null) {
             tagService.getOwnedTag(member, tagId);
         }
-        return regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId, tagId).stream()
+        List<RegionMapSummaryQueryResult> summaries = operationTimer.record(
+                MonitoredOperation.MAP_SUMMARY_QUERY,
+                () -> regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId, tagId)
+        );
+        return summaries.stream()
                 .map(result -> RegionMapSummaryResponse.from(result, levelPolicy))
                 .toList();
     }

--- a/backend/src/main/java/com/mapmory/backend/upload/storage/S3PresignedUrlProvider.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/storage/S3PresignedUrlProvider.java
@@ -1,7 +1,5 @@
 package com.mapmory.backend.upload.storage;
 
-import com.mapmory.backend.common.monitoring.MonitoredOperation;
-import com.mapmory.backend.common.monitoring.OperationTimer;
 import java.net.URI;
 import java.time.Duration;
 import org.springframework.stereotype.Component;
@@ -14,16 +12,13 @@ public class S3PresignedUrlProvider implements PresignedUrlProvider {
 
     private final S3Presigner s3Presigner;
     private final String bucket;
-    private final OperationTimer operationTimer;
 
     public S3PresignedUrlProvider(
             S3Presigner s3Presigner,
-            S3StorageProperties properties,
-            OperationTimer operationTimer
+            S3StorageProperties properties
     ) {
         this.s3Presigner = s3Presigner;
         this.bucket = properties.bucket();
-        this.operationTimer = operationTimer;
     }
 
     @Override
@@ -44,9 +39,6 @@ public class S3PresignedUrlProvider implements PresignedUrlProvider {
                 .putObjectRequest(putObjectRequest)
                 .build();
 
-        return operationTimer.record(
-                MonitoredOperation.S3_PRESIGN,
-                () -> URI.create(s3Presigner.presignPutObject(presignRequest).url().toString())
-        );
+        return URI.create(s3Presigner.presignPutObject(presignRequest).url().toString());
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/storage/S3PresignedUrlProvider.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/storage/S3PresignedUrlProvider.java
@@ -1,5 +1,7 @@
 package com.mapmory.backend.upload.storage;
 
+import com.mapmory.backend.common.monitoring.MonitoredOperation;
+import com.mapmory.backend.common.monitoring.OperationTimer;
 import java.net.URI;
 import java.time.Duration;
 import org.springframework.stereotype.Component;
@@ -12,13 +14,16 @@ public class S3PresignedUrlProvider implements PresignedUrlProvider {
 
     private final S3Presigner s3Presigner;
     private final String bucket;
+    private final OperationTimer operationTimer;
 
     public S3PresignedUrlProvider(
             S3Presigner s3Presigner,
-            S3StorageProperties properties
+            S3StorageProperties properties,
+            OperationTimer operationTimer
     ) {
         this.s3Presigner = s3Presigner;
         this.bucket = properties.bucket();
+        this.operationTimer = operationTimer;
     }
 
     @Override
@@ -39,6 +44,9 @@ public class S3PresignedUrlProvider implements PresignedUrlProvider {
                 .putObjectRequest(putObjectRequest)
                 .build();
 
-        return URI.create(s3Presigner.presignPutObject(presignRequest).url().toString());
+        return operationTimer.record(
+                MonitoredOperation.S3_PRESIGN,
+                () -> URI.create(s3Presigner.presignPutObject(presignRequest).url().toString())
+        );
     }
 }

--- a/backend/src/main/resources/application-local.yaml
+++ b/backend/src/main/resources/application-local.yaml
@@ -14,3 +14,33 @@ spring:
 jwt:
   # 로컬 개발 전용 키. 운영에는 절대 사용하지 말 것. (HS256: 최소 32바이트)
   secret: local-development-only-secret-key-change-me-0123456789
+
+
+management:
+  endpoints:
+    access:
+      default: none
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+        discovery:
+          enabled: false
+
+  endpoint:
+    health:
+      access: read-only
+      show-details: never
+    prometheus:
+      access: read-only
+
+  metrics:
+    tags:
+      service: ${spring.application.name}
+      environment: local
+      version: ${APP_VERSION:local}
+
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true

--- a/backend/src/main/resources/application-local.yaml
+++ b/backend/src/main/resources/application-local.yaml
@@ -15,32 +15,7 @@ jwt:
   # 로컬 개발 전용 키. 운영에는 절대 사용하지 말 것. (HS256: 최소 32바이트)
   secret: local-development-only-secret-key-change-me-0123456789
 
-
 management:
-  endpoints:
-    access:
-      default: none
-    web:
-      exposure:
-        include:
-          - health
-          - prometheus
-        discovery:
-          enabled: false
-
-  endpoint:
-    health:
-      access: read-only
-      show-details: never
-    prometheus:
-      access: read-only
-
   metrics:
     tags:
-      service: ${spring.application.name}
       environment: local
-      version: ${APP_VERSION:local}
-
-    distribution:
-      percentiles-histogram:
-        http.server.requests: true

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -12,6 +12,14 @@ jwt:
   secret: ${JWT_SECRET}
 
 logging:
+  structured:
+    format:
+      console: logstash
+    json:
+      add:
+        service: ${spring.application.name}
+        environment: prod
+        version: ${APP_VERSION:unknown}
   level:
     org.hibernate.SQL: warn
     org.flywaydb: info

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -12,9 +12,13 @@ jwt:
   secret: ${JWT_SECRET}
 
 logging:
+  file:
+    name: /var/log/mapmory/application.log
+
   structured:
     format:
       console: logstash
+      file: logstash
     json:
       add:
         service: ${spring.application.name}

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -14,3 +14,14 @@ jwt:
 logging:
   level:
     org.hibernate.SQL: warn
+    org.flywaydb: info
+    org.springframework.boot.autoconfigure: info
+
+management:
+  server:
+    port: 8081
+    address: 127.0.0.1
+
+  metrics:
+    tags:
+      environment: prod

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -85,5 +85,7 @@ management:
         http.server.requests: 10ms
       maximum-expected-value:
         http.server.requests: 5s
+        mapmory.operation.duration: 5s
       slo:
         http.server.requests: 100ms,300ms,500ms,1s,2s,3s,5s
+        mapmory.operation.duration: 10ms,50ms,100ms,300ms,500ms,1s,3s,5s

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -81,5 +81,9 @@ management:
       version: ${APP_VERSION:unknown}
 
     distribution:
-      percentiles-histogram:
-        http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 10ms
+      maximum-expected-value:
+        http.server.requests: 5s
+      slo:
+        http.server.requests: 100ms,300ms,500ms,1s,2s,3s,5s

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -49,6 +49,8 @@ server:
     context-path: /
 
 logging:
+  pattern:
+    level: "%5p [requestId:%X{requestId:-}]"
   level:
     org.hibernate.SQL: debug
     org.flywaydb: debug

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -15,6 +15,10 @@ spring:
           time_zone: UTC
         format_sql: true
     open-in-view: false
+  http:
+    clients:
+      connect-timeout: 2s
+      read-timeout: 3s
 
   flyway:
     enabled: true
@@ -49,3 +53,31 @@ logging:
     org.hibernate.SQL: debug
     org.flywaydb: debug
     org.springframework.boot.autoconfigure: debug
+
+management:
+  endpoints:
+    access:
+      default: none
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+      discovery:
+        enabled: false
+
+  endpoint:
+    health:
+      access: read-only
+      show-details: never
+    prometheus:
+      access: read-only
+
+  metrics:
+    tags:
+      service: ${spring.application.name}
+      version: ${APP_VERSION:unknown}
+
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true

--- a/backend/src/test/java/com/mapmory/backend/auth/kakao/KakaoApiClientTest.java
+++ b/backend/src/test/java/com/mapmory/backend/auth/kakao/KakaoApiClientTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
 
 class KakaoApiClientTest {
 
@@ -58,7 +59,9 @@ class KakaoApiClientTest {
                 .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
 
         assertThatThrownBy(() -> kakaoApiClient.fetchUser("token"))
-                .isInstanceOfSatisfying(BusinessException.class, exception ->
-                        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.KAKAO_UNAVAILABLE));
+                .isInstanceOfSatisfying(BusinessException.class, exception -> {
+                    assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.KAKAO_UNAVAILABLE);
+                    assertThat(exception.getCause()).isInstanceOf(RestClientResponseException.class);
+                });
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/auth/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/auth/security/SecurityIntegrationTest.java
@@ -93,10 +93,18 @@ class SecurityIntegrationTest extends IntegrationTest {
 
     @Test
     void Prometheus_Metric은_토큰_없이_조회할_수_있다() throws Exception {
+        // HTTP 서버 요청 메트릭이 생성되도록 일반 엔드포인트를 먼저 호출한다.
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk());
+
         mockMvc.perform(get ("/actuator/prometheus"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("# HELP")))
-                .andExpect(content().string(containsString("jvm_memory_used_bytes")));
+                .andExpect(content().string(containsString("jvm_memory_used_bytes")))
+                .andExpect(content().string(containsString("hikaricp_connections")))
+                .andExpect(content().string(containsString("http_server_requests_seconds_count")))
+                .andExpect(content().string(containsString("service=\"mapmory-backend\"")))
+                .andExpect(content().string(containsString("environment=\"local\"")));
     }
 
     @TestConfiguration

--- a/backend/src/test/java/com/mapmory/backend/auth/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/auth/security/SecurityIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.auth.security;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -81,6 +82,21 @@ class SecurityIntegrationTest extends IntegrationTest {
         // ERROR 디스패치가 permitAll이 아니면 이 응답이 401로 덮인다.
         mockMvc.perform(post("/api/v1/auth/no-such-endpoint"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void Actuator_health는_토큰_없이_접근할_수_있다() throws Exception{
+        mockMvc.perform(get ("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    void Prometheus_Metric은_토큰_없이_조회할_수_있다() throws Exception {
+        mockMvc.perform(get ("/actuator/prometheus"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("# HELP")))
+                .andExpect(content().string(containsString("jvm_memory_used_bytes")));
     }
 
     @TestConfiguration

--- a/backend/src/test/java/com/mapmory/backend/auth/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/auth/security/SecurityIntegrationTest.java
@@ -103,6 +103,9 @@ class SecurityIntegrationTest extends IntegrationTest {
                 .andExpect(content().string(containsString("jvm_memory_used_bytes")))
                 .andExpect(content().string(containsString("hikaricp_connections")))
                 .andExpect(content().string(containsString("http_server_requests_seconds_count")))
+                .andExpect(content().string(containsString("http_server_requests_seconds_bucket")))
+                .andExpect(content().string(containsString("uri=\"/health\"")))
+                .andExpect(content().string(containsString("status=\"200\"")))
                 .andExpect(content().string(containsString("service=\"mapmory-backend\"")))
                 .andExpect(content().string(containsString("environment=\"local\"")));
     }

--- a/backend/src/test/java/com/mapmory/backend/common/handler/BusinessExceptionHandlerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/handler/BusinessExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.common.handler;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -11,12 +12,16 @@ import com.mapmory.backend.common.exception.ErrorCode;
 import com.mapmory.backend.common.exception.ErrorKind;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@ExtendWith(OutputCaptureExtension.class)
 class BusinessExceptionHandlerTest {
 
     private MockMvc mockMvc;
@@ -42,6 +47,17 @@ class BusinessExceptionHandlerTest {
                 .andExpect(jsonPath("$.code").value("TRAVEL_RECORD_NOT_FOUND"));
     }
 
+    @Test
+    void 서비스_불가_예외는_ERROR와_원인을_기록한다(CapturedOutput output) throws Exception {
+        mockMvc.perform(get("/test/service-unavailable"))
+                .andExpect(status().isServiceUnavailable());
+
+        assertThat(output)
+                .contains("ERROR")
+                .contains("code=SERVICE_UNAVAILABLE")
+                .contains("upstream failure");
+    }
+
     @RestController
     private static class BusinessExceptionController {
 
@@ -49,14 +65,36 @@ class BusinessExceptionHandlerTest {
         void throwBusinessException() {
             throw new BusinessException(TestErrorCode.TRAVEL_RECORD_NOT_FOUND);
         }
+
+        @GetMapping("/test/service-unavailable")
+        void throwServiceUnavailable() {
+            throw new BusinessException(
+                    TestErrorCode.SERVICE_UNAVAILABLE,
+                    TestErrorCode.SERVICE_UNAVAILABLE.detail(),
+                    new IllegalStateException("upstream failure")
+            );
+        }
     }
 
     private enum TestErrorCode implements ErrorCode {
-        TRAVEL_RECORD_NOT_FOUND;
+        TRAVEL_RECORD_NOT_FOUND(ErrorKind.NOT_FOUND, "여행 기록을 찾을 수 없습니다.",
+                "요청한 여행 기록이 존재하지 않습니다."),
+        SERVICE_UNAVAILABLE(ErrorKind.SERVICE_UNAVAILABLE, "서비스를 사용할 수 없습니다.",
+                "외부 서비스 장애로 요청을 처리할 수 없습니다.");
+
+        private final ErrorKind kind;
+        private final String title;
+        private final String detail;
+
+        TestErrorCode(ErrorKind kind, String title, String detail) {
+            this.kind = kind;
+            this.title = title;
+            this.detail = detail;
+        }
 
         @Override
         public ErrorKind kind() {
-            return ErrorKind.NOT_FOUND;
+            return kind;
         }
 
         @Override
@@ -66,12 +104,12 @@ class BusinessExceptionHandlerTest {
 
         @Override
         public String title() {
-            return "여행 기록을 찾을 수 없습니다.";
+            return title;
         }
 
         @Override
         public String detail() {
-            return "요청한 여행 기록이 존재하지 않습니다.";
+            return detail;
         }
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/common/handler/BusinessExceptionHandlerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/handler/BusinessExceptionHandlerTest.java
@@ -6,13 +6,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.mapmory.backend.common.ProblemDetailFactory;
 import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.common.exception.ErrorCode;
 import com.mapmory.backend.common.exception.ErrorKind;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.MediaType;
@@ -49,13 +55,33 @@ class BusinessExceptionHandlerTest {
 
     @Test
     void 서비스_불가_예외는_ERROR와_원인을_기록한다(CapturedOutput output) throws Exception {
-        mockMvc.perform(get("/test/service-unavailable"))
-                .andExpect(status().isServiceUnavailable());
+        Logger logger = (Logger) LoggerFactory.getLogger(BusinessExceptionHandler.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            mockMvc.perform(get("/test/service-unavailable"))
+                    .andExpect(status().isServiceUnavailable());
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
 
         assertThat(output)
                 .contains("ERROR")
                 .contains("code=SERVICE_UNAVAILABLE")
                 .contains("upstream failure");
+
+        ILoggingEvent logEvent = appender.list.getFirst();
+        Map<String, Object> fields = logEvent.getKeyValuePairs().stream()
+                .collect(Collectors.toMap(pair -> pair.key, pair -> pair.value));
+        assertThat(fields)
+                .containsEntry("event", "BUSINESS_EXCEPTION")
+                .containsEntry("errorCode", "SERVICE_UNAVAILABLE")
+                .containsEntry("status", 503)
+                .containsEntry("httpMethod", "GET")
+                .containsEntry("uri", "/test/service-unavailable");
     }
 
     @RestController

--- a/backend/src/test/java/com/mapmory/backend/common/logging/RequestIdFilterTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/logging/RequestIdFilterTest.java
@@ -1,0 +1,77 @@
+package com.mapmory.backend.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RequestIdFilterTest {
+
+    private final RequestIdFilter filter = new RequestIdFilter();
+
+    @AfterEach
+    void clearMdc() {
+        MDC.remove(RequestIdFilter.REQUEST_ID_MDC_KEY);
+    }
+
+    @Test
+    void 요청_ID가_없으면_생성하여_MDC와_응답에_추가한다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (servletRequest, servletResponse) -> {
+            String requestId = MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY);
+            assertThat(requestId).isNotNull();
+            assertThat(UUID.fromString(requestId).toString()).isEqualTo(requestId);
+        });
+
+        assertThat(response.getHeader(RequestIdFilter.REQUEST_ID_HEADER)).isNotNull();
+        assertThat(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY)).isNull();
+    }
+
+    @Test
+    void 유효한_요청_ID는_그대로_사용한다() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(RequestIdFilter.REQUEST_ID_HEADER, requestId);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (servletRequest, servletResponse) ->
+                assertThat(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY)).isEqualTo(requestId));
+
+        assertThat(response.getHeader(RequestIdFilter.REQUEST_ID_HEADER)).isEqualTo(requestId);
+    }
+
+    @Test
+    void 유효하지_않은_요청_ID는_새로_생성한다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(RequestIdFilter.REQUEST_ID_HEADER, "invalid-request-id");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (servletRequest, servletResponse) -> {
+        });
+
+        String responseRequestId = response.getHeader(RequestIdFilter.REQUEST_ID_HEADER);
+        assertThat(responseRequestId).isNotEqualTo("invalid-request-id");
+        assertThat(UUID.fromString(responseRequestId).toString()).isEqualTo(responseRequestId);
+    }
+
+    @Test
+    void 예외가_발생해도_MDC를_정리한다() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, (servletRequest, servletResponse) -> {
+            throw new IOException("test failure");
+        })).isInstanceOf(IOException.class);
+
+        assertThat(MDC.get(RequestIdFilter.REQUEST_ID_MDC_KEY)).isNull();
+        assertThat(response.getHeader(RequestIdFilter.REQUEST_ID_HEADER)).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/common/logging/StructuredLoggingConfigurationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/logging/StructuredLoggingConfigurationTest.java
@@ -1,0 +1,48 @@
+package com.mapmory.backend.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+class StructuredLoggingConfigurationTest {
+
+    private final YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+
+    @Test
+    void 운영_환경은_Logstash_JSON_로그를_사용한다() throws IOException {
+        List<PropertySource<?>> sources = loader.load(
+                "application-prod",
+                new ClassPathResource("application-prod.yaml")
+        );
+
+        assertThat(property(sources, "logging.structured.format.console")).isEqualTo("logstash");
+        assertThat(property(sources, "logging.structured.json.add.service"))
+                .isEqualTo("${spring.application.name}");
+        assertThat(property(sources, "logging.structured.json.add.environment")).isEqualTo("prod");
+        assertThat(property(sources, "logging.structured.json.add.version"))
+                .isEqualTo("${APP_VERSION:unknown}");
+    }
+
+    @Test
+    void 로컬_환경은_구조화_로그를_활성화하지_않는다() throws IOException {
+        List<PropertySource<?>> sources = loader.load(
+                "application-local",
+                new ClassPathResource("application-local.yaml")
+        );
+
+        assertThat(property(sources, "logging.structured.format.console")).isNull();
+    }
+
+    private static Object property(List<PropertySource<?>> sources, String name) {
+        return sources.stream()
+                .map(source -> source.getProperty(name))
+                .filter(value -> value != null)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/common/monitoring/MetricsConfigurationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/monitoring/MetricsConfigurationTest.java
@@ -24,6 +24,8 @@ class MetricsConfigurationTest {
                 .isNull();
         assertThat(property(sources, "management.metrics.distribution.slo.http.server.requests"))
                 .isEqualTo("100ms,300ms,500ms,1s,2s,3s,5s");
+        assertThat(property(sources, "management.metrics.distribution.slo.mapmory.operation.duration"))
+                .isEqualTo("10ms,50ms,100ms,300ms,500ms,1s,3s,5s");
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/common/monitoring/MetricsConfigurationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/monitoring/MetricsConfigurationTest.java
@@ -1,0 +1,51 @@
+package com.mapmory.backend.common.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+class MetricsConfigurationTest {
+
+    @Test
+    void HTTP_응답_시간은_제한된_SLO_버킷으로_수집한다() throws IOException {
+        List<PropertySource<?>> sources = new YamlPropertySourceLoader().load(
+                "application",
+                new ClassPathResource("application.yaml")
+        );
+
+        assertThat(property(sources, "management.metrics.distribution.percentiles-histogram.http.server.requests"))
+                .isNull();
+        assertThat(property(sources, "management.metrics.distribution.slo.http.server.requests"))
+                .isEqualTo("100ms,300ms,500ms,1s,2s,3s,5s");
+    }
+
+    @Test
+    void HTTP_URI_태그는_허용된_개수까지만_등록한다() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        registry.config().meterFilter(new MetricsConfiguration().httpServerUriCardinalityLimit());
+
+        for (int index = 0; index <= MetricsConfiguration.MAX_HTTP_SERVER_URI_TAG_VALUES; index++) {
+            Timer.builder("http.server.requests")
+                    .tag("uri", "/test/" + index)
+                    .register(registry);
+        }
+
+        assertThat(registry.find("http.server.requests").timers())
+                .hasSize(MetricsConfiguration.MAX_HTTP_SERVER_URI_TAG_VALUES);
+    }
+
+    private static Object property(List<PropertySource<?>> sources, String name) {
+        return sources.stream()
+                .map(source -> source.getProperty(name))
+                .filter(value -> value != null)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/common/monitoring/OperationTimerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/monitoring/OperationTimerTest.java
@@ -1,0 +1,39 @@
+package com.mapmory.backend.common.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+class OperationTimerTest {
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final OperationTimer operationTimer = new OperationTimer(meterRegistry);
+
+    @Test
+    void 성공한_작업의_시간을_기록한다() {
+        String result = operationTimer.record(MonitoredOperation.MEDIA_SYNC, () -> "result");
+
+        assertThat(result).isEqualTo("result");
+        assertThat(timer(MonitoredOperation.MEDIA_SYNC, "SUCCESS").count()).isEqualTo(1L);
+    }
+
+    @Test
+    void 실패한_작업의_시간을_기록하고_예외를_다시_던진다() {
+        assertThatThrownBy(() -> operationTimer.record(MonitoredOperation.S3_PRESIGN, () -> {
+            throw new IllegalStateException("presign failed");
+        })).isInstanceOf(IllegalStateException.class)
+                .hasMessage("presign failed");
+
+        assertThat(timer(MonitoredOperation.S3_PRESIGN, "FAILURE").count()).isEqualTo(1L);
+    }
+
+    private Timer timer(MonitoredOperation operation, String outcome) {
+        return meterRegistry.get(OperationTimer.METRIC_NAME)
+                .tag("operation", operation.name())
+                .tag("outcome", outcome)
+                .timer();
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/common/monitoring/OperationTimerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/common/monitoring/OperationTimerTest.java
@@ -22,12 +22,12 @@ class OperationTimerTest {
 
     @Test
     void 실패한_작업의_시간을_기록하고_예외를_다시_던진다() {
-        assertThatThrownBy(() -> operationTimer.record(MonitoredOperation.S3_PRESIGN, () -> {
-            throw new IllegalStateException("presign failed");
+        assertThatThrownBy(() -> operationTimer.record(MonitoredOperation.MAP_SUMMARY_QUERY, () -> {
+            throw new IllegalStateException("query failed");
         })).isInstanceOf(IllegalStateException.class)
-                .hasMessage("presign failed");
+                .hasMessage("query failed");
 
-        assertThat(timer(MonitoredOperation.S3_PRESIGN, "FAILURE").count()).isEqualTo(1L);
+        assertThat(timer(MonitoredOperation.MAP_SUMMARY_QUERY, "FAILURE").count()).isEqualTo(1L);
     }
 
     private Timer timer(MonitoredOperation operation, String outcome) {

--- a/backend/src/test/java/com/mapmory/backend/monitoring/HttpClientMetricsIntegrationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/monitoring/HttpClientMetricsIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.mapmory.backend.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.mapmory.backend.IntegrationTest;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class HttpClientMetricsIntegrationTest extends IntegrationTest {
+
+    private static final String TEST_URI = "https://example.test/users/1";
+
+    @Autowired
+    private RestClient.Builder restClientBuilder;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @Test
+    void 자동_구성된_RestClient는_외부_HTTP_호출_메트릭을_기록한다() {
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+        RestClient restClient = restClientBuilder.build();
+        server.expect(requestTo(TEST_URI))
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+        restClient.get()
+                .uri(TEST_URI)
+                .retrieve()
+                .toBodilessEntity();
+
+        server.verify();
+
+        Collection<Timer> timers = meterRegistry.find("http.client.requests").timers();
+        assertThat(timers)
+                .anySatisfy(timer -> {
+                    assertThat(timer.count()).isPositive();
+                    assertThat(timer.getId().getTag("service")).isEqualTo("mapmory-backend");
+                    assertThat(timer.getId().getTag("environment")).isEqualTo("local");
+                });
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.common.monitoring.MonitoredOperation;
+import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
@@ -23,6 +25,7 @@ import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -56,6 +60,9 @@ class TravelRecordServiceTest {
 
     @Mock
     private TagService tagService;
+
+    @Spy
+    private OperationTimer operationTimer = new OperationTimer(new SimpleMeterRegistry());
 
     @InjectMocks
     private TravelRecordService travelRecordService;
@@ -209,6 +216,7 @@ class TravelRecordServiceTest {
                     && iterator.next() == mediaA
                     && !iterator.hasNext();
         }));
+        verify(operationTimer).record(eq(MonitoredOperation.MEDIA_SYNC), any());
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.region.exception.RegionErrorCode;
@@ -18,6 +19,7 @@ import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryQueryResult;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,6 +47,7 @@ class RegionMapSummaryServiceTest {
     private TagService tagService;
 
     private final LevelPolicy levelPolicy = LevelPolicy.standard();
+    private final OperationTimer operationTimer = new OperationTimer(new SimpleMeterRegistry());
 
     @Nested
     @DisplayName("Region 요약을 조회할 때")
@@ -136,7 +139,8 @@ class RegionMapSummaryServiceTest {
                 regionRepository,
                 regionMapSummaryRepository,
                 levelPolicy,
-                tagService
+                tagService,
+                operationTimer
         );
     }
 

--- a/backend/src/test/java/com/mapmory/backend/upload/storage/S3PresignedUrlProviderTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/storage/S3PresignedUrlProviderTest.java
@@ -1,0 +1,76 @@
+package com.mapmory.backend.upload.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.common.monitoring.MonitoredOperation;
+import com.mapmory.backend.common.monitoring.OperationTimer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+class S3PresignedUrlProviderTest {
+
+    private final S3Presigner s3Presigner = mock(S3Presigner.class);
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private S3PresignedUrlProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new S3PresignedUrlProvider(
+                s3Presigner,
+                new S3StorageProperties("mapmory-test", "ap-northeast-2"),
+                new OperationTimer(meterRegistry)
+        );
+    }
+
+    @Test
+    void Presigned_URL_생성_성공_시간을_기록한다() throws Exception {
+        PresignedPutObjectRequest result = mock(PresignedPutObjectRequest.class);
+        when(result.url()).thenReturn(URI.create("https://upload.example/object-key").toURL());
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(result);
+
+        URI uri = provider.createPresignedPutUrl(
+                "object-key",
+                "image/jpeg",
+                1024L,
+                Duration.ofMinutes(5)
+        );
+
+        assertThat(uri).isEqualTo(URI.create("https://upload.example/object-key"));
+        assertThat(timerCount("SUCCESS")).isEqualTo(1L);
+    }
+
+    @Test
+    void Presigned_URL_생성_실패_시간을_기록하고_예외를_전파한다() {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+                .thenThrow(new IllegalStateException("s3 failure"));
+
+        assertThatThrownBy(() -> provider.createPresignedPutUrl(
+                "object-key",
+                "image/jpeg",
+                1024L,
+                Duration.ofMinutes(5)
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessage("s3 failure");
+
+        assertThat(timerCount("FAILURE")).isEqualTo(1L);
+    }
+
+    private long timerCount(String outcome) {
+        return meterRegistry.get(OperationTimer.METRIC_NAME)
+                .tag("operation", MonitoredOperation.S3_PRESIGN.name())
+                .tag("outcome", outcome)
+                .timer()
+                .count();
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/upload/storage/S3PresignedUrlProviderTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/storage/S3PresignedUrlProviderTest.java
@@ -6,10 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.mapmory.backend.common.monitoring.MonitoredOperation;
-import com.mapmory.backend.common.monitoring.OperationTimer;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.URI;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,20 +17,18 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 class S3PresignedUrlProviderTest {
 
     private final S3Presigner s3Presigner = mock(S3Presigner.class);
-    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
     private S3PresignedUrlProvider provider;
 
     @BeforeEach
     void setUp() {
         provider = new S3PresignedUrlProvider(
                 s3Presigner,
-                new S3StorageProperties("mapmory-test", "ap-northeast-2"),
-                new OperationTimer(meterRegistry)
+                new S3StorageProperties("mapmory-test", "ap-northeast-2")
         );
     }
 
     @Test
-    void Presigned_URL_생성_성공_시간을_기록한다() throws Exception {
+    void Presigned_URL을_생성한다() throws Exception {
         PresignedPutObjectRequest result = mock(PresignedPutObjectRequest.class);
         when(result.url()).thenReturn(URI.create("https://upload.example/object-key").toURL());
         when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(result);
@@ -47,11 +41,10 @@ class S3PresignedUrlProviderTest {
         );
 
         assertThat(uri).isEqualTo(URI.create("https://upload.example/object-key"));
-        assertThat(timerCount("SUCCESS")).isEqualTo(1L);
     }
 
     @Test
-    void Presigned_URL_생성_실패_시간을_기록하고_예외를_전파한다() {
+    void Presigned_URL_생성_실패_예외를_전파한다() {
         when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
                 .thenThrow(new IllegalStateException("s3 failure"));
 
@@ -62,15 +55,5 @@ class S3PresignedUrlProviderTest {
                 Duration.ofMinutes(5)
         )).isInstanceOf(IllegalStateException.class)
                 .hasMessage("s3 failure");
-
-        assertThat(timerCount("FAILURE")).isEqualTo(1L);
-    }
-
-    private long timerCount(String outcome) {
-        return meterRegistry.get(OperationTimer.METRIC_NAME)
-                .tag("operation", MonitoredOperation.S3_PRESIGN.name())
-                .tag("outcome", outcome)
-                .timer()
-                .count();
     }
 }


### PR DESCRIPTION
## 요약

백엔드 장애를 요청 단위로 추적하고 주요 API 및 내부 작업의 성능을 관찰할 수 있도록 로깅·메트릭 기반을 구축합니다.
Prometheus가 수집할 Actuator 엔드포인트, 운영 JSON 로그, Request ID, 저카디널리티 내부 작업 Timer를 추가합니다.

## 관련 이슈

Closes #133

## 배경

사용자 오류와 외부 API 장애의 원인 및 병목 지점을 운영 환경에서 빠르게 식별하기 위함입니다.
설계 근거와 운영 기준은 ADR 0014에 정리했습니다.

## 주요 결정

- Actuator의 health/info/prometheus만 노출하고 메트릭 상세 정보는 인증된 관리 경로에서만 확인
- X-Request-Id를 검증하거나 생성해 응답·MDC·예외 로그를 하나의 요청으로 연결
- 운영 로그는 CloudWatch 검색·필드 분석에 적합한 JSON 형식으로 출력
- URI·예외명 등의 태그 값을 제한해 Prometheus 시계열 증가 방지
- MEDIA_SYNC, MAP_SUMMARY_QUERY, S3_PRESIGN 작업을 고정된 operation/outcome 태그로 측정

## 한계

- CloudWatch 수집·대시보드·알람 구성은 후속 작업에서 진행
- Prometheus 서버 배포 및 장기 보관 구성은 포함하지 않음

## 확인

- [x] 로컬 전체 테스트 실행: ./gradlew test --rerun-tasks
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 새 환경변수 추가 없음
- [x] DB 스키마 변경 없음
- [x] 설계 및 운영 기준 ADR 갱신
