### PR TITLE
feat: 작성 중 이탈 및 사진 로딩 중 저장 확인 추가

### DIFF
--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
@@ -45,21 +45,28 @@ actual fun rememberPhotoLibraryActions(
     onPhotosPicked: (List<SelectedPhoto>) -> Unit,
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
+    onLoadingChanged: (Boolean) -> Unit,
 ): PhotoLibraryActions {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val latestPicked by rememberUpdatedState(onPhotosPicked)
     val latestRecommended by rememberUpdatedState(onPhotosRecommended)
     val latestMessage by rememberUpdatedState(onMessage)
+    val latestLoadingChanged by rememberUpdatedState(onLoadingChanged)
     var pendingRecommendation by remember { mutableStateOf<Pair<Location, String?>?>(null) }
 
     fun loadRecommendations(target: Location, parentName: String?) {
+        latestLoadingChanged(true)
         scope.launch {
+            try {
             val result = withContext(Dispatchers.IO) {
                 runCatching { context.recommendPhotos(target, parentName) }
             }
-            result.onSuccess(latestRecommended).onFailure {
-                latestMessage("사진 추천을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.")
+                result.onSuccess(latestRecommended).onFailure {
+                    latestMessage("사진 추천을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.")
+                }
+            } finally {
+                latestLoadingChanged(false)
             }
         }
     }
@@ -84,8 +91,12 @@ actual fun rememberPhotoLibraryActions(
     val galleryPicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickMultipleVisualMedia(),
     ) { uris ->
-        if (uris.isEmpty()) return@rememberLauncherForActivityResult
+        if (uris.isEmpty()) {
+            latestLoadingChanged(false)
+            return@rememberLauncherForActivityResult
+        }
         scope.launch {
+            try {
             val photos = withContext(Dispatchers.IO) {
                 Trace.beginAsyncSection("photo.pick.total", TraceCookie.Pick)
                 val startedAt = SystemClock.elapsedRealtime()
@@ -103,10 +114,13 @@ actual fun rememberPhotoLibraryActions(
                     Trace.endAsyncSection("photo.pick.total", TraceCookie.Pick)
                 }
             }
-            if (photos.isEmpty()) {
-                latestMessage("선택한 사진을 읽지 못했어요.")
-            } else {
-                latestPicked(photos)
+                if (photos.isEmpty()) {
+                    latestMessage("선택한 사진을 읽지 못했어요.")
+                } else {
+                    latestPicked(photos)
+                }
+            } finally {
+                latestLoadingChanged(false)
             }
         }
     }
@@ -114,6 +128,7 @@ actual fun rememberPhotoLibraryActions(
     return remember(context, galleryPicker, galleryPermissionLauncher) {
         PhotoLibraryActions(
             pickFromGallery = {
+                latestLoadingChanged(true)
                 galleryPicker.launch(
                     PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
                 )

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -4,15 +4,23 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -33,6 +41,7 @@ import com.mapmory.shared.presentation.triprecord.screen.TripProfileScreen
 import com.mapmory.shared.presentation.triprecord.screen.TripRecordDetailScreen
 import com.mapmory.shared.presentation.triprecord.screen.TripRecordEditorScreen
 import com.mapmory.shared.presentation.triprecord.screen.TripRecordListScreen
+import com.mapmory.shared.presentation.triprecord.screen.TripRecordPalette
 import com.mapmory.shared.presentation.triprecord.state.TripRecordDetailUiState
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEffect
 import com.mapmory.shared.presentation.triprecord.state.TripRecordListUiState
@@ -72,8 +81,12 @@ fun MapmoryApp(
     var mapScope by remember { mutableStateOf(MapScope.KOREA) }
     var koreaMapUiState by remember { mutableStateOf<KoreaMapUiState>(KoreaMapUiState.ProvinceOverview) }
     val locationsById = remember { appLocations.associateBy(Location::id) }
+    var isEditorVisible by remember { mutableStateOf(false) }
+    var pendingEditorExit by remember { mutableStateOf<(() -> Unit)?>(null) }
+    var pendingPhotoLoadingAction by remember { mutableStateOf<(() -> Unit)?>(null) }
+    var isPhotoLoadingSaveConfirmation by remember { mutableStateOf(false) }
 
-    fun navigateBack(): Boolean {
+    fun navigateBackDirectly(): Boolean {
         if (mapScope == MapScope.KOREA && koreaMapUiState is KoreaMapUiState.DistrictDetail) {
             koreaMapUiState = KoreaMapUiState.ProvinceOverview
             return true
@@ -85,16 +98,34 @@ fun MapmoryApp(
             return true
         }
 
-        // popBackStack can empty the stack when a destination has no parent.
-        // Restore the home route instead of leaving NavHost without content.
         navController.navigate(MapRoute) {
             launchSingleTop = true
         }
         return true
     }
 
+    fun requestEditorExit(exit: () -> Unit) {
+        when {
+            recordsUiState.editor.isPhotoLoading -> {
+                isPhotoLoadingSaveConfirmation = false
+                pendingPhotoLoadingAction = exit
+            }
+            recordsUiState.editor.isDirty -> pendingEditorExit = exit
+            else -> exit()
+        }
+    }
+
+    fun navigateBack(): Boolean {
+        if (isEditorVisible) {
+            requestEditorExit { navigateBackDirectly() }
+            return true
+        }
+        return navigateBackDirectly()
+    }
+
+    val latestNavigateBack by rememberUpdatedState(::navigateBack)
     DisposableEffect(navigation, navController) {
-        navigation?.bindBackHandler(::navigateBack)
+        navigation?.bindBackHandler { latestNavigateBack() }
         onDispose { navigation?.unbindBackHandler() }
     }
 
@@ -294,6 +325,10 @@ fun MapmoryApp(
         }
 
         composable<CreateRoute> {
+            DisposableEffect(Unit) {
+                isEditorVisible = true
+                onDispose { isEditorVisible = false }
+            }
             TripRecordEditorScreen(
                 modifier = Modifier.windowInsetsPadding(
                     contentWindowInsets.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
@@ -324,11 +359,23 @@ fun MapmoryApp(
                 onPhotoRemoved = { photoId ->
                     recordsViewModel.onAction(TripRecordAction.PhotoRemoved(photoId))
                 },
-                onSaveClick = { recordsViewModel.onAction(TripRecordAction.Save) },
-                onBackClick = { navigateBack() },
-                onMapClick = { navigateToTab(MapRoute) },
-                onRecordClick = { navigateToTab(RecordsRoute) },
-                onProfileClick = { navigateToTab(ProfileRoute) },
+                onPhotoLoadingChanged = { isLoading ->
+                    recordsViewModel.onAction(TripRecordAction.PhotoLoadingChanged(isLoading))
+                },
+                onSaveClick = {
+                    if (recordsUiState.editor.isPhotoLoading) {
+                        isPhotoLoadingSaveConfirmation = true
+                        pendingPhotoLoadingAction = {
+                            recordsViewModel.onAction(TripRecordAction.SaveWithoutPendingPhotos)
+                        }
+                    } else {
+                        recordsViewModel.onAction(TripRecordAction.Save)
+                    }
+                },
+                onBackClick = { requestEditorExit { navigateBackDirectly() } },
+                onMapClick = { requestEditorExit { navigateToTab(MapRoute) } },
+                onRecordClick = { requestEditorExit { navigateToTab(RecordsRoute) } },
+                onProfileClick = { requestEditorExit { navigateToTab(ProfileRoute) } },
             )
         }
 
@@ -371,6 +418,76 @@ fun MapmoryApp(
             )
         }
     }
+
+    pendingEditorExit?.let { exit ->
+        EditorConfirmationDialog(
+            title = "작성 중인 기록이 있어요",
+            message = "지금 나가면 작성한 내용이 사라집니다. 그래도 나갈까요?",
+            confirmLabel = "나가기",
+            confirmColor = TripRecordPalette.danger,
+            onConfirm = {
+                pendingEditorExit = null
+                exit()
+            },
+            onDismiss = { pendingEditorExit = null },
+        )
+    }
+
+    pendingPhotoLoadingAction?.let { action ->
+        EditorConfirmationDialog(
+            title = "사진을 불러오는 중이에요",
+            message = if (isPhotoLoadingSaveConfirmation) {
+                "지금 저장하면 불러오는 중인 사진은 기록에 포함되지 않아요. 현재 내용만 저장할까요?"
+            } else {
+                "지금 나가면 불러오는 사진과 작성 중인 내용은 저장되지 않아요. 그래도 나갈까요?"
+            },
+            confirmLabel = if (isPhotoLoadingSaveConfirmation) "현재 내용 저장" else "나가기",
+            confirmColor = if (isPhotoLoadingSaveConfirmation) {
+                TripRecordPalette.accent
+            } else {
+                TripRecordPalette.danger
+            },
+            onConfirm = {
+                pendingPhotoLoadingAction = null
+                action()
+            },
+            onDismiss = { pendingPhotoLoadingAction = null },
+        )
+    }
+}
+
+@Composable
+private fun EditorConfirmationDialog(
+    title: String,
+    message: String,
+    confirmLabel: String,
+    confirmColor: Color,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
+        shape = RoundedCornerShape(20.dp),
+        containerColor = TripRecordPalette.surface,
+        titleContentColor = TripRecordPalette.text,
+        textContentColor = TripRecordPalette.bodyText,
+        title = { Text(title) },
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(confirmLabel, color = confirmColor)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("계속 작성", color = TripRecordPalette.accent)
+            }
+        },
+    )
 }
 
 fun createTripRecordsViewModel(): TripRecordsViewModel = TripRecordsViewModel(appLocations)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -87,21 +87,22 @@ fun MapmoryApp(
     var isPhotoLoadingSaveConfirmation by remember { mutableStateOf(false) }
 
     fun navigateBackDirectly(): Boolean {
+        if (navController.currentDestination?.id != navController.graph.startDestinationId) {
+            if (navController.popBackStack()) {
+                return true
+            }
+
+            navController.navigate(MapRoute) {
+                launchSingleTop = true
+            }
+            return true
+        }
+
         if (mapScope == MapScope.KOREA && koreaMapUiState is KoreaMapUiState.DistrictDetail) {
             koreaMapUiState = KoreaMapUiState.ProvinceOverview
             return true
         }
-        if (navController.currentDestination?.id == navController.graph.startDestinationId) {
-            return false
-        }
-        if (navController.popBackStack()) {
-            return true
-        }
-
-        navController.navigate(MapRoute) {
-            launchSingleTop = true
-        }
-        return true
+        return false
     }
 
     fun requestEditorExit(exit: () -> Unit) {

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
@@ -27,6 +27,7 @@ typealias PhotoLibraryActionsFactory = @Composable (
     onPhotosPicked: (List<SelectedPhoto>) -> Unit,
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
+    onLoadingChanged: (Boolean) -> Unit,
 ) -> PhotoLibraryActions
 
 @Composable
@@ -34,6 +35,7 @@ expect fun rememberPhotoLibraryActions(
     onPhotosPicked: (List<SelectedPhoto>) -> Unit,
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
+    onLoadingChanged: (Boolean) -> Unit,
 ): PhotoLibraryActions
 
 internal fun mergeSelectedPhotos(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -103,13 +103,14 @@ fun TripRecordEditorScreen(
     onEndDateChanged: (String) -> Unit,
     onPhotosAdded: (List<SelectedPhoto>) -> Unit = {},
     onPhotoRemoved: (String) -> Unit = {},
+    onPhotoLoadingChanged: (Boolean) -> Unit = {},
     onSaveClick: () -> Unit,
     onBackClick: () -> Unit,
     onMapClick: () -> Unit = {},
     onRecordClick: () -> Unit = {},
     onProfileClick: () -> Unit = {},
-    photoLibraryActionsFactory: PhotoLibraryActionsFactory = { onPicked, onRecommended, onMessage ->
-        rememberPhotoLibraryActions(onPicked, onRecommended, onMessage)
+    photoLibraryActionsFactory: PhotoLibraryActionsFactory = { onPicked, onRecommended, onMessage, onLoadingChanged ->
+        rememberPhotoLibraryActions(onPicked, onRecommended, onMessage, onLoadingChanged)
     },
     modifier: Modifier = Modifier,
 ) {
@@ -148,6 +149,7 @@ fun TripRecordEditorScreen(
             }
         },
         { photoMessage = it },
+        onPhotoLoadingChanged,
     )
     val locationResultsListState = rememberLazyListState()
     val filteredLocations = remember(locationSearchQuery, selectableLocations) {
@@ -206,6 +208,7 @@ fun TripRecordEditorScreen(
                             },
                             onRemoveClick = onPhotoRemoved,
                             recommendationsAvailable = photoLibrary.recommendationsAvailable,
+                            isLoading = uiState.isPhotoLoading,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = 18.dp),
@@ -416,8 +419,10 @@ fun TripRecordEditorScreen(
                         val selectedPhotos = recommendedPhotos
                             .filter { it.id in selectedRecommendationIds }
                         isPreparingRecommendationPhotos = true
+                        onPhotoLoadingChanged(true)
                         photoLibrary.prepareForAdding(selectedPhotos) { preparedPhotos ->
                             isPreparingRecommendationPhotos = false
+                            onPhotoLoadingChanged(false)
                             if (preparedPhotos.isEmpty()) {
                                 photoMessage = "선택한 사진의 원본을 읽지 못했어요."
                             } else {
@@ -536,6 +541,7 @@ private fun PhotoSection(
     onRecommendClick: () -> Unit,
     onRemoveClick: (String) -> Unit,
     recommendationsAvailable: Boolean,
+    isLoading: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -557,7 +563,7 @@ private fun PhotoSection(
             Spacer(Modifier.width(10.dp))
             TextButton(
                 onClick = onRecommendClick,
-                enabled = recommendationsAvailable,
+                enabled = recommendationsAvailable && !isLoading,
                 contentPadding = PaddingValues(horizontal = 9.dp, vertical = 2.dp),
                 modifier = Modifier
                     .height(36.dp)
@@ -581,6 +587,7 @@ private fun PhotoSection(
             photos = photos,
             onAddClick = onAddClick,
             onRemoveClick = onRemoveClick,
+            isAddEnabled = !isLoading,
             modifier = Modifier.padding(top = 12.dp, bottom = 16.dp),
         )
     }
@@ -796,6 +803,7 @@ private fun PhotoEditor(
     photos: List<TripRecordPhotoUiState>,
     onAddClick: () -> Unit,
     onRemoveClick: (String) -> Unit,
+    isAddEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -805,7 +813,7 @@ private fun PhotoEditor(
             .padding(horizontal = 20.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        PhotoActionButton(onClick = onAddClick)
+        PhotoActionButton(onClick = onAddClick, enabled = isAddEnabled)
         photos.forEach { photo ->
             Box {
                 PhotoPreview(photo = photo, modifier = Modifier.size(112.dp, 84.dp))
@@ -828,12 +836,12 @@ private fun PhotoEditor(
 }
 
 @Composable
-private fun PhotoActionButton(onClick: () -> Unit) {
+private fun PhotoActionButton(onClick: () -> Unit, enabled: Boolean) {
     Column(
         modifier = Modifier
             .size(112.dp, 84.dp)
             .clip(RoundedCornerShape(14.dp))
-            .clickable(onClick = onClick)
+            .clickable(enabled = enabled, onClick = onClick)
             .background(TripRecordPalette.photoGalleryBackground)
             .border(1.dp, TripRecordPalette.photoGalleryBorder, RoundedCornerShape(14.dp)),
         verticalArrangement = Arrangement.Center,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordEditorUiState.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordEditorUiState.kt
@@ -14,6 +14,7 @@ data class TripRecordEditorUiState(
     val isDirty: Boolean = false,
     val dirtyFields: Set<TripRecordEditorErrorTarget> = emptySet(),
     val isSaving: Boolean = false,
+    val isPhotoLoading: Boolean = false,
     val fieldErrors: Map<TripRecordEditorErrorTarget, String> = emptyMap(),
     val generalErrorMessage: String? = null,
 ) {

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModel.kt
@@ -47,7 +47,11 @@ sealed interface TripRecordAction {
 
     data class PhotoRemoved(val photoId: String) : TripRecordAction
 
+    data class PhotoLoadingChanged(val isLoading: Boolean) : TripRecordAction
+
     data object Save : TripRecordAction
+
+    data object SaveWithoutPendingPhotos : TripRecordAction
 
     data class Delete(val recordId: Long) : TripRecordAction
 
@@ -137,7 +141,14 @@ class TripRecordsViewModel(
 
             is TripRecordAction.PhotosAdded -> addPhotos(action.photos)
             is TripRecordAction.PhotoRemoved -> removePhoto(action.photoId)
+            is TripRecordAction.PhotoLoadingChanged -> updateEditor {
+                copy(isPhotoLoading = action.isLoading)
+            }
             TripRecordAction.Save -> save()
+            TripRecordAction.SaveWithoutPendingPhotos -> {
+                updateEditor { copy(isPhotoLoading = false) }
+                save()
+            }
             is TripRecordAction.Delete -> delete(action.recordId)
             TripRecordAction.EffectHandled -> uiState = uiState.copy(effect = null)
         }
@@ -213,6 +224,7 @@ class TripRecordsViewModel(
 
     private fun save() {
         val editor = uiState.editor
+        if (editor.isPhotoLoading) return
         val title = editor.title.trim()
         val startDate = editor.startDate.takeIf(String::isNotBlank)?.toLocalDateOrNull()
         val endDate = editor.endDate.takeIf(String::isNotBlank)?.toLocalDateOrNull()

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordsViewModelTest.kt
@@ -44,6 +44,27 @@ class TripRecordsViewModelTest {
     }
 
     @Test
+    fun `사진을 불러오는 동안 확인 없이 저장할 수 없고 사진 제외 저장은 가능하다`() {
+        val viewModel = TripRecordsViewModel(locations)
+        viewModel.onAction(TripRecordAction.StartCreating(gangnam))
+        viewModel.onAction(TripRecordAction.EffectHandled)
+        viewModel.onAction(TripRecordAction.TitleChanged("서울 여행"))
+        viewModel.onAction(TripRecordAction.PhotoLoadingChanged(true))
+
+        assertTrue(viewModel.uiState.editor.isSaveEnabled)
+
+        viewModel.onAction(TripRecordAction.Save)
+
+        assertTrue(viewModel.uiState.records.isEmpty())
+        assertNull(viewModel.uiState.effect)
+
+        viewModel.onAction(TripRecordAction.SaveWithoutPendingPhotos)
+
+        assertEquals("서울 여행", viewModel.uiState.records.single().title)
+        assertEquals(TripRecordEffect.OpenRecords, viewModel.uiState.effect)
+    }
+
+    @Test
     fun `화면 액션으로 도메인 여행 기록을 생성하고 UI 상태를 발행한다`() {
         val viewModel = TripRecordsViewModel(locations)
         val initialState = viewModel.uiState

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
@@ -65,12 +65,14 @@ actual fun rememberPhotoLibraryActions(
     onPhotosPicked: (List<SelectedPhoto>) -> Unit,
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
+    onLoadingChanged: (Boolean) -> Unit,
 ): PhotoLibraryActions {
     val scope = rememberCoroutineScope()
     val controller = remember(scope) { IosPhotoLibraryController(scope) }
     controller.onPhotosPicked = onPhotosPicked
     controller.onPhotosRecommended = onPhotosRecommended
     controller.onMessage = onMessage
+    controller.onLoadingChanged = onLoadingChanged
 
     return remember(controller) {
         PhotoLibraryActions(
@@ -87,6 +89,7 @@ private class IosPhotoLibraryController(
     var onPhotosPicked: (List<SelectedPhoto>) -> Unit = {}
     var onPhotosRecommended: (List<SelectedPhoto>) -> Unit = {}
     var onMessage: (String) -> Unit = {}
+    var onLoadingChanged: (Boolean) -> Unit = {}
     private var recommendationJob: Job? = null
     private var recommendationGeneration = 0
 
@@ -100,6 +103,7 @@ private class IosPhotoLibraryController(
             selectionLimit = 0
         }
         val picker = PHPickerViewController(configuration)
+        onLoadingChanged(true)
         picker.delegate = this
         presenter.presentViewController(picker, animated = true, completion = null)
     }
@@ -107,7 +111,10 @@ private class IosPhotoLibraryController(
     override fun picker(picker: PHPickerViewController, didFinishPicking: List<*>) {
         picker.dismissViewControllerAnimated(true, completion = null)
         val results = didFinishPicking.filterIsInstance<PHPickerResult>()
-        if (results.isEmpty()) return
+        if (results.isEmpty()) {
+            onLoadingChanged(false)
+            return
+        }
 
         val loaded = MutableList<SelectedPhoto?>(results.size) { null }
         var remaining = results.size
@@ -122,6 +129,7 @@ private class IosPhotoLibraryController(
                     } else {
                         onPhotosPicked(photos)
                     }
+                    onLoadingChanged(false)
                 }
             }
         }
@@ -153,12 +161,14 @@ private class IosPhotoLibraryController(
     private fun findRecommendations(location: Location) {
         recommendationJob?.cancel()
         val generation = ++recommendationGeneration
+        onLoadingChanged(true)
         recommendationJob = scope.launch {
             val region = withContext(Dispatchers.Default) {
                 runCatching { location.photoRecommendationRegion() }.getOrNull()
             }
             if (region == null) {
                 onMessage("선택한 장소의 경계를 확인하지 못했어요.")
+                onLoadingChanged(false)
                 return@launch
             }
             val matchingAssets = withContext(Dispatchers.Default) {
@@ -167,10 +177,12 @@ private class IosPhotoLibraryController(
             if (generation != recommendationGeneration) return@launch
             if (matchingAssets.isEmpty()) {
                 onPhotosRecommended(emptyList())
+                onLoadingChanged(false)
             } else {
                 loadAssetPreviews(matchingAssets) { photos ->
                     if (generation == recommendationGeneration) {
                         onPhotosRecommended(photos)
+                        onLoadingChanged(false)
                     }
                 }
             }
@@ -240,7 +252,7 @@ private class IosPhotoLibraryController(
                 loaded[index] = photo
                 remaining -= 1
                 val available = loaded.filterNotNull()
-                if (available.isNotEmpty() || remaining == 0) {
+                if (remaining == 0) {
                     completion(available)
                 }
             }

--- a/client/shared/src/jvmMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.jvm.kt
+++ b/client/shared/src/jvmMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.jvm.kt
@@ -8,7 +8,8 @@ actual fun rememberPhotoLibraryActions(
     onPhotosPicked: (List<SelectedPhoto>) -> Unit,
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
-): PhotoLibraryActions = remember(onMessage) {
+    onLoadingChanged: (Boolean) -> Unit,
+): PhotoLibraryActions = remember(onMessage, onLoadingChanged) {
     PhotoLibraryActions(
         pickFromGallery = { onMessage("사진 선택은 Android와 iOS 앱에서 사용할 수 있어요.") },
         recommendForLocation = { _, _ -> },


### PR DESCRIPTION
## 요약
입력 이탈 방어 로직 추가

## 구현한 기능
- 작성 중인 내용이 있을 때 화면 이탈 전 확인 절차를 추가했습니다.
  - 상단 뒤로가기
  - 시스템 뒤로가기
  - 하단 탭 이동
- 사진을 불러오는 중 저장을 누르면, 불러오는 사진을 제외하고 현재 내용만 저장할지 확인합니다.
- 사진 로딩 중 이탈 시 불러오는 사진과 작성 내용이 저장되지 않음을 안내합니다.
- 확인 UI에 앱 컬러 팔레트를 적용했습니다.
- 확인 UI 외부 영역 또는 뒤로가기를 누르면 UI를 닫고 작성을 계속합니다.
- Android/iOS 사진 선택 및 추천 로딩 상태를 공통 편집 상태에 연결했습니다.

close #130 