### PR TITLE
ci: Android 검증 실행 범위 제한

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -13,10 +13,41 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect Android changes
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+
+    steps:
+      - name: Checkout source
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v7
+
+      - name: Detect Android-related paths
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            android:
+              - '.github/workflows/android-ci.yml'
+              - 'client/androidApp/**'
+              - 'client/shared/**'
+              - 'client/gradle/**'
+              - 'client/build.gradle.kts'
+              - 'client/settings.gradle.kts'
+              - 'client/gradle.properties'
+              - 'client/gradlew'
+              - 'client/gradlew.bat'
+
   android:
     name: Test and build Android
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:

--- a/client/docs/ci.md
+++ b/client/docs/ci.md
@@ -1,6 +1,6 @@
 # 클라이언트 CI
 
-Mapmory 클라이언트의 `develop` 또는 `main`을 대상으로 하는 Pull Request가 생성·수정되면 GitHub Actions가 자동으로 실행됩니다.
+Mapmory 클라이언트의 `develop` 또는 `main`을 대상으로 하는 Pull Request가 생성·수정되면 GitHub Actions가 변경 경로를 확인합니다.
 
 ## PR에서 실행하는 검증
 
@@ -12,6 +12,21 @@ Mapmory 클라이언트의 `develop` 또는 `main`을 대상으로 하는 Pull R
 4. `:androidApp:assembleDebug` — Android Debug APK 빌드
 
 각 작업을 별도 Step으로 실행하므로 실패한 검증과 로그를 GitHub Actions의 PR Checks 화면에서 바로 확인할 수 있습니다.
+
+### Android CI 실행 범위
+
+Android 빌드는 다음 경로 중 하나가 변경된 경우에만 실행합니다.
+
+- `.github/workflows/android-ci.yml`
+- `client/androidApp/**`
+- `client/shared/**`
+- `client/gradle/**`
+- `client/build.gradle.kts`
+- `client/settings.gradle.kts`
+- `client/gradle.properties`
+- `client/gradlew`, `client/gradlew.bat`
+
+백엔드나 랜딩 페이지만 변경한 PR에서도 필수 체크가 대기 상태로 남지 않도록 workflow 자체는 실행하고, `Detect Android changes` 결과에 따라 `Test and build Android` job을 건너뜁니다. `workflow_dispatch`로 수동 실행한 경우에는 변경 경로와 관계없이 전체 Android 검증을 실행합니다.
 
 ## 로컬에서 동일하게 실행
 


### PR DESCRIPTION
## 개요

Android와 무관한 백엔드·랜딩 변경에서도 전체 Android 검증이 실행되어 PR 피드백과 머지를 지연시키는 문제를 해결합니다.

브랜치 보호의 필수 체크가 대기 상태로 남지 않도록 workflow 수준의 paths 필터는 사용하지 않습니다. 체크는 항상 생성하고, 변경 경로 감지 결과에 따라 Android 빌드 job만 실행하거나 건너뜁니다.

## 변경 사항

- Detect Android changes job 추가
- 다음 경로가 변경된 경우에만 Test and build Android 실행
  - Android 앱과 shared 모듈
  - Gradle wrapper 및 빌드 설정
  - Android CI workflow
- 수동 workflow_dispatch 실행은 변경 경로와 관계없이 전체 검증
- PR 경로 감지를 위한 pull-requests: read 최소 권한 추가
- CI 문서에 실행 범위와 필수 체크 대기 방지 방식 기록

## 기대 동작

- Android 또는 shared 변경 PR: Android 테스트·lint·APK 빌드 실행
- backend 또는 landing 전용 변경 PR: Android 빌드 job skip
- Android 필수 체크: workflow 자체가 생략되지 않아 대기 상태로 남지 않음

## 검증

- git diff --check 통과
- 이 PR은 Android workflow 자체를 변경하므로 원격 Android CI가 전체 실행되는지 확인
- YAML과 경로 필터 동작은 GitHub Actions 결과로 최종 확인

Closes #143