### PR TITLE
ci: main 브랜치 Android·iOS 필수 체크 활성화

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,54 @@
+name: Android CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  android:
+    name: Test and build Android
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: client
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          packages: 'platform-tools platforms;android-36 build-tools;36.0.0'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Run common JVM tests
+        run: ./gradlew :shared:jvmTest --no-daemon
+
+      - name: Run Android host tests
+        run: ./gradlew :shared:testAndroidHostTest --no-daemon
+
+      - name: Run Android lint
+        run: ./gradlew :androidApp:lint --no-daemon
+
+      - name: Build Android Debug APK
+        run: ./gradlew :androidApp:assembleDebug --no-daemon

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,50 @@
+name: iOS CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ios:
+    name: Build iOS Simulator
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Check Xcode
+        run: xcodebuild -version
+
+      - name: Build iOS Simulator app
+        run: |
+          xcodebuild \
+            -project client/iosApp/Mapmory.xcodeproj \
+            -scheme Mapmory \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/mapmory-derived-data" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            build

--- a/client/README.md
+++ b/client/README.md
@@ -23,4 +23,6 @@ cd client
 
 세부 환경 기준은 [docs/environment.md](docs/environment.md)를 확인합니다.
 
+CI 실행 범위와 실패 대응은 [docs/ci.md](docs/ci.md)를 확인합니다.
+
 진행 중인 작업은 [docs/development-tasks.md](docs/development-tasks.md)에서 관리합니다.

--- a/client/androidApp/src/main/java/com/mapmory/android/MainActivity.kt
+++ b/client/androidApp/src/main/java/com/mapmory/android/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.getValue
@@ -43,9 +44,11 @@ class MainActivity : ComponentActivity() {
                 modifier = Modifier.fillMaxSize(),
                 containerColor = SystemBarColor,
                 contentWindowInsets = WindowInsets(0, 0, 0, 0),
-            ) {
+            ) { innerPadding ->
                 Box(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
                 ) {
                     MapmoryApp(
                         providedRecordsViewModel = appViewModel.recordsViewModel,

--- a/client/docs/ci.md
+++ b/client/docs/ci.md
@@ -1,0 +1,78 @@
+# 클라이언트 CI
+
+Mapmory 클라이언트의 `develop` 또는 `main`을 대상으로 하는 Pull Request가 생성·수정되면 GitHub Actions가 자동으로 실행됩니다.
+
+## PR에서 실행하는 검증
+
+`.github/workflows/android-ci.yml`은 다음 작업을 순서대로 실행합니다.
+
+1. `:shared:jvmTest` — 공통 JVM 테스트
+2. `:shared:testAndroidHostTest` — Android 호스트 테스트
+3. `:androidApp:lint` — Android 정적 분석
+4. `:androidApp:assembleDebug` — Android Debug APK 빌드
+
+각 작업을 별도 Step으로 실행하므로 실패한 검증과 로그를 GitHub Actions의 PR Checks 화면에서 바로 확인할 수 있습니다.
+
+## 로컬에서 동일하게 실행
+
+```bash
+cd client
+./gradlew :shared:jvmTest --no-daemon
+./gradlew :shared:testAndroidHostTest --no-daemon
+./gradlew :androidApp:lint --no-daemon
+./gradlew :androidApp:assembleDebug --no-daemon
+```
+
+Windows에서는 `./gradlew` 대신 `gradlew.bat`을 사용합니다.
+
+```bat
+cd client
+gradlew.bat :shared:jvmTest --no-daemon
+gradlew.bat :shared:testAndroidHostTest --no-daemon
+gradlew.bat :androidApp:lint --no-daemon
+gradlew.bat :androidApp:assembleDebug --no-daemon
+```
+
+## 실패 시 대응
+
+1. PR의 **Checks** 탭에서 실패한 Step을 확인합니다.
+2. 로컬에서 해당 Gradle 명령을 단독 실행해 오류를 재현합니다.
+3. 오류를 수정하고 커밋을 추가하면 PR 검증이 다시 실행됩니다.
+4. 모든 검증이 성공한 뒤 리뷰와 병합을 진행합니다.
+
+## 병합 보호 규칙
+
+저장소 관리자는 GitHub 저장소의 **Settings → Branches → Branch protection rules**에서 `develop`, `main`에 다음 규칙을 적용합니다.
+
+- Pull request required
+- Require status checks to pass before merging
+- Required checks:
+  - `Android CI / Test and build Android`
+  - `iOS CI / Build iOS Simulator`
+- Require branches to be up to date before merging
+
+브랜치 보호 규칙은 저장소 설정이므로 workflow 파일을 커밋하는 것만으로 자동 적용되지는 않습니다.
+
+## 이번 CI에서 제외한 검증
+
+- `:shared:androidConnectedCheck`: 실제 Android 기기 또는 에뮬레이터가 필요하므로 PR마다 실행하지 않고 로컬 수동 검증으로 둡니다.
+- iOS 실제 기기 빌드·Archive: 배포 서명과 Apple Developer 계정이 필요하므로 별도 작업으로 둡니다.
+
+## iOS 컴파일 CI
+
+`.github/workflows/ios-ci.yml`은 `develop`, `main` 대상 PR과 push에서 iOS Simulator용 Debug 빌드를 실행합니다.
+
+- Runner: `macos-26`
+- Xcode scheme: `Mapmory`
+- 프로젝트: `client/iosApp/Mapmory.xcodeproj`
+- 서명: `CODE_SIGNING_ALLOWED=NO`, `CODE_SIGNING_REQUIRED=NO`
+- 목적: 실제 배포가 아니라 Swift 코드와 Compose Multiplatform framework 연결 상태를 컴파일 단계에서 확인
+
+macOS Runner는 Android Linux CI보다 실행 비용과 시간이 크므로, 이후 실행 시간이 부담되면 iOS 변경이 포함된 PR만 실행하도록 경로 조건을 좁히거나 정기 실행으로 전환합니다.
+
+수동 계측 테스트는 Android 기기 또는 에뮬레이터를 연결한 뒤 다음 명령으로 실행합니다.
+
+```bash
+cd client
+./gradlew :shared:androidConnectedCheck
+```


### PR DESCRIPTION
## 개요

main 브랜치 보호 규칙은 Android와 iOS 체크를 필수로 요구하지만, 해당 워크플로가 develop에만 있어 main 대상 PR의 머지가 차단되고 있습니다.

develop에서 검증된 모바일 CI 구성을 main에 먼저 반영해 필수 체크가 실행될 수 있도록 합니다.

## 변경 사항

- Android CI 워크플로 추가
  - 공통 JVM 테스트
  - Android host 테스트
  - Android lint
  - Android Debug APK 빌드
- iOS CI 워크플로 추가
  - iOS Simulator Debug 빌드
  - 코드 서명 없이 Shared.framework 연결 검증
- Android lint가 실제로 통과하도록 MainActivity의 Scaffold content padding 적용
- CI 실행 방법, 필수 체크 이름, 실패 대응 문서 추가

## 검증

Windows 로컬 환경에서 다음 작업을 한 번에 실행해 통과했습니다.

- shared:jvmTest
- shared:testAndroidHostTest
- androidApp:lint
- androidApp:assembleDebug

결과: BUILD SUCCESSFUL (95 actionable tasks)

iOS 빌드는 macOS가 필요한 작업이므로 이 PR의 GitHub Actions 결과로 검증합니다.

Closes #143