### PR TITLE
chore: 모바일 코드 소유권과 CI 실행 범위 정리

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Mobile client code requires approval from an Android team member.
+/client/ @Redish03 @chohs4164 @Soojin6943
+
+# Mobile CI changes follow the same review policy.
+/.github/workflows/android-ci.yml @Redish03 @chohs4164 @Soojin6943
+/.github/workflows/ios-ci.yml @Redish03 @chohs4164 @Soojin6943
+
+# Changes to this ownership policy require an Android team review.
+/.github/CODEOWNERS @Redish03 @chohs4164 @Soojin6943

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Mobile client code requires approval from an Android team member.
-/client/ @Redish03 @chohs4164 @Soojin6943
+/client/ @Redish03 @chohs4164
 
 # Mobile CI changes follow the same review policy.
-/.github/workflows/android-ci.yml @Redish03 @chohs4164 @Soojin6943
-/.github/workflows/ios-ci.yml @Redish03 @chohs4164 @Soojin6943
+/.github/workflows/android-ci.yml @Redish03 @chohs4164
+/.github/workflows/ios-ci.yml @Redish03 @chohs4164
 
 # Changes to this ownership policy require an Android team review.
-/.github/CODEOWNERS @Redish03 @chohs4164 @Soojin6943
+/.github/CODEOWNERS @Redish03 @chohs4164

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -13,10 +13,41 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect iOS changes
+    runs-on: ubuntu-latest
+    outputs:
+      ios: ${{ steps.filter.outputs.ios }}
+
+    steps:
+      - name: Checkout source
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v7
+
+      - name: Detect iOS-related paths
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            ios:
+              - '.github/workflows/ios-ci.yml'
+              - 'client/iosApp/**'
+              - 'client/shared/**'
+              - 'client/gradle/**'
+              - 'client/build.gradle.kts'
+              - 'client/settings.gradle.kts'
+              - 'client/gradle.properties'
+              - 'client/gradlew'
+              - 'client/gradlew.bat'
+
   ios:
     name: Build iOS Simulator
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.ios == 'true'
     runs-on: macos-26
     timeout-minutes: 30
 

--- a/client/docs/ci.md
+++ b/client/docs/ci.md
@@ -83,7 +83,18 @@ gradlew.bat :androidApp:assembleDebug --no-daemon
 - 서명: `CODE_SIGNING_ALLOWED=NO`, `CODE_SIGNING_REQUIRED=NO`
 - 목적: 실제 배포가 아니라 Swift 코드와 Compose Multiplatform framework 연결 상태를 컴파일 단계에서 확인
 
-macOS Runner는 Android Linux CI보다 실행 비용과 시간이 크므로, 이후 실행 시간이 부담되면 iOS 변경이 포함된 PR만 실행하도록 경로 조건을 좁히거나 정기 실행으로 전환합니다.
+iOS 빌드는 다음 경로 중 하나가 변경된 경우에만 실행합니다.
+
+- `.github/workflows/ios-ci.yml`
+- `client/iosApp/**`
+- `client/shared/**`
+- `client/gradle/**`
+- `client/build.gradle.kts`
+- `client/settings.gradle.kts`
+- `client/gradle.properties`
+- `client/gradlew`, `client/gradlew.bat`
+
+백엔드, 랜딩 또는 Android 앱 전용 변경에서도 필수 체크가 대기 상태로 남지 않도록 workflow 자체는 실행하고, `Detect iOS changes` 결과에 따라 `Build iOS Simulator` job을 건너뜁니다. `workflow_dispatch`로 수동 실행한 경우에는 변경 경로와 관계없이 iOS Simulator 빌드를 실행합니다.
 
 수동 계측 테스트는 Android 기기 또는 에뮬레이터를 연결한 뒤 다음 명령으로 실행합니다.
 


### PR DESCRIPTION
## 개요

백엔드와 랜딩 PR에는 일반 승인 리뷰를 요구하지 않고, 모바일 코드 변경에만 Android 팀원 승인을 요구하는 CODEOWNERS 정책을 추가합니다. 모바일과 무관한 PR에서 오래 걸리는 iOS Simulator 빌드도 건너뛰도록 실행 범위를 제한합니다.

## Code Owners

- @Redish03
- @chohs4164

## 변경 사항

- client 전체와 모바일 CI에 Code Owner 지정
- CODEOWNERS 정책 파일 자체 보호
- iOS 및 shared 관련 경로가 변경된 경우에만 iOS Simulator 빌드 실행
- backend, landing, Android 전용 변경에서는 iOS 필수 job을 조건부 스킵
- 수동 실행 시 전체 iOS Simulator 빌드 유지

브랜치 보호의 일반 승인 수는 0이며 Code Owner 리뷰만 필수입니다.