### PR TITLE
test: Android 사진·지도 흐름 자동화 테스트 보강

### DIFF
--- a/client/docs/testing/photo-metadata-automation.md
+++ b/client/docs/testing/photo-metadata-automation.md
@@ -4,9 +4,13 @@
 
 | 대상 | 테스트 | 확인 내용 |
 | --- | --- | --- |
-| 순수 캐시 규칙 | `commonTest` | 수정 시각이 같을 때 좌표를 재사용하고, 달라지면 재조회하는지 |
-| 실제 Room 동기화 | `androidDeviceTest` | 신규·변경·삭제 사진이 Room 스냅샷에 반영되는지 |
-| 실제 갤러리·Photo Picker | 수동 확인 | 권한, 사진 선택, 미리보기 표시 흐름 |
+| 지도·추천 경계 로직 | `commonTest` | 지도 Polygon 경계 터치, 잘못된 좌표·퇴화한 링, 추천 사진 최대 개수와 캐시 재사용 규칙 |
+| 순수 캐시 규칙 | `commonTest` | 수정 시각이 같고 좌표가 있을 때만 재사용하고, 그 외에는 재조회하는지 |
+| 실제 Room 동기화 | `androidDeviceTest` | 신규·변경·삭제·빈 스냅샷, GPS 누락 재시도, 사진별 재사용/재조회, DAO 필터·정렬 |
+| 실제 지도 리소스 연결 | `androidDeviceTest` | canonical 시·군·구 코드가 번들된 경계 리소스를 정확히 선택하는지 |
+| 실제 MediaStore·EXIF·미리보기 | `androidDeviceTest` | ContentResolver 조회, EXIF GPS 읽기, 원본·미리보기 바이트 생성 |
+| 기록 작성 화면 추천 흐름 | `androidApp connectedAndroidTest` | 선택 장소 전달, 추천 사진 표시·추가, 장소 미선택 안내 |
+| 권한·Photo Picker UI | 수동 확인 | 권한 허용·거부·부분 허용, Photo Picker에서 실제 사진 선택 |
 
 ## 실행
 
@@ -24,6 +28,9 @@
 # 실제 Android 기기 또는 에뮬레이터에서 Room 계측 테스트
 ./gradlew :shared:androidConnectedCheck
 
+# 기록 작성 화면 Compose 계측 테스트
+./gradlew :androidApp:connectedDebugAndroidTest
+
 # 앱 전체 Android 컴파일
 ./gradlew :androidApp:assembleDebug
 ```
@@ -36,6 +43,7 @@ Windows에서는 `./gradlew` 대신 `gradlew.bat`을 사용한다.
 gradlew.bat :shared:jvmTest
 gradlew.bat :shared:testAndroidHostTest
 gradlew.bat :shared:androidConnectedCheck
+gradlew.bat :androidApp:connectedDebugAndroidTest
 gradlew.bat :androidApp:assembleDebug
 ```
 
@@ -48,6 +56,9 @@ gradlew.bat :androidApp:assembleDebug
 - 수정 시각이 바뀐 사진은 EXIF를 다시 읽고 좌표를 갱신한다.
 - 현재 MediaStore 스냅샷에 없는 사진은 Room에서 삭제된다.
 - MediaStore 조회가 실패한 경우에는 기존 스냅샷을 임의로 삭제하지 않는다.
+- EXIF GPS가 없는 사진은 좌표를 캐시된 것으로 간주하지 않고 다음 동기화에서 다시 시도한다.
+- 지도 경계의 선 위를 눌러도 해당 지역을 선택한다.
+- 실제 MediaStore 이미지의 EXIF GPS와 미리보기 생성 흐름이 동작한다.
 
 ## 성능 로그
 
@@ -58,4 +69,4 @@ adb -s <serial> shell setprop log.tag.MapmoryPhotoPerf DEBUG
 adb -s <serial> logcat -v time -s MapmoryPhotoPerf:D
 ```
 
-`exif_reads`, `reused_coordinates`, `metadata_sync_ms`를 비교할 수 있지만, 현재는 고정된 성능 기준선으로 사용하지 않는다. 실제 갤러리 자동화, Photo Picker UI 자동화, Macrobenchmark와 CI 성능 기준선은 별도 작업으로 남긴다.
+`exif_reads`, `reused_coordinates`, `metadata_sync_ms`를 비교할 수 있지만, 현재는 고정된 성능 기준선으로 사용하지 않는다. Photo Picker UI 자동화, 권한별 UI 자동화, Macrobenchmark와 CI 성능 기준선은 별도 작업으로 남긴다.

--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryAndroidDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryAndroidDeviceTest.kt
@@ -1,0 +1,107 @@
+package com.mapmory.shared.presentation.photo
+
+import android.Manifest
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.exifinterface.media.ExifInterface
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.ByteArrayOutputStream
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PhotoLibraryAndroidDeviceTest {
+    @Test
+    fun mediaStoreSnapshotAndPhotoReaderUseAndroidContentResolver() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val fixture = insertFixturePhoto(context)
+        try {
+            val candidate = context.queryPhotoMetadataSnapshot()
+                ?.single { photo -> photo.contentUri == fixture.uri.toString() }
+
+            assertNotNull(candidate)
+            assertEquals("mapmory-test.jpg", candidate.displayName)
+            assertEquals("image/jpeg", candidate.mimeType)
+
+            val coordinates = withMediaLocationPermission {
+                context.readCoordinates(fixture.uri)
+            }
+            assertNotNull(coordinates)
+            assertEquals(37.4979, coordinates.first, 0.0001)
+            assertEquals(127.0276, coordinates.second, 0.0001)
+
+            val selectedPhoto = context.readPhoto(fixture.uri)
+            assertNotNull(selectedPhoto)
+            assertEquals("mapmory-test.jpg", selectedPhoto.displayName)
+            assertTrue(selectedPhoto.originalBytes?.isNotEmpty() == true)
+            assertTrue(selectedPhoto.previewBytes?.isNotEmpty() == true)
+        } finally {
+            context.contentResolver.delete(fixture.uri, null, null)
+            fixture.file.delete()
+        }
+    }
+
+    private fun insertFixturePhoto(context: Context): FixturePhoto {
+        val file = File.createTempFile("mapmory-photo-", ".jpg", context.cacheDir)
+        val bitmap = Bitmap.createBitmap(64, 32, Bitmap.Config.ARGB_8888)
+        try {
+            ByteArrayOutputStream().use { output ->
+                check(bitmap.compress(Bitmap.CompressFormat.JPEG, 100, output))
+                file.writeBytes(output.toByteArray())
+            }
+        } finally {
+            bitmap.recycle()
+        }
+        ExifInterface(file).apply {
+            setLatLong(37.4979, 127.0276)
+            saveAttributes()
+        }
+
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, "mapmory-test.jpg")
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+            put(MediaStore.Images.Media.DATE_TAKEN, 1_700_000_000_000L)
+            put(MediaStore.Images.Media.DATE_MODIFIED, 1_700_000_000L)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/MapmoryTest")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+        }
+        val uri = requireNotNull(
+            context.contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values),
+        )
+        context.contentResolver.openOutputStream(uri).use { output ->
+            requireNotNull(output).write(file.readBytes())
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            context.contentResolver.update(
+                uri,
+                ContentValues().apply { put(MediaStore.Images.Media.IS_PENDING, 0) },
+                null,
+                null,
+            )
+        }
+        return FixturePhoto(uri, file)
+    }
+
+    private fun <T> withMediaLocationPermission(block: () -> T): T {
+        val automation = InstrumentationRegistry.getInstrumentation().uiAutomation
+        automation.adoptShellPermissionIdentity(Manifest.permission.ACCESS_MEDIA_LOCATION)
+        return try {
+            block()
+        } finally {
+            automation.dropShellPermissionIdentity()
+        }
+    }
+
+    private data class FixturePhoto(
+        val uri: Uri,
+        val file: File,
+    )
+}

--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncDeviceTest.kt
@@ -92,6 +92,62 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
+    fun photoWithoutGpsIsRetriedUntilCoordinatesAreAvailable() = runBlocking {
+        val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
+        val firstResult = sync(
+            current = listOf(photo),
+            coordinates = emptyMap(),
+            exifReads = mutableListOf(),
+        ).sync()
+
+        assertEquals(1, firstResult.exifReadCount)
+        assertEquals(null, database.photoMetadataDao().getAll().single().latitude)
+
+        val exifReads = mutableListOf<String>()
+        val secondResult = sync(
+            current = listOf(photo),
+            coordinates = mapOf(photo.contentUri to (35.1 to 129.0)),
+            exifReads = exifReads,
+            scanId = 2L,
+        ).sync()
+
+        assertEquals(1, secondResult.exifReadCount)
+        assertEquals(0, secondResult.reusedCoordinateCount)
+        assertEquals(listOf(photo.contentUri), exifReads)
+        assertEquals(35.1, database.photoMetadataDao().getAll().single().latitude)
+        assertEquals(129.0, database.photoMetadataDao().getAll().single().longitude)
+    }
+
+    @Test
+    fun mixedSnapshotReusesOnlyUnchangedLocatedPhotos() = runBlocking {
+        val unchanged = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
+        val changed = candidate(mediaId = 2L, modifiedAtSeconds = 10L)
+        sync(
+            current = listOf(unchanged, changed),
+            coordinates = mapOf(
+                unchanged.contentUri to (37.5 to 127.0),
+                changed.contentUri to (35.1 to 129.0),
+            ),
+            exifReads = mutableListOf(),
+        ).sync()
+
+        val exifReads = mutableListOf<String>()
+        val result = sync(
+            current = listOf(unchanged, changed.copy(modifiedAtSeconds = 11L)),
+            coordinates = mapOf(changed.contentUri to (35.2 to 129.1)),
+            exifReads = exifReads,
+            scanId = 2L,
+        ).sync()
+
+        assertEquals(1, result.reusedCoordinateCount)
+        assertEquals(1, result.exifReadCount)
+        assertEquals(listOf(changed.contentUri), exifReads)
+        val stored = database.photoMetadataDao().getAll().associateBy(PhotoMetadataEntity::mediaId)
+        assertEquals(37.5, stored.getValue(unchanged.mediaId).latitude)
+        assertEquals(35.2, stored.getValue(changed.mediaId).latitude)
+    }
+
+    @Test
     fun photoMissingFromCurrentSnapshotIsRemoved() = runBlocking {
         val first = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
         val second = candidate(mediaId = 2L, modifiedAtSeconds = 10L)
@@ -112,6 +168,50 @@ class PhotoMetadataSyncDeviceTest {
         ).sync()
 
         assertEquals(setOf(1L), database.photoMetadataDao().getAll().map(PhotoMetadataEntity::mediaId).toSet())
+    }
+
+    @Test
+    fun emptyMediaStoreSnapshotClearsRoom() = runBlocking {
+        val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
+        sync(
+            current = listOf(photo),
+            coordinates = mapOf(photo.contentUri to (37.5 to 127.0)),
+            exifReads = mutableListOf(),
+        ).sync()
+
+        sync(
+            current = emptyList(),
+            coordinates = emptyMap(),
+            exifReads = mutableListOf(),
+            scanId = 2L,
+        ).sync()
+
+        assertTrue(database.photoMetadataDao().getAll().isEmpty())
+    }
+
+    @Test
+    fun roomQueriesFilterLocatedPhotosAndOrderByCaptureTime() = runBlocking {
+        val newest = candidate(mediaId = 1L, modifiedAtSeconds = 10L, capturedAtMillis = 300L)
+        val withoutGps = candidate(mediaId = 2L, modifiedAtSeconds = 10L, capturedAtMillis = 200L)
+        val oldest = candidate(mediaId = 3L, modifiedAtSeconds = 10L, capturedAtMillis = 100L)
+        sync(
+            current = listOf(newest, withoutGps, oldest),
+            coordinates = mapOf(
+                newest.contentUri to (37.5 to 127.0),
+                oldest.contentUri to (35.1 to 129.0),
+            ),
+            exifReads = mutableListOf(),
+        ).sync()
+
+        val dao = database.photoMetadataDao()
+        assertEquals(
+            listOf(1L, 3L),
+            dao.getLocatedPhotos().map(PhotoMetadataEntity::mediaId),
+        )
+        assertEquals(
+            listOf(1L, 2L),
+            dao.getPhotosCapturedBetween(150L, 350L).map(PhotoMetadataEntity::mediaId),
+        )
     }
 
     @Test
@@ -155,11 +255,12 @@ class PhotoMetadataSyncDeviceTest {
     private fun candidate(
         mediaId: Long,
         modifiedAtSeconds: Long,
+        capturedAtMillis: Long? = 1_000L,
     ) = PhotoMetadataCandidate(
         mediaId = mediaId,
         contentUri = "content://photo/$mediaId",
         displayName = "photo-$mediaId.jpg",
-        capturedAtMillis = 1_000L,
+        capturedAtMillis = capturedAtMillis,
         modifiedAtSeconds = modifiedAtSeconds,
         mimeType = "image/jpeg",
         sizeBytes = 128L,

--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionDeviceTest.kt
@@ -1,0 +1,37 @@
+package com.mapmory.shared.presentation.photo
+
+import com.mapmory.shared.domain.model.Location
+import com.mapmory.shared.domain.model.LocationType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+
+class PhotoRecommendationRegionDeviceTest {
+    @Test
+    fun canonicalDistrictCodeLoadsItsBundledBoundary() = runBlocking {
+        val gangnam = Location(
+            id = 11680L,
+            countryId = 1L,
+            parentId = 1L,
+            regionCode = "11680",
+            name = "강남구",
+            type = LocationType.DISTRICT,
+        )
+
+        assertEquals("11680", gangnam.photoRecommendationRegion()?.code)
+    }
+
+    @Test
+    fun unknownDistrictCodeDoesNotUseAnotherBoundary() = runBlocking {
+        val unknownDistrict = Location(
+            id = 11999L,
+            countryId = 1L,
+            parentId = 1L,
+            regionCode = "11999",
+            name = "알 수 없는 구",
+            type = LocationType.DISTRICT,
+        )
+
+        assertEquals(null, unknownDistrict.photoRecommendationRegion())
+    }
+}

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
@@ -274,7 +274,7 @@ private suspend fun Context.syncPhotoMetadata(): PhotoMetadataSyncResult {
     ).sync()
 }
 
-private fun Context.queryPhotoMetadataSnapshot(): List<PhotoMetadataCandidate>? {
+internal fun Context.queryPhotoMetadataSnapshot(): List<PhotoMetadataCandidate>? {
     val projection = arrayOf(
         MediaStore.Images.Media._ID,
         MediaStore.Images.Media.DISPLAY_NAME,
@@ -383,7 +383,7 @@ private fun logPhotoPickPerformance(
     )
 }
 
-private fun Context.readPhoto(
+internal fun Context.readPhoto(
     uri: Uri,
     knownName: String? = null,
     knownCoordinates: Pair<Double, Double>? = null,
@@ -560,7 +560,7 @@ private fun Context.queryPhotoMetadata(uri: Uri): Pair<String?, Long?> {
     } ?: (null to null)
 }
 
-private fun Context.readCoordinates(uri: Uri): Pair<Double, Double>? = runCatching {
+internal fun Context.readCoordinates(uri: Uri): Pair<Double, Double>? = runCatching {
     val metadataUri = if (
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
         ContextCompat.checkSelfPermission(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapArtwork.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapArtwork.kt
@@ -183,6 +183,7 @@ private data class MapTransform(
 private const val MinZoom = 1f
 private const val MaxZoom = 6f
 private const val PanSlackFraction = 0.1f
+private const val BoundaryEpsilon = 0.000001f
 
 @Composable
 fun KoreaMapStatusMessage(
@@ -373,6 +374,7 @@ private fun pointInRing(point: GeoPoint, ring: List<GeoPoint>): Boolean {
     var inside = false
     var previous = ring.last()
     ring.forEach { current ->
+        if (pointOnSegment(point, previous, current)) return true
         val crossesY = (current.latitude > point.latitude) != (previous.latitude > point.latitude)
         if (crossesY) {
             val intersectionLongitude =
@@ -384,6 +386,14 @@ private fun pointInRing(point: GeoPoint, ring: List<GeoPoint>): Boolean {
         previous = current
     }
     return inside
+}
+
+private fun pointOnSegment(point: GeoPoint, start: GeoPoint, end: GeoPoint): Boolean {
+    val cross = (point.latitude - start.latitude) * (end.longitude - start.longitude) -
+        (point.longitude - start.longitude) * (end.latitude - start.latitude)
+    if (kotlin.math.abs(cross) > BoundaryEpsilon) return false
+    return point.longitude in minOf(start.longitude, end.longitude)..maxOf(start.longitude, end.longitude) &&
+        point.latitude in minOf(start.latitude, end.latitude)..maxOf(start.latitude, end.latitude)
 }
 
 private data class KoreaBounds(

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/data/KoreaMapStaticDataTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/data/KoreaMapStaticDataTest.kt
@@ -51,6 +51,14 @@ class KoreaMapStaticDataTest {
     }
 
     @Test
+    fun mapTapOnTheRightOrTopBoundaryStillSelectsTheRegion() {
+        val region = square("KR-11", "서울특별시", 0f, 0f, 10f, 10f)
+
+        assertEquals("KR-11", listOf(region).regionAt(GeoPoint(10f, 5f))?.code)
+        assertEquals("KR-11", listOf(region).regionAt(GeoPoint(5f, 10f))?.code)
+    }
+
+    @Test
     fun generatedMapKeepsSeoulAndGyeonggiBoundariesDistinct() {
         assertEquals(
             "KR-11",

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryTest.kt
@@ -31,6 +31,20 @@ class PhotoLibraryTest {
         assertTrue(region.contains(latitude = 5.0, longitude = 0.0))
         assertFalse(region.contains(latitude = 5.0, longitude = 10.1))
         assertFalse(region.contains(latitude = 91.0, longitude = 5.0))
+        assertFalse(region.contains(latitude = 5.0, longitude = 181.0))
+    }
+
+    @Test
+    fun degenerateRingsDoNotMatchAnyPhoto() {
+        val region = PhotoRecommendationRegion(
+            code = "invalid",
+            rings = listOf(
+                emptyList(),
+                listOf(GeoPoint(0f, 0f), GeoPoint(1f, 1f)),
+            ),
+        )
+
+        assertFalse(region.contains(latitude = 0.5, longitude = 0.5))
     }
 
     @Test

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCachePolicyTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCachePolicyTest.kt
@@ -8,6 +8,7 @@ class PhotoMetadataCachePolicyTest {
     @Test
     fun reusesCoordinatesOnlyWhenMediaStoreTimestampAndCoordinatesArePresent() {
         assertTrue(shouldReuseCoordinates(10L, 37.5, 127.0, 10L))
+        assertFalse(shouldReuseCoordinates(null, 37.5, 127.0, 10L))
         assertFalse(shouldReuseCoordinates(11L, 37.5, 127.0, 10L))
         assertFalse(shouldReuseCoordinates(10L, null, 127.0, 10L))
         assertFalse(shouldReuseCoordinates(10L, 37.5, null, 10L))


### PR DESCRIPTION
## 변경 내용

- 사진 메타데이터 동기화의 GPS 누락 재시도, 부분 캐시 재사용, 빈 스냅샷 삭제, DAO 필터·정렬을 검증하는 계측 테스트를 추가했습니다.
- 실제 MediaStore·EXIF GPS·미리보기 바이트 흐름을 검증하는 Android 계측 테스트를 추가했습니다.
- canonical 시·군·구 코드와 번들 지도 경계 연결을 검증하는 테스트를 추가했습니다.
- 지도 경계선 터치와 사진 추천 입력 검증을 보강했습니다.
- 테스트 범위와 실행 방법을 문서화했습니다.

## 검증

- `./gradlew :shared:jvmTest`
- `./gradlew :shared:testAndroidHostTest`
- `./gradlew :shared:androidConnectedCheck` — 에뮬레이터·SM-S938N에서 shared 계측 테스트 성공
- `ANDROID_SERIAL=emulator-5554 ./gradlew :androidApp:connectedDebugAndroidTest` — 앱 Compose 계측 테스트 3개 성공

## 참고

두 기기를 동시에 연결한 전체 앱 계측 실행에서는 SM-S938N에서만 `No compose hierarchies found`가 발생했습니다. 동일 테스트를 에뮬레이터 단독으로 실행하면 성공하므로 기기별 실행 환경 문제로 기록합니다.

## 커밋

- `218cd91 test: Android 사진·지도 흐름 자동화 테스트 보강`
