### PR TITLE
ci: 랜딩 자동 배포를 중단하고 CI만 유지

### DIFF
--- a/.github/workflows/landing-cicd.yml
+++ b/.github/workflows/landing-cicd.yml
@@ -1,4 +1,4 @@
-name: Landing CI/CD
+name: Landing CI
 
 on:
   pull_request:
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build:
-    name: Test and build
+    name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -47,67 +47,3 @@ jobs:
 
       - name: Run landing tests
         run: npm run test:sites
-
-      - name: Package static files
-        run: tar -czf "$RUNNER_TEMP/mapmory-landing.tar.gz" -C dist/client .
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: mapmory-landing
-          path: ${{ runner.temp }}/mapmory-landing.tar.gz
-          if-no-files-found: error
-          retention-days: 7
-
-  deploy:
-    name: Deploy to EC2
-    if: github.event_name != 'pull_request'
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: landing-production
-
-    steps:
-      - name: Check out deployment script
-        uses: actions/checkout@v7
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: mapmory-landing
-          path: ${{ runner.temp }}
-
-      - name: Configure SSH
-        env:
-          LANDING_EC2_SSH_KEY: ${{ secrets.LANDING_EC2_SSH_KEY }}
-          LANDING_EC2_KNOWN_HOSTS: ${{ secrets.LANDING_EC2_KNOWN_HOSTS }}
-        run: |
-          test -n "$LANDING_EC2_SSH_KEY"
-          test -n "$LANDING_EC2_KNOWN_HOSTS"
-          install -d -m 700 "$HOME/.ssh"
-          printf '%s\n' "$LANDING_EC2_SSH_KEY" > "$HOME/.ssh/landing_deploy_key"
-          printf '%s\n' "$LANDING_EC2_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
-          chmod 600 "$HOME/.ssh/landing_deploy_key" "$HOME/.ssh/known_hosts"
-
-      - name: Upload and activate release
-        env:
-          LANDING_EC2_HOST: ${{ secrets.LANDING_EC2_HOST }}
-          LANDING_EC2_USER: ${{ secrets.LANDING_EC2_USER }}
-        run: |
-          test -n "$LANDING_EC2_HOST"
-          test -n "$LANDING_EC2_USER"
-          release_id="${GITHUB_SHA}-${GITHUB_RUN_ATTEMPT}"
-          remote_archive="/tmp/mapmory-landing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.tar.gz"
-          ssh_options=(-i "$HOME/.ssh/landing_deploy_key" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes)
-
-          scp "${ssh_options[@]}" \
-            "$RUNNER_TEMP/mapmory-landing.tar.gz" \
-            "$LANDING_EC2_USER@$LANDING_EC2_HOST:$remote_archive"
-
-          ssh "${ssh_options[@]}" \
-            "$LANDING_EC2_USER@$LANDING_EC2_HOST" \
-            "bash -s -- '$release_id' '$remote_archive'" \
-            < landing/scripts/deploy-ec2.sh
-
-      - name: Verify public landing page
-        run: curl --fail --silent --show-error --retry 3 --retry-delay 2 https://map-mory.com/ --output /dev/null

--- a/landing/DEPLOYMENT.md
+++ b/landing/DEPLOYMENT.md
@@ -1,30 +1,15 @@
-# Landing CI/CD
+# Landing CI
 
-`landing-cicd.yml` validates every landing-page pull request and deploys only after a landing-related change reaches `main`, or when the workflow is manually dispatched.
+`landing-cicd.yml` validates landing-page changes without deploying them. It runs for landing-related pull requests, changes merged into `main`, and manual workflow dispatches.
 
-## GitHub environment
-
-Create an environment named `landing-production` and add these environment secrets:
-
-- `LANDING_EC2_HOST`: EC2 Elastic IP or SSH hostname
-- `LANDING_EC2_USER`: `ubuntu`
-- `LANDING_EC2_SSH_KEY`: a private SSH key authorized for the EC2 deploy user
-- `LANDING_EC2_KNOWN_HOSTS`: the verified `known_hosts` entry for the EC2 host
-
-Prefer a dedicated deployment key instead of a personal EC2 key. Verify the host fingerprint before saving `LANDING_EC2_KNOWN_HOSTS`.
-
-To prevent an accidental production release, restrict this environment to the `main` branch and configure a required reviewer when the repository plan supports it.
-
-## Pipeline
+## CI pipeline
 
 1. Install dependencies with `npm ci`.
-2. Run the existing landing-page tests.
-3. Build `dist/client`.
-4. Package and retain the static build as a GitHub Actions artifact for seven days.
-5. Copy the artifact to EC2 over SSH.
-6. Extract it into `/var/www/mapmory/releases/<commit>-<attempt>`.
-7. Atomically switch `/var/www/mapmory/current` to the new release.
-8. Validate and reload Nginx.
-9. Verify the landing page locally on the EC2 origin and publicly over HTTPS.
+2. Build `dist/client`.
+3. Run the landing-page tests against the built output.
 
-If the origin verification fails after activation, the deployment script switches `current` back to its previous target and reloads Nginx.
+The workflow does not package a release, access AWS, or connect to EC2. No GitHub environment, AWS credential, or SSH secret is required to run it.
+
+## Deployment
+
+Automatic deployment is intentionally postponed. Production releases must use the separately reviewed manual deployment procedure until the team introduces an AWS-supported deployment pipeline.


### PR DESCRIPTION
## 변경 사항
- 랜딩 워크플로에서 EC2 자동 배포 단계를 제거했습니다.
- AWS/SSH 시크릿과 배포 아티팩트를 더 이상 사용하지 않습니다.
- PR과 main 변경 시 빌드 및 테스트만 수행합니다.
- 자동 배포 보류 상태를 문서에 반영했습니다.

## 검증
- npm run build
- npm run test:sites (4 tests passed)