### PR TITLE
test: 테스트 함수명을 한글로 통일

### DIFF
--- a/client/androidApp/src/androidTest/java/com/mapmory/android/MapmoryAppNavigationTest.kt
+++ b/client/androidApp/src/androidTest/java/com/mapmory/android/MapmoryAppNavigationTest.kt
@@ -20,7 +20,7 @@ class MapmoryAppNavigationTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun recordListDetailDeleteAndEditorUseDestinationViewModels() {
+    fun `기록_목록_상세_삭제와_편집_화면은_목적지_ViewModel을_사용한다`() {
         val container = createInMemoryAppContainer()
         val gangnam = container.regionCatalog.requireByCode("11680")
         val photoBytes = createPngBytes()

--- a/client/androidApp/src/androidTest/java/com/mapmory/android/PhotoRecommendationFlowTest.kt
+++ b/client/androidApp/src/androidTest/java/com/mapmory/android/PhotoRecommendationFlowTest.kt
@@ -19,7 +19,7 @@ class PhotoRecommendationFlowTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun selectedLocationRecommendationCanBeReviewedAndAdded() {
+    fun `선택한_장소의_추천_사진을_확인하고_추가할_수_있다`() {
         val seoul = province()
         val gangnam = district(parentId = seoul.id)
         val recommendedPhoto = SelectedPhoto(
@@ -86,7 +86,7 @@ class PhotoRecommendationFlowTest {
     }
 
     @Test
-    fun recommendationWithoutLocationShowsGuidanceWithoutCallingPhotoLibrary() {
+    fun `장소를_선택하지_않으면_사진_라이브러리를_호출하지_않고_안내를_표시한다`() {
         var recommendationCalls = 0
 
         composeRule.setContent {

--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryAndroidDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryAndroidDeviceTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 
 class PhotoLibraryAndroidDeviceTest {
     @Test
-    fun mediaStoreSnapshotAndPhotoReaderUseAndroidContentResolver() {
+    fun `MediaStore_스냅샷과_사진_리더는_Android_ContentResolver를_사용한다`() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val fixture = insertFixturePhoto(context)
         try {

--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncDeviceTest.kt
@@ -28,7 +28,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun newPhotoReadsExifAndWritesRoom() = runBlocking {
+    fun `새_사진의_EXIF를_읽고_Room에_저장한다`() = runBlocking {
         val exifReads = mutableListOf<String>()
         val result = sync(
             current = listOf(candidate(mediaId = 1L, modifiedAtSeconds = 10L)),
@@ -44,7 +44,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun unchangedPhotoReusesCachedCoordinates() = runBlocking {
+    fun `변경되지_않은_사진은_캐시된_좌표를_재사용한다`() = runBlocking {
         val exifReads = mutableListOf<String>()
         val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
         sync(
@@ -68,7 +68,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun modifiedPhotoReadsExifAgainAndUpdatesCoordinates() = runBlocking {
+    fun `변경된_사진은_EXIF를_다시_읽고_좌표를_갱신한다`() = runBlocking {
         val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
         sync(
             current = listOf(photo),
@@ -92,7 +92,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun photoWithoutGpsIsRetriedUntilCoordinatesAreAvailable() = runBlocking {
+    fun `GPS가_없는_사진은_좌표를_얻을_때까지_다시_시도한다`() = runBlocking {
         val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
         val firstResult = sync(
             current = listOf(photo),
@@ -119,7 +119,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun mixedSnapshotReusesOnlyUnchangedLocatedPhotos() = runBlocking {
+    fun `혼합_스냅샷에서는_변경되지_않은_위치_사진만_재사용한다`() = runBlocking {
         val unchanged = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
         val changed = candidate(mediaId = 2L, modifiedAtSeconds = 10L)
         sync(
@@ -148,7 +148,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun photoMissingFromCurrentSnapshotIsRemoved() = runBlocking {
+    fun `현재_스냅샷에_없는_사진은_삭제한다`() = runBlocking {
         val first = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
         val second = candidate(mediaId = 2L, modifiedAtSeconds = 10L)
         sync(
@@ -171,7 +171,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun emptyMediaStoreSnapshotClearsRoom() = runBlocking {
+    fun `빈_MediaStore_스냅샷은_Room을_비운다`() = runBlocking {
         val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
         sync(
             current = listOf(photo),
@@ -190,7 +190,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun roomQueriesFilterLocatedPhotosAndOrderByCaptureTime() = runBlocking {
+    fun `Room_조회는_위치가_있는_사진만_필터링하고_촬영_시각순으로_정렬한다`() = runBlocking {
         val newest = candidate(mediaId = 1L, modifiedAtSeconds = 10L, capturedAtMillis = 300L)
         val withoutGps = candidate(mediaId = 2L, modifiedAtSeconds = 10L, capturedAtMillis = 200L)
         val oldest = candidate(mediaId = 3L, modifiedAtSeconds = 10L, capturedAtMillis = 100L)
@@ -215,7 +215,7 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
-    fun mediaStoreFailureKeepsPreviousSnapshot() = runBlocking {
+    fun `MediaStore_조회_실패_시_기존_스냅샷을_유지한다`() = runBlocking {
         val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)
         sync(
             current = listOf(photo),

--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionDeviceTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.runBlocking
 
 class PhotoRecommendationRegionDeviceTest {
     @Test
-    fun canonicalDistrictCodeLoadsItsBundledBoundary() = runBlocking {
+    fun `정규_지역_코드로_번들된_지도_경계를_조회한다`() = runBlocking {
         val gangnam = Location(
             id = 11680L,
             countryId = 1L,
@@ -22,7 +22,7 @@ class PhotoRecommendationRegionDeviceTest {
     }
 
     @Test
-    fun unknownDistrictCodeDoesNotUseAnotherBoundary() = runBlocking {
+    fun `알_수_없는_지역_코드는_다른_지도_경계를_사용하지_않는다`() = runBlocking {
         val unknownDistrict = Location(
             id = 11999L,
             countryId = 1L,

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/MapLocationSelectionTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/MapLocationSelectionTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertNull
 
 class MapLocationSelectionTest {
     @Test
-    fun matchesMapNameBeforeRegionCodeWhenLegacyCodesCollide() {
+    fun `기존_코드가_충돌하면_지역_코드보다_지도_이름을_먼저_일치시킨다`() {
         val busanDistricts = listOf(
             location(code = "26110", name = "중구"),
             location(code = "26410", name = "금정구"),
@@ -25,7 +25,7 @@ class MapLocationSelectionTest {
     }
 
     @Test
-    fun removesProvinceNameBeforeMatchingDistrict() {
+    fun `지역을_일치시키기_전에_시도_이름을_제거한다`() {
         val district = location(code = "26410", name = "금정구")
 
         assertEquals(
@@ -35,14 +35,14 @@ class MapLocationSelectionTest {
     }
 
     @Test
-    fun doesNotGuessWhenMapNameDoesNotMatchAnyDistrict() {
+    fun `지도_이름이_어떤_지역과도_일치하지_않으면_추측하지_않는다`() {
         val district = location(code = "26110", name = "중구")
 
         assertNull(findMapDistrictLocation("금정구", listOf(district)))
     }
 
     @Test
-    fun resolvesDistrictByCanonicalCodeAndProvince() {
+    fun `정규_코드와_시도로_지역을_조회한다`() {
         val province = Location(
             id = 4L,
             countryId = 1L,

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/app/AppContainerTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/app/AppContainerTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
 
 class AppContainerTest {
     @Test
-    fun `container can be assembled with a replaceable repository`() {
+    fun `교체_가능한_저장소로_컨테이너를_구성할_수_있다`() {
         val repository = FakeTripRecordRepository(7) { "2026-08-24T00:00:00" }
 
         val container = createAppContainer(
@@ -28,7 +28,7 @@ class AppContainerTest {
     }
 
     @Test
-    fun `screen view models share one repository without sharing ui state`() = runSuspend {
+    fun `화면_ViewModel은_UI_상태를_공유하지_않고_저장소를_공유한다`() = runSuspend {
         val container = createInMemoryAppContainer()
         val gangnam = container.regionCatalog.requireByCode("11680")
         val editor = container.viewModelFactory.createTripRecordEditorViewModel()

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/local/StaticRegionCatalogTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/local/StaticRegionCatalogTest.kt
@@ -9,7 +9,7 @@ class StaticRegionCatalogTest {
     private val catalog = StaticRegionCatalog()
 
     @Test
-    fun `canonical province and district codes resolve without App composable`() {
+    fun `App_컴포저블_없이_정규_시도와_지역_코드를_조회한다`() {
         val seoul = catalog.findByCode("KR-11")
         val gangnam = catalog.findDistrict(
             provinceCode = "KR-11",
@@ -23,7 +23,7 @@ class StaticRegionCatalogTest {
     }
 
     @Test
-    fun `district lookup never crosses the requested province`() {
+    fun `지역_조회는_요청한_시도를_벗어나지_않는다`() {
         assertNull(
             catalog.findDistrict(
                 provinceCode = "KR-26",

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/LocationRemoteRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/LocationRemoteRepositoryTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 
 class LocationRemoteRepositoryTest {
     @Test
-    fun getLocationsMapsServerLocationAndQuery() = runBlocking {
+    fun `지역_조회는_서버_지역과_검색어를_매핑한다`() = runBlocking {
         val client = HttpClient(MockEngine) {
             configureCommonHttpClient()
             engine {

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/TripRecordRemoteRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/TripRecordRemoteRepositoryTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertEquals
 
 class TripRecordRemoteRepositoryTest {
     @Test
-    fun getRecordsSendsContractQueryAndMemberHeader() = runBlocking {
+    fun `기록_조회는_계약된_검색어와_회원_헤더를_전송한다`() = runBlocking {
         val client = HttpClient(MockEngine) {
             configureCommonHttpClient()
             engine {

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/model/TripRecordDtoMappersTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/model/TripRecordDtoMappersTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 class ApiDtoMappersTest {
     @Test
-    fun tripRecordDetailMapsMediaAndDates() {
+    fun `여행_기록_상세는_미디어와_날짜를_매핑한다`() {
         val result = TripRecordDetailDto(
             id = 101,
             member = MemberSummaryDto(10, "맵모리"),
@@ -26,7 +26,7 @@ class ApiDtoMappersTest {
     }
 
     @Test
-    fun draftMapsToRequestWithObjectKeys() {
+    fun `초안은_Object_Key를_포함한_요청으로_변환된다`() {
         val result = TripRecordRequestDto(
             locationId = 1,
             title = "제목",

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepositoryTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertTrue
 
 class FakeTripRecordRepositoryTest {
     @Test
-    fun createUpdateAndDeleteTripRecord() = runSuspend {
+    fun `여행_기록을_생성하고_수정하고_삭제한다`() = runSuspend {
         val repository = FakeTripRecordRepository(
             memberId = 10,
             now = { "2026-08-07T00:00:00Z" },
@@ -49,7 +49,7 @@ class FakeTripRecordRepositoryTest {
     }
 
     @Test
-    fun createRejectsInvalidDateRange() = runSuspend {
+    fun `잘못된_날짜_범위로_생성을_거부한다`() = runSuspend {
         val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
 
         val result = repository.createTripRecord(

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertTrue
 
 class TripRecordTest {
     @Test
-    fun `시작일과 종료일이 같은 당일 여행을 생성할 수 있다`() {
+    fun `시작일과_종료일이_같은_당일_여행을_생성할_수_있다`() {
         val date = LocalDate(2026, 8, 7)
 
         val record = createTripRecord(
@@ -21,7 +21,7 @@ class TripRecordTest {
     }
 
     @Test
-    fun `시작일이 종료일보다 늦으면 여행 기록을 생성할 수 없다`() {
+    fun `시작일이_종료일보다_늦으면_여행_기록을_생성할_수_없다`() {
         val exception = assertFailsWith<IllegalArgumentException> {
             createTripRecord(
                 startTripDate = LocalDate(2026, 8, 8),
@@ -33,7 +33,7 @@ class TripRecordTest {
     }
 
     @Test
-    fun `연도 경계를 넘는 여행을 생성할 수 있다`() {
+    fun `연도_경계를_넘는_여행을_생성할_수_있다`() {
         val record = createTripRecord(
             startTripDate = LocalDate(2026, 12, 31),
             endTripDate = LocalDate(2027, 1, 1),
@@ -43,7 +43,7 @@ class TripRecordTest {
     }
 
     @Test
-    fun `시작일과 종료일 없이 여행 기록을 생성할 수 있다`() {
+    fun `시작일과_종료일_없이_여행_기록을_생성할_수_있다`() {
         val record = TripRecord(
             imageUrl = "",
             tripRecordTitle = "날짜 없는 여행",
@@ -58,14 +58,14 @@ class TripRecordTest {
     }
 
     @Test
-    fun `ID는 Long 타입으로 지정한 값을 유지한다`() {
+    fun `ID는_Long_타입으로_지정한_값을_유지한다`() {
         val record = createTripRecord(id = Long.MAX_VALUE)
 
         assertEquals(Long.MAX_VALUE, record.id)
     }
 
     @Test
-    fun `자동 생성된 ID는 양수다`() {
+    fun `자동_생성된_ID는_양수다`() {
         val record = TripRecord(
             imageUrl = "image.jpg",
             tripRecordTitle = "제주도 여행",

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordsTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/TripRecordsTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertSame
 
 class TripRecordsTest {
     @Test
-    fun `여행 기록을 추가한다`() {
+    fun `여행_기록을_추가한다`() {
         val tripRecords = TripRecords()
 
         val result = tripRecords.addTripRecord(
@@ -27,7 +27,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `시작일이 종료일보다 늦은 여행 기록은 추가할 수 없다`() {
+    fun `시작일이_종료일보다_늦은_여행_기록은_추가할_수_없다`() {
         val tripRecords = TripRecords()
 
         assertFailsWith<IllegalArgumentException> {
@@ -44,7 +44,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `여행 기록을 삭제한다`() {
+    fun `여행_기록을_삭제한다`() {
         val record = createTripRecord()
         val tripRecords = TripRecords(listOf(record))
 
@@ -54,7 +54,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `존재하지 않는 여행 기록을 삭제하면 기존 객체를 반환한다`() {
+    fun `존재하지_않는_여행_기록을_삭제하면_기존_객체를_반환한다`() {
         val tripRecords = TripRecords(listOf(createTripRecord(id = 1L)))
 
         val result = tripRecords.removeTripRecord(createTripRecord(id = 2L))
@@ -63,7 +63,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `빈 목록에서 여행 기록을 삭제하면 기존 객체를 반환한다`() {
+    fun `빈_목록에서_여행_기록을_삭제하면_기존_객체를_반환한다`() {
         val tripRecords = TripRecords()
 
         val result = tripRecords.removeTripRecord(createTripRecord())
@@ -72,7 +72,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `내용이 달라도 ID가 같은 여행 기록을 삭제한다`() {
+    fun `내용이_달라도_ID가_같은_여행_기록을_삭제한다`() {
         val storedRecord = createTripRecord(id = 1L, title = "저장된 제목")
         val deletingRecord = createTripRecord(id = 1L, title = "변경된 제목")
         val tripRecords = TripRecords(listOf(storedRecord))
@@ -83,7 +83,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `여행 기록의 전달된 필드만 수정한다`() {
+    fun `여행_기록의_전달된_필드만_수정한다`() {
         val record = createTripRecord()
         val tripRecords = TripRecords(listOf(record))
 
@@ -109,7 +109,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `여행 기록을 수정해도 목록 순서는 유지된다`() {
+    fun `여행_기록을_수정해도_목록_순서는_유지된다`() {
         val firstRecord = createTripRecord(id = 1L, title = "첫 번째")
         val secondRecord = createTripRecord(id = 2L, title = "두 번째")
         val tripRecords = TripRecords(listOf(firstRecord, secondRecord))
@@ -129,7 +129,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `수정할 필드가 없으면 기록 내용을 유지한다`() {
+    fun `수정할_필드가_없으면_기록_내용을_유지한다`() {
         val record = createTripRecord()
         val tripRecords = TripRecords(listOf(record))
 
@@ -148,7 +148,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `여행 시작일과 종료일을 함께 수정한다`() {
+    fun `여행_시작일과_종료일을_함께_수정한다`() {
         val record = createTripRecord()
         val tripRecords = TripRecords(listOf(record))
         val editingStartTripDate = LocalDate(2026, 9, 1)
@@ -170,7 +170,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `시작일만 수정하면 기존 종료일을 유지한다`() {
+    fun `시작일만_수정하면_기존_종료일을_유지한다`() {
         val record = createTripRecord()
         val tripRecords = TripRecords(listOf(record))
         val editingStartTripDate = LocalDate(2026, 8, 2)
@@ -191,7 +191,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `수정한 시작일이 종료일보다 늦으면 예외가 발생한다`() {
+    fun `수정한_시작일이_종료일보다_늦으면_예외가_발생한다`() {
         val record = createTripRecord()
         val tripRecords = TripRecords(listOf(record))
 
@@ -210,7 +210,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `수정한 종료일이 시작일보다 빠르면 예외가 발생한다`() {
+    fun `수정한_종료일이_시작일보다_빠르면_예외가_발생한다`() {
         val record = createTripRecord()
         val tripRecords = TripRecords(listOf(record))
 
@@ -229,7 +229,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `존재하지 않는 여행 기록을 수정하면 예외가 발생한다`() {
+    fun `존재하지_않는_여행_기록을_수정하면_예외가_발생한다`() {
         val tripRecords = TripRecords(listOf(createTripRecord(id = 1L)))
 
         assertFailsWith<IllegalArgumentException> {
@@ -246,7 +246,7 @@ class TripRecordsTest {
     }
 
     @Test
-    fun `생성자에 전달한 목록이 바뀌어도 여행 기록 목록은 바뀌지 않는다`() {
+    fun `생성자에_전달한_목록이_바뀌어도_여행_기록_목록은_바뀌지_않는다`() {
         val source = mutableListOf(createTripRecord(id = 1L))
         val tripRecords = TripRecords(source)
 

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/model/KoreanCountryNamesTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/domain/model/KoreanCountryNamesTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertTrue
 
 class KoreanCountryNamesTest {
     @Test
-    fun everyWorldMapCountryHasKoreanName() {
+    fun `세계_지도_모든_국가에_한글_이름이_있다`() {
         val missingCodes = GeneratedWorldMapData.countries
             .map { it.code }
             .filterNot(KoreanCountryNames.byCode::containsKey)

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/data/KoreaMapStaticDataTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/data/KoreaMapStaticDataTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertTrue
 
 class KoreaMapStaticDataTest {
     @Test
-    fun everyMapSelectableDistrictUsesAKnownProvinceCode() {
+    fun `모든_지도_선택_지역은_알려진_시도_코드를_사용한다`() {
         val provinceCodes = GeneratedKoreaMapData.provinces.map { it.code }
         val mapSelectableDistricts = KoreanSelectableDistrictCodes.filter { it.provinceCode != null }
 
@@ -20,13 +20,13 @@ class KoreaMapStaticDataTest {
     }
 
     @Test
-    fun knownDistrictSelectionsUseCanonicalCodes() {
+    fun `알려진_지역_선택은_정규_코드를_사용한다`() {
         assertEquals("51760", KoreanSelectableDistrictCodes.single { it.code == "51760" }.code)
         assertEquals("11680", KoreanSelectableDistrictCodes.single { it.code == "11680" }.code)
     }
 
     @Test
-    fun provinceSelectionCanResolveOnlyItsCanonicalDistricts() {
+    fun `시도_선택은_해당_시도의_정규_지역만_조회한다`() {
         val gangwon = KoreanSelectableDistrictCodes.filter { it.provinceCode == "KR-42" }
 
         assertTrue(gangwon.isNotEmpty())
@@ -35,13 +35,13 @@ class KoreaMapStaticDataTest {
     }
 
     @Test
-    fun generatedProvinceAndWorldDataSupportMapScopeSwitch() {
+    fun `생성된_시도와_세계_데이터는_지도_범위_전환을_지원한다`() {
         assertEquals(17, GeneratedKoreaMapData.provinces.size)
         assertTrue(GeneratedWorldMapData.countries.isNotEmpty())
     }
 
     @Test
-    fun selectsTheSmallestExactBoundaryWhenRegionsOverlap() {
+    fun `지역이_겹치면_가장_작은_정확한_경계를_선택한다`() {
         val province = square("KR-41", "경기도", 0f, 0f, 10f, 10f)
         val city = square("KR-11", "서울특별시", 2f, 2f, 4f, 4f)
 
@@ -51,7 +51,7 @@ class KoreaMapStaticDataTest {
     }
 
     @Test
-    fun mapTapOnTheRightOrTopBoundaryStillSelectsTheRegion() {
+    fun `오른쪽이나_위쪽_경계선을_눌러도_지역을_선택한다`() {
         val region = square("KR-11", "서울특별시", 0f, 0f, 10f, 10f)
 
         assertEquals("KR-11", listOf(region).regionAt(GeoPoint(10f, 5f))?.code)
@@ -59,7 +59,7 @@ class KoreaMapStaticDataTest {
     }
 
     @Test
-    fun generatedMapKeepsSeoulAndGyeonggiBoundariesDistinct() {
+    fun `생성된_지도는_서울과_경기도_경계를_구분한다`() {
         assertEquals(
             "KR-11",
             GeneratedKoreaMapData.provinces.regionAt(GeoPoint(126.98f, 37.56f))?.code,
@@ -71,7 +71,7 @@ class KoreaMapStaticDataTest {
     }
 
     @Test
-    fun adjacentProvinceBoundariesShareCoordinatesWithoutVisibleGaps() {
+    fun `인접한_시도_경계는_좌표를_공유하고_빈틈이_없다`() {
         assertTrue(sharedBoundaryEdgeCount("KR-31", "KR-48") > 0, "울산과 경남 경계가 분리되어 있습니다")
         assertTrue(sharedBoundaryEdgeCount("KR-50", "KR-44") > 0, "세종과 충남 경계가 분리되어 있습니다")
     }

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapPanBoundsTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/ui/KoreaMapPanBoundsTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 
 class KoreaMapPanBoundsTest {
     @Test
-    fun `map smaller than viewport can move within the slack boundary`() {
+    fun `지도_크기가_뷰포트보다_작아도_여유_경계_안에서_이동할_수_있다`() {
         val result = clampKoreaMapPan(
             pan = Offset(500f, -500f),
             zoom = 1f,
@@ -23,7 +23,7 @@ class KoreaMapPanBoundsTest {
     }
 
     @Test
-    fun `zoomed map cannot be dragged completely outside viewport`() {
+    fun `확대된_지도는_뷰포트_밖으로_완전히_끌어낼_수_없다`() {
         val result = clampKoreaMapPan(
             pan = Offset(10_000f, -10_000f),
             zoom = 2f,

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/viewmodel/MapViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/viewmodel/MapViewModelTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertTrue
 
 class MapViewModelTest {
     @Test
-    fun refreshBuildsVisitedCountriesProvincesAndDistrictsFromRepositoryRecords() = runSuspend {
+    fun `새로고침은_저장소_기록에서_방문_국가_시도_지역을_구성한다`() = runSuspend {
         val catalog = StaticRegionCatalog()
         val repository = FakeTripRecordRepository(1) { "2026-08-24T00:00:00" }
         val gangnam = catalog.requireByCode("11680")

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertTrue
 
 class PhotoLibraryTest {
     @Test
-    fun selectedPhotosAreDeduplicatedWithoutAnApplicationLimit() {
+    fun `선택한_사진은_앱_제한_없이_중복_제거된다`() {
         val existing = listOf(photo("same"), photo("existing"))
         val incoming = listOf(photo("same")) + (1..20).map { photo("new-$it") }
 
@@ -21,7 +21,7 @@ class PhotoLibraryTest {
     }
 
     @Test
-    fun boundaryIncludesInteriorAndEdgeButRejectsOutsideCoordinates() {
+    fun `경계는_내부와_선_위_좌표를_포함하고_외부_좌표는_거부한다`() {
         val region = PhotoRecommendationRegion(
             code = "test",
             rings = listOf(square(left = 0f, bottom = 0f, right = 10f, top = 10f)),
@@ -35,7 +35,7 @@ class PhotoLibraryTest {
     }
 
     @Test
-    fun degenerateRingsDoNotMatchAnyPhoto() {
+    fun `퇴화한_링은_어떤_사진과도_일치하지_않는다`() {
         val region = PhotoRecommendationRegion(
             code = "invalid",
             rings = listOf(
@@ -48,7 +48,7 @@ class PhotoLibraryTest {
     }
 
     @Test
-    fun boundaryChecksEveryDisconnectedRing() {
+    fun `경계는_분리된_모든_링을_확인한다`() {
         val region = PhotoRecommendationRegion(
             code = "islands",
             rings = listOf(
@@ -63,7 +63,7 @@ class PhotoLibraryTest {
     }
 
     @Test
-    fun generatedSeoulBoundaryRejectsNearbyGyeonggiPhoto() {
+    fun `생성된_서울_경계는_인접한_경기도_사진을_거부한다`() {
         val seoul = GeneratedKoreaMapData.provinces.single { it.code == "KR-11" }
         val region = PhotoRecommendationRegion(seoul.code, seoul.rings)
 
@@ -72,7 +72,7 @@ class PhotoLibraryTest {
     }
 
     @Test
-    fun recommendationKeepsNewestInputOrderAndStopsAtTwelveMatches() {
+    fun `추천_결과는_최신_입력_순서를_유지하고_열두_개에서_멈춘다`() {
         val region = PhotoRecommendationRegion(
             code = "test",
             rings = listOf(square(left = 0f, bottom = 0f, right = 10f, top = 10f)),
@@ -90,7 +90,7 @@ class PhotoLibraryTest {
     }
 
     @Test
-    fun nonPositiveRecommendationLimitReturnsNoPhotos() {
+    fun `양수가_아닌_추천_개수_제한은_사진을_반환하지_않는다`() {
         val region = PhotoRecommendationRegion(
             code = "test",
             rings = listOf(square(left = 0f, bottom = 0f, right = 10f, top = 10f)),

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCachePolicyTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataCachePolicyTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertTrue
 
 class PhotoMetadataCachePolicyTest {
     @Test
-    fun reusesCoordinatesOnlyWhenMediaStoreTimestampAndCoordinatesArePresent() {
+    fun `MediaStore_수정_시각과_좌표가_모두_있을_때만_캐시_좌표를_재사용한다`() {
         assertTrue(shouldReuseCoordinates(10L, 37.5, 127.0, 10L))
         assertFalse(shouldReuseCoordinates(null, 37.5, 127.0, 10L))
         assertFalse(shouldReuseCoordinates(11L, 37.5, 127.0, 10L))

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordDetailViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordDetailViewModelTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertIs
 
 class TripRecordDetailViewModelTest {
     @Test
-    fun loadChangesStateForSuccessAndFailure() {
+    fun `로드는_성공과_실패에_따라_상태를_변경한다`() {
         runSuspend {
             val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
             val record = repository.createTripRecord(

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModelTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 
 class TripRecordEditorViewModelTest {
     @Test
-    fun repeatedRouteInitializationKeepsTheDraft() = runSuspend {
+    fun `경로를_반복_초기화해도_작성_초안을_유지한다`() = runSuspend {
         val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
         val viewModel = TripRecordEditorViewModel(
             createTripRecord = CreateTripRecordUseCase(repository),
@@ -33,7 +33,7 @@ class TripRecordEditorViewModelTest {
     }
 
     @Test
-    fun saveWaitsForPendingPhotosUntilUserConfirmsExcludingThem() = runSuspend {
+    fun `저장은_대기_중인_사진을_기다리고_사용자_확인_후_제외한다`() = runSuspend {
         val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
         val viewModel = TripRecordEditorViewModel(
             createTripRecord = CreateTripRecordUseCase(repository),
@@ -55,7 +55,7 @@ class TripRecordEditorViewModelTest {
     }
 
     @Test
-    fun saveCreatesAndUpdatesTripRecord() {
+    fun `저장은_여행_기록을_생성하고_수정한다`() {
         runSuspend {
             val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
             val viewModel = TripRecordEditorViewModel(
@@ -89,7 +89,7 @@ class TripRecordEditorViewModelTest {
     }
 
     @Test
-    fun saveAllowsEitherDateToBeOmittedAndRejectsInvalidDateRange() {
+    fun `저장은_한쪽_날짜_생략을_허용하고_잘못된_날짜_범위를_거부한다`() {
         runSuspend {
             val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
             val viewModel = TripRecordEditorViewModel(
@@ -122,7 +122,7 @@ class TripRecordEditorViewModelTest {
     }
 
     @Test
-    fun editingShowsOnlyTheTouchedFieldErrorImmediately() {
+    fun `수정_중에는_건드린_필드의_오류만_즉시_표시한다`() {
         runSuspend {
             val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
             val viewModel = TripRecordEditorViewModel(
@@ -161,7 +161,7 @@ class TripRecordEditorViewModelTest {
     }
 
     @Test
-    fun mediaObjectKeysCanBeAddedAndRemoved() {
+    fun `미디어_Object_Key를_추가하고_삭제할_수_있다`() {
         val viewModel = TripRecordEditorViewModel(
             createTripRecord = CreateTripRecordUseCase(FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }),
             updateTripRecord = UpdateTripRecordUseCase(FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }),

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordListViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordListViewModelTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertIs
 
 class TripRecordListViewModelTest {
     @Test
-    fun repeatedRouteInitializationKeepsTheCurrentFilter() = runSuspend {
+    fun `경로를_반복_초기화해도_현재_필터를_유지한다`() = runSuspend {
         val repository = FakeTripRecordRepository(10) { "2026-08-07T00:00:00Z" }
         val viewModel = TripRecordListViewModel(GetTripRecordsUseCase(repository))
 
@@ -25,7 +25,7 @@ class TripRecordListViewModelTest {
     }
 
     @Test
-    fun loadChangesStateForSuccessAndFailure() {
+    fun `로드는_성공과_실패에_따라_상태를_변경한다`() {
         runSuspend {
             val repository = FakeTripRecordRepository(
                 memberId = 10,

--- a/client/tools/map/test_generate_korea_map.py
+++ b/client/tools/map/test_generate_korea_map.py
@@ -15,7 +15,7 @@ SPEC.loader.exec_module(MODULE)
 
 
 class GenerateKoreaMapTest(unittest.TestCase):
-    def test_bundled_resources_have_canonical_codes_by_province(self):
+    def test_시도별_번들_리소스는_정규_코드를_사용한다(self):
         client_dir = MODULE_PATH.parents[2]
         resource_dir = client_dir / "shared/src/commonMain/composeResources/files"
         locations_file = client_dir / "shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/KoreanDistrictCode.kt"
@@ -36,7 +36,7 @@ class GenerateKoreaMapTest(unittest.TestCase):
         self.assertEqual("51760", next(item["code"] for item in gangwon["districts"] if item["name"] == "평창군"))
         self.assertEqual("11680", next(item["code"] for item in seoul["districts"] if item["name"] == "강남구"))
 
-    def test_outer_rings_discards_polygon_holes(self):
+    def test_외곽_링은_폴리곤_구멍을_제외한다(self):
         geometry = {
             "type": "Polygon",
             "coordinates": [
@@ -47,7 +47,7 @@ class GenerateKoreaMapTest(unittest.TestCase):
 
         self.assertEqual(1, len(MODULE.outer_rings(geometry)))
 
-    def test_outer_rings_keeps_each_multipolygon_exterior(self):
+    def test_외곽_링은_멀티폴리곤의_각_외곽을_유지한다(self):
         geometry = {
             "type": "MultiPolygon",
             "coordinates": [
@@ -58,7 +58,7 @@ class GenerateKoreaMapTest(unittest.TestCase):
 
         self.assertEqual(2, len(MODULE.outer_rings(geometry)))
 
-    def test_simplify_ring_preserves_closed_ring(self):
+    def test_링_단순화는_닫힌_링을_유지한다(self):
         ring = [[0, 0], [1, 0.001], [2, 0], [2, 2], [0, 2], [0, 0]]
 
         simplified = MODULE.simplify_ring(ring, 0.01)
@@ -67,7 +67,7 @@ class GenerateKoreaMapTest(unittest.TestCase):
         self.assertLess(len(simplified), len(ring))
         self.assertIn([2, 2], simplified)
 
-    def test_major_province_override_replaces_only_target_codes(self):
+    def test_주요_시도_재정의는_대상_코드만_교체한다(self):
         base = [
             ("KR-11", "서울특별시", [[[0, 0], [1, 0], [0, 1]]]),
             ("KR-41", "경기도", [[[2, 2], [3, 2], [2, 3]]]),
@@ -81,13 +81,13 @@ class GenerateKoreaMapTest(unittest.TestCase):
         self.assertEqual(10, merged[0][2][0][0][0])
         self.assertEqual(base[1], merged[1])
 
-    def test_overview_override_uses_one_source_for_every_province(self):
+    def test_개요_재정의는_모든_시도에_하나의_소스를_사용한다(self):
         self.assertEqual(
             frozenset(MODULE.PROVINCE_NAMES),
             MODULE.PROVINCE_OVERRIDE_CODES,
         )
 
-    def test_province_parts_are_split_by_coordinate_count(self):
+    def test_시도_조각은_좌표_개수에_따라_분할된다(self):
         feature = lambda code, count: (code, code, [[[index, 0] for index in range(count)]])
 
         parts = MODULE.partition_province_features(
@@ -97,7 +97,7 @@ class GenerateKoreaMapTest(unittest.TestCase):
 
         self.assertEqual([["A", "B"], ["C"]], [[feature[0] for feature in part] for part in parts])
 
-    def test_canonicalizes_legacy_pyeongchang_code_to_app_code(self):
+    def test_기존_평창_코드를_앱_코드로_정규화한다(self):
         feature = {
             "type": "Feature",
             "properties": {"code": "32340", "name": "평창군"},


### PR DESCRIPTION
## 변경 내용

- Kotlin 테스트 함수명을 한글 문장과 밑줄(`_`) 형식으로 통일했습니다.
- Android D8가 함수명 공백을 허용하지 않아, 한글은 유지하고 공백만 밑줄로 변경했습니다.
- Python 지도 생성 테스트 함수명도 한글 형식으로 정리했습니다.

## 검증

- `./gradlew :shared:jvmTest` 성공
- `./gradlew :shared:testAndroidHostTest` 성공
- `python3 -m unittest discover -s tools/map -p 'test_*.py'` 성공 (8개)\n- `ANDROID_SERIAL=emulator-5554 ./gradlew :shared:androidConnectedCheck :androidApp:connectedDebugAndroidTest` 성공 (shared 12개, 앱 3개)\n\n## 관련 커밋\n\n- `01db60c test: 테스트 함수명을 한글로 통일`