### PR TITLE
feat: 위치 기반 사진 추천 진행률 표시

### DIFF
--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSyncDeviceTest.kt
@@ -44,6 +44,23 @@ class PhotoMetadataSyncDeviceTest {
     }
 
     @Test
+    fun reportsPhotoScanProgress() = runBlocking {
+        val progress = mutableListOf<Pair<Int, Int>>()
+        sync(
+            current = listOf(
+                candidate(mediaId = 1L, modifiedAtSeconds = 10L),
+                candidate(mediaId = 2L, modifiedAtSeconds = 10L),
+            ),
+            coordinates = emptyMap(),
+            exifReads = mutableListOf(),
+        ).sync { processed, total ->
+            progress += processed to total
+        }
+
+        assertEquals(listOf(1 to 2, 2 to 2), progress)
+    }
+
+    @Test
     fun unchangedPhotoReusesCachedCoordinates() = runBlocking {
         val exifReads = mutableListOf<String>()
         val photo = candidate(mediaId = 1L, modifiedAtSeconds = 10L)

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
@@ -46,6 +46,7 @@ actual fun rememberPhotoLibraryActions(
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
     onLoadingChanged: (Boolean) -> Unit,
+    onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
 ): PhotoLibraryActions {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -53,15 +54,20 @@ actual fun rememberPhotoLibraryActions(
     val latestRecommended by rememberUpdatedState(onPhotosRecommended)
     val latestMessage by rememberUpdatedState(onMessage)
     val latestLoadingChanged by rememberUpdatedState(onLoadingChanged)
+    val latestLoadingProgressChanged by rememberUpdatedState(onLoadingProgressChanged)
     var pendingRecommendation by remember { mutableStateOf<Pair<Location, String?>?>(null) }
 
     fun loadRecommendations(target: Location, parentName: String?) {
         latestLoadingChanged(true)
         scope.launch {
             try {
-            val result = withContext(Dispatchers.IO) {
-                runCatching { context.recommendPhotos(target, parentName) }
-            }
+                val result = withContext(Dispatchers.IO) {
+                    runCatching {
+                        context.recommendPhotos(target, parentName) { progress ->
+                            latestLoadingProgressChanged(progress)
+                        }
+                    }
+                }
                 result.onSuccess(latestRecommended).onFailure {
                     latestMessage("사진 추천을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.")
                 }
@@ -201,6 +207,7 @@ private fun requiredRecommendationPermissions(): Array<String> = buildList {
 private suspend fun Context.recommendPhotos(
     target: Location,
     parentName: String?,
+    onProgress: (PhotoLoadingProgress) -> Unit,
 ): List<SelectedPhoto> {
     Trace.beginAsyncSection("photo.recommend.total", TraceCookie.Recommend)
     val totalStartedAt = SystemClock.elapsedRealtime()
@@ -214,7 +221,7 @@ private suspend fun Context.recommendPhotos(
         } ?: return emptyList()
         val boundaryLoadMillis = SystemClock.elapsedRealtime() - boundaryStartedAt
         val syncStartedAt = SystemClock.elapsedRealtime()
-        val syncResult = syncPhotoMetadata()
+        val syncResult = syncPhotoMetadata(onProgress)
         val syncMillis = SystemClock.elapsedRealtime() - syncStartedAt
         val regionFilterStartedAt = SystemClock.elapsedRealtime()
         val matchedPhotos = traceSection("photo.recommend.region_filter") {
@@ -256,7 +263,9 @@ private suspend fun Context.recommendPhotos(
     }
 }
 
-private suspend fun Context.syncPhotoMetadata(): PhotoMetadataSyncResult {
+private suspend fun Context.syncPhotoMetadata(
+    onProgress: (PhotoLoadingProgress) -> Unit,
+): PhotoMetadataSyncResult {
     val dao = PhotoMetadataDatabase.getInstance(this).photoMetadataDao()
     return PhotoMetadataSync(
         readPrevious = {
@@ -271,7 +280,9 @@ private suspend fun Context.syncPhotoMetadata(): PhotoMetadataSyncResult {
                 dao.replaceSnapshot(photos, scanId)
             }
         },
-    ).sync()
+    ).sync { processed, total ->
+        onProgress(PhotoLoadingProgress(processed, total))
+    }
 }
 
 internal fun Context.queryPhotoMetadataSnapshot(): List<PhotoMetadataCandidate>? {

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSync.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoMetadataSync.kt
@@ -9,7 +9,9 @@ internal class PhotoMetadataSync(
     private val writeSnapshot: suspend (List<PhotoMetadataEntity>, Long) -> Unit,
     private val scanIdProvider: () -> Long = { System.currentTimeMillis() },
 ) {
-    suspend fun sync(): PhotoMetadataSyncResult {
+    suspend fun sync(
+        onProgress: (processed: Int, total: Int) -> Unit = { _, _ -> },
+    ): PhotoMetadataSyncResult {
         val previousPhotos = readPrevious()
         val previousById = previousPhotos.associateBy(PhotoMetadataEntity::mediaId)
         val currentPhotos = readCurrent() ?: return PhotoMetadataSyncResult(
@@ -19,6 +21,9 @@ internal class PhotoMetadataSync(
             previousPhotoCount = previousPhotos.size,
         )
         val scanId = scanIdProvider()
+        val total = currentPhotos.size
+        val progressStep = (total / 100).coerceAtLeast(1)
+        var processed = 0
         var exifReadCount = 0
         var reusedCoordinateCount = 0
         val photos = currentPhotos.map { candidate ->
@@ -41,6 +46,10 @@ internal class PhotoMetadataSync(
             } else {
                 exifReadCount++
                 readCoordinates(candidate.contentUri)
+            }
+            processed++
+            if (processed == total || processed % progressStep == 0) {
+                onProgress(processed, total)
             }
             PhotoMetadataEntity(
                 mediaId = candidate.mediaId,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
@@ -13,6 +13,15 @@ data class SelectedPhoto(
     val originalBytes: ByteArray? = null,
 )
 
+data class PhotoLoadingProgress(
+    val processed: Int,
+    val total: Int,
+) {
+    val percentage: Int?
+        get() = total.takeIf { it > 0 }
+            ?.let { (processed * 100 / it).coerceIn(0, 100) }
+}
+
 data class PhotoLibraryActions(
     val pickFromGallery: () -> Unit,
     val recommendForLocation: (Location, String?) -> Unit,
@@ -28,6 +37,7 @@ typealias PhotoLibraryActionsFactory = @Composable (
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
     onLoadingChanged: (Boolean) -> Unit,
+    onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
 ) -> PhotoLibraryActions
 
 @Composable
@@ -36,6 +46,7 @@ expect fun rememberPhotoLibraryActions(
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
     onLoadingChanged: (Boolean) -> Unit,
+    onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
 ): PhotoLibraryActions
 
 internal fun mergeSelectedPhotos(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -62,6 +63,7 @@ import androidx.compose.ui.unit.sp
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.photo.PhotoLibraryActionsFactory
+import com.mapmory.shared.presentation.photo.PhotoLoadingProgress
 import com.mapmory.shared.presentation.photo.SelectedPhoto
 import com.mapmory.shared.presentation.photo.rememberPhotoLibraryActions
 import com.mapmory.shared.presentation.date.PlatformDatePicker
@@ -109,9 +111,16 @@ fun TripRecordEditorScreen(
     onMapClick: () -> Unit = {},
     onRecordClick: () -> Unit = {},
     onProfileClick: () -> Unit = {},
-    photoLibraryActionsFactory: PhotoLibraryActionsFactory = { onPicked, onRecommended, onMessage, onLoadingChanged ->
-        rememberPhotoLibraryActions(onPicked, onRecommended, onMessage, onLoadingChanged)
-    },
+    photoLibraryActionsFactory: PhotoLibraryActionsFactory =
+        { onPicked, onRecommended, onMessage, onLoadingChanged, onLoadingProgressChanged ->
+            rememberPhotoLibraryActions(
+                onPicked,
+                onRecommended,
+                onMessage,
+                onLoadingChanged,
+                onLoadingProgressChanged,
+            )
+        },
     modifier: Modifier = Modifier,
 ) {
     val selectableLocations = remember(locations) {
@@ -127,6 +136,7 @@ fun TripRecordEditorScreen(
     var knownRecommendationIds by remember { mutableStateOf(emptySet<String>()) }
     var showRecommendationSheet by remember { mutableStateOf(false) }
     var isPreparingRecommendationPhotos by remember { mutableStateOf(false) }
+    var photoLoadingProgress by remember { mutableStateOf<PhotoLoadingProgress?>(null) }
     var datePickerTarget by rememberSaveable { mutableStateOf<String?>(null) }
     val dismissKeyboardOnTap = rememberDismissKeyboardOnTapModifier()
     val photoLibrary = photoLibraryActionsFactory(
@@ -149,7 +159,11 @@ fun TripRecordEditorScreen(
             }
         },
         { photoMessage = it },
-        onPhotoLoadingChanged,
+        { isLoading ->
+            photoLoadingProgress = null
+            onPhotoLoadingChanged(isLoading)
+        },
+        { progress -> photoLoadingProgress = progress },
     )
     val locationResultsListState = rememberLazyListState()
     val filteredLocations = remember(locationSearchQuery, selectableLocations) {
@@ -209,6 +223,7 @@ fun TripRecordEditorScreen(
                             onRemoveClick = onPhotoRemoved,
                             recommendationsAvailable = photoLibrary.recommendationsAvailable,
                             isLoading = uiState.isPhotoLoading,
+                            loadingProgress = photoLoadingProgress,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = 18.dp),
@@ -542,6 +557,7 @@ private fun PhotoSection(
     onRemoveClick: (String) -> Unit,
     recommendationsAvailable: Boolean,
     isLoading: Boolean,
+    loadingProgress: PhotoLoadingProgress? = null,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -575,12 +591,34 @@ private fun PhotoSection(
                         shape = RoundedCornerShape(6.dp),
                     ),
             ) {
-                Text(
-                    text = "위치 기반 사진\n불러오기",
-                    color = TripRecordPalette.photoRecommendText,
-                    fontSize = 9.sp,
-                    lineHeight = 11.sp,
-                )
+                if (isLoading) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(13.dp),
+                            color = TripRecordPalette.photoRecommendText,
+                            strokeWidth = 1.5.dp,
+                        )
+                        Text(
+                            text = loadingProgress?.let { progress ->
+                                progress.percentage?.let { percentage ->
+                                    "${progress.processed}/${progress.total} ($percentage%)"
+                                }
+                            } ?: "불러오는 중",
+                            color = TripRecordPalette.photoRecommendText,
+                            fontSize = 9.sp,
+                        )
+                    }
+                } else {
+                    Text(
+                        text = "위치 기반 사진\n불러오기",
+                        color = TripRecordPalette.photoRecommendText,
+                        fontSize = 9.sp,
+                        lineHeight = 11.sp,
+                    )
+                }
             }
         }
         PhotoEditor(

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
@@ -66,6 +66,7 @@ actual fun rememberPhotoLibraryActions(
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
     onLoadingChanged: (Boolean) -> Unit,
+    @Suppress("UNUSED_PARAMETER") onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
 ): PhotoLibraryActions {
     val scope = rememberCoroutineScope()
     val controller = remember(scope) { IosPhotoLibraryController(scope) }

--- a/client/shared/src/jvmMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.jvm.kt
+++ b/client/shared/src/jvmMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.jvm.kt
@@ -9,7 +9,8 @@ actual fun rememberPhotoLibraryActions(
     onPhotosRecommended: (List<SelectedPhoto>) -> Unit,
     onMessage: (String) -> Unit,
     onLoadingChanged: (Boolean) -> Unit,
-): PhotoLibraryActions = remember(onMessage, onLoadingChanged) {
+    onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
+): PhotoLibraryActions = remember(onMessage, onLoadingChanged, onLoadingProgressChanged) {
     PhotoLibraryActions(
         pickFromGallery = { onMessage("사진 선택은 Android와 iOS 앱에서 사용할 수 있어요.") },
         recommendForLocation = { _, _ -> },


### PR DESCRIPTION
## 변경 내용
- 위치 기반 사진 추천 중 사진 메타데이터 처리 진행률을 전달합니다.
- 기록 작성 화면에 처리 수와 백분율을 표시합니다.
- iOS/JVM actual 시그니처를 공통 콜백과 맞춥니다.
- 사진 스캔 진행률 계측 테스트를 추가합니다.

## 검증
- `:shared:jvmTest`
- `:shared:testAndroidHostTest`
- `:shared:compileAndroidDeviceTest`
- `:androidApp:assembleDebug`
- `:shared:compileKotlinIosSimulatorArm64`

실제 연결 기기에서의 계측 테스트 실행은 별도 확인이 필요합니다.