### PR TITLE
fix: 가로 화면 회전 방지

### DIFF
--- a/client/androidApp/src/main/AndroidManifest.xml
+++ b/client/androidApp/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## 변경 내용
- Android MainActivity를 세로 방향으로 고정했습니다.
- 가로 회전으로 인해 세로형 UI가 깨지는 문제를 방지합니다.

## 검증
- [x] `:androidApp:assembleDebug`
- [x] 실기기에서 화면 회전 동작 확인

Closes #129