### PR TITLE
chore: S3 객체 키에 서비스 prefix 추가

### DIFF
--- a/api.md
+++ b/api.md
@@ -238,6 +238,8 @@ Authorization: Bearer {게스트 accessToken}
 
 이미지는 API 서버를 거치지 않고 S3에 직접 업로드한다. 서버는 UUID 기반 `objectKey`만 발급하며, DB에는 만료되는 Presigned URL이 아닌 `objectKey`를 저장한다.
 
+`objectKey`의 형식은 서버가 정하며 환경에 따라 접두사가 달라질 수 있다. 클라이언트는 값을 해석하지 말고 받은 그대로 저장하고 전달한다.
+
 ### 이미지 업로드 URL 발급
 
 `POST /api/v1/uploads/presigned-urls`

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,6 +23,9 @@ APP_VERSION=unknown
 # --- S3 ---
 AWS_S3_BUCKET=
 AWS_REGION=ap-northeast-2
+# 공용 버킷에서 우리 객체를 모을 접두사. 전용 버킷이면 비워 둔다
+# 운영은 우테코 공용 버킷을 쓰므로 mapmory 를 넣는다
+AWS_S3_KEY_PREFIX=
 
 # --- 랜딩 출시 알림 ---
 # 쉼표로 구분한 정확한 랜딩 origin. 와일드카드는 사용하지 않는다.

--- a/backend/src/main/java/com/mapmory/backend/upload/policy/ObjectKeyGenerator.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/policy/ObjectKeyGenerator.java
@@ -1,19 +1,38 @@
 package com.mapmory.backend.upload.policy;
 
+import com.mapmory.backend.upload.storage.S3StorageProperties;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 
+/**
+ * 업로드 객체의 키를 만든다.
+ *
+ * 형식: {keyPrefix}/travel-records/{memberId}/{UUID}.{ext}
+ *
+ * 회원별로 묶여 있어 회원 단위 정리가 가능하고, 파일명이 UUID라 다른 사용자가 추측할 수 없다.
+ * keyPrefix는 공용 버킷에서 우리 객체를 한 곳에 모으기 위한 값으로, 없으면 붙이지 않는다.
+ */
 @Component
 public class ObjectKeyGenerator {
 
     private static final String PREFIX = "travel-records";
 
+    private final String keyPrefix;
+
+    public ObjectKeyGenerator(S3StorageProperties properties) {
+        this.keyPrefix = properties.normalizedKeyPrefix();
+    }
+
     public String generate(Long memberId, UploadFileType fileType) {
-        return "%s/%d/%s.%s".formatted(
+        String objectKey = "%s/%d/%s.%s".formatted(
                 PREFIX,
                 memberId,
                 UUID.randomUUID(),
                 fileType.canonicalExtension()
         );
+        if (keyPrefix.isEmpty()) {
+            return objectKey;
+        }
+        return keyPrefix + "/" + objectKey;
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/storage/S3StorageProperties.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/storage/S3StorageProperties.java
@@ -4,10 +4,32 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+/**
+ * S3 저장 위치.
+ *
+ * keyPrefix는 공용 버킷에서 우리 객체를 한 곳에 모으기 위한 값이다.
+ * 전용 버킷을 쓰는 환경에서는 비워 두면 된다.
+ */
 @Validated
 @ConfigurationProperties(prefix = "upload.storage.s3")
 public record S3StorageProperties(
         @NotBlank String bucket,
-        @NotBlank String region
+        @NotBlank String region,
+        String keyPrefix
 ) {
+
+    /**
+     * 앞뒤 슬래시를 제거한 prefix. 값이 없으면 빈 문자열이다.
+     *
+     * 운영자가 콘솔의 경로 표기를 그대로 옮겨 적어 "/mapmory" 나 "mapmory/" 가 들어와도
+     * 같은 위치를 가리키게 한다.
+     */
+    public String normalizedKeyPrefix() {
+        if (keyPrefix == null || keyPrefix.isBlank()) {
+            return "";
+        }
+        return keyPrefix.strip()
+                .replaceAll("^/+", "")
+                .replaceAll("/+$", "");
+    }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -51,6 +51,8 @@ upload:
     s3:
       bucket: ${AWS_S3_BUCKET:mapmory-local}
       region: ${AWS_REGION:ap-northeast-2}
+      # 공용 버킷에서 우리 객체를 모으기 위한 접두사. 전용 버킷이면 비워 둔다.
+      key-prefix: ${AWS_S3_KEY_PREFIX:}
 
 waitlist:
   cors:

--- a/backend/src/test/java/com/mapmory/backend/upload/UploadKeyPrefixIntegrationTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/UploadKeyPrefixIntegrationTest.java
@@ -1,0 +1,69 @@
+package com.mapmory.backend.upload;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import com.mapmory.backend.IntegrationTest;
+import com.mapmory.backend.upload.storage.PresignedUrlProvider;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * 업로드 키 prefix 인수 테스트.
+ *
+ * 운영 버킷은 여러 팀이 함께 쓰는 공용 버킷이라, 우리 객체는 서비스 prefix 아래에만 놓여야 한다.
+ * S3 호출은 외부 시스템이므로 대역으로 대체하고, 서버가 발급하는 objectKey만 검증한다.
+ */
+@AutoConfigureMockMvc
+@TestPropertySource(properties = "upload.storage.s3.key-prefix=mapmory")
+class UploadKeyPrefixIntegrationTest extends IntegrationTest {
+
+    private static final String REQUEST_BODY = """
+            {
+              "files": [
+                { "fileName": "jeju.jpg", "contentType": "image/jpeg", "fileSize": 1024 }
+              ]
+            }
+            """;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PresignedUrlProvider presignedUrlProvider;
+
+    @Test
+    void 발급된_objectKey는_서비스_prefix_아래에_있다() throws Exception {
+        given(presignedUrlProvider.createPresignedPutUrl(anyString(), anyString(), anyLong(), any()))
+                .willReturn(URI.create("https://bucket.s3.ap-northeast-2.amazonaws.com/signed"));
+
+        mockMvc.perform(post("/api/v1/uploads/presigned-urls")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(REQUEST_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.uploads[0].objectKey")
+                        .value(org.hamcrest.Matchers.startsWith("mapmory/travel-records/")));
+    }
+
+    private String accessToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login/guest"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.accessToken");
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/upload/controller/UploadControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/controller/UploadControllerTest.java
@@ -11,6 +11,7 @@ import com.mapmory.backend.common.handler.BusinessExceptionHandler;
 import com.mapmory.backend.common.handler.ValidationExceptionHandler;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.upload.policy.ObjectKeyGenerator;
+import com.mapmory.backend.upload.storage.S3StorageProperties;
 import com.mapmory.backend.upload.policy.UploadPolicy;
 import com.mapmory.backend.upload.policy.UploadPolicyProperties;
 import com.mapmory.backend.upload.service.UploadService;
@@ -53,7 +54,7 @@ class UploadControllerTest {
         );
         UploadService uploadService = new UploadService(
                 new UploadPolicy(properties),
-                new ObjectKeyGenerator(),
+                new ObjectKeyGenerator(new S3StorageProperties("mapmory-test", "ap-northeast-2", "")),
                 new FakePresignedUrlProvider(),
                 properties
         );

--- a/backend/src/test/java/com/mapmory/backend/upload/policy/ObjectKeyGeneratorTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/policy/ObjectKeyGeneratorTest.java
@@ -2,12 +2,16 @@ package com.mapmory.backend.upload.policy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.mapmory.backend.upload.storage.S3StorageProperties;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ObjectKeyGeneratorTest {
 
-    private final ObjectKeyGenerator objectKeyGenerator = new ObjectKeyGenerator();
+    private static final String UUID_PATTERN =
+            "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 
     @ParameterizedTest
     @CsvSource({
@@ -20,11 +24,46 @@ class ObjectKeyGeneratorTest {
             UploadFileType fileType,
             String extension
     ) {
-        String objectKey = objectKeyGenerator.generate(10L, fileType);
+        String objectKey = objectKeyGenerator("").generate(10L, fileType);
 
-        assertThat(objectKey).matches(
-                "travel-records/10/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
-                        + "[0-9a-f]{4}-[0-9a-f]{12}\\." + extension
-        );
+        assertThat(objectKey).matches("travel-records/10/" + UUID_PATTERN + "\\." + extension);
+    }
+
+    @Test
+    void prefix가_설정되면_Object_Key_앞에_붙인다() {
+        String objectKey = objectKeyGenerator("mapmory").generate(10L, UploadFileType.JPEG);
+
+        assertThat(objectKey).matches("mapmory/travel-records/10/" + UUID_PATTERN + "\\.jpg");
+    }
+
+    /**
+     * 운영자가 콘솔의 경로 표기를 그대로 옮겨 적을 수 있으므로 앞뒤 슬래시를 허용한다.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"mapmory", "/mapmory", "mapmory/", "/mapmory/", " mapmory "})
+    void prefix의_앞뒤_슬래시와_공백은_무시한다(String keyPrefix) {
+        String objectKey = objectKeyGenerator(keyPrefix).generate(10L, UploadFileType.JPEG);
+
+        assertThat(objectKey).matches("mapmory/travel-records/10/" + UUID_PATTERN + "\\.jpg");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "/"})
+    void prefix가_비어_있으면_붙이지_않는다(String keyPrefix) {
+        String objectKey = objectKeyGenerator(keyPrefix).generate(10L, UploadFileType.JPEG);
+
+        assertThat(objectKey).startsWith("travel-records/");
+    }
+
+    @Test
+    void prefix가_설정되지_않아도_동작한다() {
+        String objectKey = objectKeyGenerator(null).generate(10L, UploadFileType.JPEG);
+
+        assertThat(objectKey).startsWith("travel-records/");
+    }
+
+    private ObjectKeyGenerator objectKeyGenerator(String keyPrefix) {
+        return new ObjectKeyGenerator(
+                new S3StorageProperties("mapmory-test", "ap-northeast-2", keyPrefix));
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/upload/service/UploadServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/service/UploadServiceTest.java
@@ -7,6 +7,7 @@ import com.mapmory.backend.upload.dto.CreatePresignedUrlsRequest;
 import com.mapmory.backend.upload.dto.CreatePresignedUrlsResponse;
 import com.mapmory.backend.upload.dto.UploadFileRequest;
 import com.mapmory.backend.upload.policy.ObjectKeyGenerator;
+import com.mapmory.backend.upload.storage.S3StorageProperties;
 import com.mapmory.backend.upload.policy.UploadPolicy;
 import com.mapmory.backend.upload.policy.UploadPolicyProperties;
 import com.mapmory.backend.upload.storage.PresignedUrlProvider;
@@ -27,7 +28,7 @@ class UploadServiceTest {
         FakePresignedUrlProvider provider = new FakePresignedUrlProvider();
         UploadService uploadService = new UploadService(
                 new UploadPolicy(properties),
-                new ObjectKeyGenerator(),
+                new ObjectKeyGenerator(new S3StorageProperties("mapmory-test", "ap-northeast-2", "")),
                 provider,
                 properties
         );

--- a/backend/src/test/java/com/mapmory/backend/upload/storage/S3PresignedUrlProviderTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/storage/S3PresignedUrlProviderTest.java
@@ -23,7 +23,7 @@ class S3PresignedUrlProviderTest {
     void setUp() {
         provider = new S3PresignedUrlProvider(
                 s3Presigner,
-                new S3StorageProperties("mapmory-test", "ap-northeast-2")
+                new S3StorageProperties("mapmory-test", "ap-northeast-2", "")
         );
     }
 


### PR DESCRIPTION
## 요약

S3 객체 키에 서비스 prefix를 붙입니다. 운영에서 `AWS_S3_KEY_PREFIX=mapmory` 를 넣으면
객체가 `mapmory/travel-records/...` 아래에 생성됩니다. (#163)

```
현재   travel-records/{memberId}/{UUID}.jpg      ← 공용 버킷 루트
변경   mapmory/travel-records/{memberId}/{UUID}.jpg
```

## 배경

운영 버킷은 2026 우테코 **공용 버킷**이고 그 안에 `mapmory/` 를 만들어 쓰기로 했는데,
`ObjectKeyGenerator` 에는 서비스 prefix 개념이 없었습니다.

특히 위험한 건 **IAM 정책이 `mapmory/*` 로 제한된 경우 실패가 서버에 보이지 않는다**는 점입니다.
presigned URL 발급은 서명을 만드는 동작이라 권한과 무관하게 성공하고, 앱이 실제로 PUT 할 때
403 이 납니다. 서버 로그에는 아무 흔적이 없어 원인을 찾기 어렵습니다.

버킷 이름에 경로를 넣는 우회(`AWS_S3_BUCKET=버킷/mapmory`)는 SDK가 잘못된 요청을 만들어
업로드가 깨지므로 쓸 수 없습니다. prefix는 키의 일부여야 합니다.

## 주요 결정

### 기본값을 비워 두어 기존 동작을 유지

`key-prefix: ${AWS_S3_KEY_PREFIX:}` 입니다. 값이 없으면 지금과 똑같은 키를 만듭니다.
로컬은 전용 버킷이라 prefix 없이 쓰고, 운영에서만 켭니다.

### 앞뒤 슬래시와 공백을 정규화

`mapmory`, `/mapmory`, `mapmory/`, `/mapmory/` 가 모두 같은 위치를 가리킵니다.
운영자가 콘솔의 경로 표기를 그대로 옮겨 적기 쉬운 값이라, 실수를 설정 단계에서 흡수합니다.

### prefix를 키 생성 쪽에 둔다

`S3PresignedUrlProvider` 에서 붙이면 서명 URL에만 반영되고 DB에 저장되는 `objectKey` 는
prefix 없이 남아 실제 객체 위치와 어긋납니다. 그래서 `ObjectKeyGenerator` 가 붙입니다.

### 마이그레이션 불필요

DB에는 전체 `objectKey` 가 저장되므로 기존 객체는 그 키로 계속 찾아집니다.
새로 생성되는 키만 prefix 아래로 갑니다.

## 배포 시 필요한 작업

```bash
# /etc/mapmory.env
AWS_S3_KEY_PREFIX=mapmory
```

넣지 않아도 기동과 동작에는 문제가 없지만, 그 경우 객체는 계속 버킷 루트에 쌓입니다.

## 테스트

ATDD로 인수 테스트를 먼저 작성해 실패를 확인한 뒤 구현했습니다.

- `UploadKeyPrefixIntegrationTest` — `POST /uploads/presigned-urls` 응답의 `objectKey` 가
  설정한 prefix 아래에 있는지 API를 통해 검증합니다. S3 호출은 외부 시스템이므로 대역으로 대체했습니다.
- `ObjectKeyGeneratorTest` — prefix 유무, 앞뒤 슬래시·공백, `null` 처리

전체 스위트 통과했습니다.

## 확인

- [x] 로컬에서 실행 확인 (`./gradlew test` 전체 통과)
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 새 환경변수를 추가했으므로 `.env.example` 갱신 (`AWS_S3_KEY_PREFIX`)
- [x] DB 스키마 변경 없음
- [x] 실행 방법 변경 없음 (운영은 `/etc/mapmory.env` 갱신 필요 — 위 참고)
