### PR TITLE
fix: 기록 작성 태그 선택 상태 수정

### DIFF
--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -735,22 +735,31 @@ private fun TripRecordEditorUiState.errorMessageFor(target: TripRecordEditorErro
 
 @Composable
 private fun CompanionChips(modifier: Modifier = Modifier) {
+    val companions = remember { listOf("가족", "애인", "친구", "혼자") }
+    var selectedCompanion by remember { mutableStateOf<String?>(null) }
+
     Row(
         modifier = modifier
             .fillMaxWidth()
             .horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        listOf("가족", "애인", "친구", "혼자").forEach { companion ->
+        companions.forEach { companion ->
+            val selected = selectedCompanion == companion
             Text(
                 text = companion,
-                color = TripRecordPalette.text,
+                color = if (selected) TripRecordPalette.primary else TripRecordPalette.text,
                 fontSize = 10.sp,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier
                     .clip(RoundedCornerShape(50.dp))
-                    .background(TripRecordPalette.surface)
+                    .background(
+                        if (selected) TripRecordPalette.primarySoft else TripRecordPalette.surface,
+                    )
                     .border(1.dp, TripRecordPalette.line, RoundedCornerShape(50.dp))
+                    .clickable {
+                        selectedCompanion = if (selected) null else companion
+                    }
                     .padding(horizontal = 11.dp, vertical = 7.dp),
             )
         }


### PR DESCRIPTION
## 변경 내용
- 기록 작성 화면의 가족·애인·친구·혼자 태그에 선택 상태를 추가했습니다.
- 선택한 태그는 강조 색상으로 표시됩니다.
- 선택한 태그를 다시 누르면 선택을 해제할 수 있습니다.

## 원인
기존 `CompanionChips`는 텍스트와 스타일만 렌더링하고 클릭 이벤트 및 선택 상태를 관리하지 않았습니다.

## 검증
- `:shared:compileAndroidMain`
- `:shared:jvmTest`
- `:shared:testAndroidHostTest`
- `:androidApp:assembleDebug`