### PR TITLE
fix: 하단 네비게이션과 지도 FAB 정렬 수정

### DIFF
--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripMapScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripMapScreen.kt
@@ -1,5 +1,6 @@
 package com.mapmory.shared.presentation.triprecord.screen
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -27,6 +28,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -93,15 +96,28 @@ fun TripMapScreen(
                         .size(44.dp)
                         .clip(CircleShape)
                         .background(TripRecordPalette.primary)
-                        .clickable(onClick = onCreateClick),
+                    .clickable(onClick = onCreateClick),
                     contentAlignment = Alignment.Center,
                 ) {
-                    Text(
-                        "＋",
-                        color = TripRecordPalette.onPrimary,
-                        fontSize = 27.sp,
-                        fontWeight = FontWeight.Light,
-                    )
+                    Canvas(Modifier.size(24.dp)) {
+                        val strokeWidth = 2.dp.toPx()
+                        val center = Offset(size.width / 2f, size.height / 2f)
+                        val armLength = size.minDimension * 0.32f
+                        drawLine(
+                            color = TripRecordPalette.onPrimary,
+                            start = Offset(center.x - armLength, center.y),
+                            end = Offset(center.x + armLength, center.y),
+                            strokeWidth = strokeWidth,
+                            cap = StrokeCap.Round,
+                        )
+                        drawLine(
+                            color = TripRecordPalette.onPrimary,
+                            start = Offset(center.x, center.y - armLength),
+                            end = Offset(center.x, center.y + armLength),
+                            strokeWidth = strokeWidth,
+                            cap = StrokeCap.Round,
+                        )
+                    }
                 }
             }
 
@@ -116,7 +132,6 @@ fun TripMapScreen(
                 selectedIconColor = TripRecordPalette.primary,
                 selectedLabelColor = TripRecordPalette.navigationSelectedLabel,
                 unselectedColor = TripRecordPalette.navigationUnselected,
-                contentTopPadding = 6.dp,
             )
         }
     }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripProfileScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripProfileScreen.kt
@@ -99,7 +99,6 @@ fun TripProfileScreen(
                 selectedIconColor = TripRecordPalette.primary,
                 selectedLabelColor = TripRecordPalette.navigationSelectedLabel,
                 unselectedColor = TripRecordPalette.navigationUnselected,
-                contentTopPadding = 6.dp,
             )
         }
     }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDesign.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordDesign.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mapmory.shared.presentation.map.ui.KoreaMapArtwork
@@ -251,7 +250,6 @@ internal fun TripBottomBar(
     selectedIconColor: Color = TripRecordPalette.accent,
     selectedLabelColor: Color = TripRecordPalette.accent,
     unselectedColor: Color = TripRecordPalette.muted,
-    contentTopPadding: Dp = 0.dp,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -276,7 +274,6 @@ internal fun TripBottomBar(
             selectedIconColor = selectedIconColor,
             selectedLabelColor = selectedLabelColor,
             unselectedColor = unselectedColor,
-            contentTopPadding = contentTopPadding,
             modifier = Modifier.weight(1f),
         )
         TripBottomItem(
@@ -286,7 +283,6 @@ internal fun TripBottomBar(
             selectedIconColor = selectedIconColor,
             selectedLabelColor = selectedLabelColor,
             unselectedColor = unselectedColor,
-            contentTopPadding = contentTopPadding,
             modifier = Modifier.weight(1f),
         )
         TripBottomItem(
@@ -296,7 +292,6 @@ internal fun TripBottomBar(
             selectedIconColor = selectedIconColor,
             selectedLabelColor = selectedLabelColor,
             unselectedColor = unselectedColor,
-            contentTopPadding = contentTopPadding,
             modifier = Modifier.weight(1f),
         )
     }
@@ -316,7 +311,6 @@ private fun TripBottomItem(
     selectedIconColor: Color,
     selectedLabelColor: Color,
     unselectedColor: Color,
-    contentTopPadding: Dp,
     modifier: Modifier = Modifier,
 ) {
     val iconColor = if (selected) selectedIconColor else unselectedColor
@@ -324,8 +318,7 @@ private fun TripBottomItem(
     Column(
         modifier = modifier
             .height(64.dp)
-            .clickable(onClick = onClick)
-            .padding(top = contentTopPadding),
+            .clickable(onClick = onClick),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {


### PR DESCRIPTION
## 변경 내용
- 지도·일지·통계 화면의 하단 네비게이션 아이콘과 텍스트 위치를 공통 기준으로 고정했습니다.
- 지도 화면 FAB의 텍스트 십자 아이콘을 중앙 기준 Canvas 십자 아이콘으로 교체했습니다.
- 기존 테스트 PR과 분리해 UI 정렬 변경만 포함했습니다.

## 검증
- [x] ./gradlew :shared:compileAndroidMain

## 리뷰 포인트
- 세 화면에서 하단 네비게이션 위치가 동일한지
- FAB 십자 아이콘이 원형 버튼의 중앙에 표시되는지