### PR TITLE
feat: 여행 기록 목록에 썸네일 URL 제공

### DIFF
--- a/backend/docs/travel-record-storage-and-query.md
+++ b/backend/docs/travel-record-storage-and-query.md
@@ -198,7 +198,9 @@ PageRequest.of(
 | `totalPages` | 전체 페이지 수 |
 | `hasNext` | 다음 페이지 존재 여부 |
 
-목록 아이템은 `id`, `title`, `regionName`, `startDate`, `endDate`, `thumbnailUrl`만 반환한다. 본문과 전체 이미지 목록은 목록 응답에서 제외한다.
+목록 아이템은 `id`, `title`, `regionName`, `startDate`, `endDate`, `thumbnailUrl`, `thumbnailUrlExpiresIn`을 반환한다. 본문과 전체 이미지 목록은 목록 응답에서 제외한다.
+
+`thumbnailUrl`은 현재 페이지의 기록 ID를 모아 `sort_order = 0`인 첫 미디어를 한 번에 조회한 뒤 Presigned GET URL로 생성한다. `thumb_key`가 있으면 썸네일 객체를 사용하고, 아직 생성되지 않았다면 원본 `object_key`를 사용한다. 미디어가 없는 기록은 `thumbnailUrl`과 `thumbnailUrlExpiresIn`이 모두 `null`이다.
 
 생성과 목록 조회의 성공 응답은 다음처럼 `data` 필드로 감싼다.
 
@@ -309,7 +311,7 @@ Service는 `travelRecordId`와 `memberId`로 소유권을 확인한 후 새 Regi
 | 생성·목록 페이징 테스트 | 구현 |
 | 여행 기록 상세 조회 및 소유권 검사 | 구현 |
 | 여행 기록 전체 수정 및 미디어 동기화 | 구현 |
-| 목록 썸네일 URL 생성 | 미구현, 현재 `null` |
+| 목록 썸네일 URL 생성 | 구현 |
 | 상세 조회 Object Key의 Presigned GET URL 변환 | 구현 |
 | 키워드 검색 | 미구현 |
 | 날짜 범위 검증 | 미구현 |

--- a/backend/docs/travel-record-storage-and-query.md
+++ b/backend/docs/travel-record-storage-and-query.md
@@ -200,7 +200,7 @@ PageRequest.of(
 
 목록 아이템은 `id`, `title`, `regionName`, `startDate`, `endDate`, `thumbnailUrl`, `thumbnailUrlExpiresIn`을 반환한다. 본문과 전체 이미지 목록은 목록 응답에서 제외한다.
 
-`thumbnailUrl`은 현재 페이지의 기록 ID를 모아 `sort_order = 0`인 첫 미디어를 한 번에 조회한 뒤 Presigned GET URL로 생성한다. `thumb_key`가 있으면 썸네일 객체를 사용하고, 아직 생성되지 않았다면 원본 `object_key`를 사용한다. 미디어가 없는 기록은 `thumbnailUrl`과 `thumbnailUrlExpiresIn`이 모두 `null`이다.
+`thumbnailUrl`은 현재 페이지의 기록 ID를 모아 미디어를 한 번에 정렬 조회한 뒤 기록별 첫 미디어의 Presigned GET URL로 생성한다. `thumb_key`가 있으면 썸네일 객체를 사용하고, 아직 생성되지 않았다면 원본 `object_key`를 사용한다. 미디어가 없는 기록은 `thumbnailUrl`과 `thumbnailUrlExpiresIn`이 모두 `null`이다.
 
 생성과 목록 조회의 성공 응답은 다음처럼 `data` 필드로 감싼다.
 

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/ExpiringUrl.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/ExpiringUrl.java
@@ -1,0 +1,24 @@
+package com.mapmory.backend.recordmedia;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Objects;
+
+public record ExpiringUrl(
+        String url,
+        long expiresIn
+) {
+    public ExpiringUrl {
+        Objects.requireNonNull(url, "url must not be null");
+        if (url.isBlank()) {
+            throw new IllegalArgumentException("url must not be blank");
+        }
+        if (expiresIn <= 0) {
+            throw new IllegalArgumentException("expiresIn must be positive");
+        }
+    }
+
+    public static ExpiringUrl from(URI url, Duration expiration) {
+        return new ExpiringUrl(url.toString(), expiration.toSeconds());
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMedia.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMedia.java
@@ -64,7 +64,7 @@ public class RecordMedia {
         return objectKey;
     }
 
-    public Long getTravelRecordId() {
+    public Long travelRecordId() {
         return travelRecord.getId();
     }
 

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMedia.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMedia.java
@@ -64,6 +64,17 @@ public class RecordMedia {
         return objectKey;
     }
 
+    public Long getTravelRecordId() {
+        return travelRecord.getId();
+    }
+
+    public String getThumbnailObjectKey() {
+        if (thumbKey == null || thumbKey.isBlank()) {
+            return objectKey;
+        }
+        return thumbKey;
+    }
+
     public int getSortOrder() {
         return sortOrder;
     }

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
@@ -8,5 +8,10 @@ public interface RecordMediaRepository extends JpaRepository<RecordMedia, Long> 
 
     List<RecordMedia> findByTravelRecordIdOrderBySortOrderAsc(Long travelRecordId);
 
+    List<RecordMedia> findByTravelRecordIdInAndSortOrder(
+            Collection<Long> travelRecordIds,
+            int sortOrder
+    );
+
     List<RecordMedia> findByObjectKeyIn(Collection<String> objectKeys);
 }

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
@@ -8,9 +8,8 @@ public interface RecordMediaRepository extends JpaRepository<RecordMedia, Long> 
 
     List<RecordMedia> findByTravelRecordIdOrderBySortOrderAsc(Long travelRecordId);
 
-    List<RecordMedia> findByTravelRecordIdInAndSortOrder(
-            Collection<Long> travelRecordIds,
-            int sortOrder
+    List<RecordMedia> findByTravelRecordIdInOrderByTravelRecordIdAscSortOrderAscIdAsc(
+            Collection<Long> travelRecordIds
     );
 
     List<RecordMedia> findByObjectKeyIn(Collection<String> objectKeys);

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaUrlService.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaUrlService.java
@@ -42,7 +42,7 @@ public class RecordMediaUrlService {
                 .findByTravelRecordIdInOrderByTravelRecordIdAscSortOrderAscIdAsc(travelRecordIds);
         for (RecordMedia media : recordMedia) {
             thumbnailUrls.computeIfAbsent(
-                    media.getTravelRecordId(),
+                    media.travelRecordId(),
                     ignored -> createViewUrl(media.getThumbnailObjectKey())
             );
         }

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaUrlService.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaUrlService.java
@@ -1,0 +1,51 @@
+package com.mapmory.backend.recordmedia;
+
+import com.mapmory.backend.upload.policy.UploadPolicyProperties;
+import com.mapmory.backend.upload.storage.PresignedUrlProvider;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RecordMediaUrlService {
+
+    private final RecordMediaRepository recordMediaRepository;
+    private final PresignedUrlProvider presignedUrlProvider;
+    private final Duration expiration;
+
+    public RecordMediaUrlService(
+            RecordMediaRepository recordMediaRepository,
+            PresignedUrlProvider presignedUrlProvider,
+            UploadPolicyProperties uploadPolicyProperties
+    ) {
+        this.recordMediaRepository = recordMediaRepository;
+        this.presignedUrlProvider = presignedUrlProvider;
+        this.expiration = uploadPolicyProperties.presignedUrlExpiration();
+    }
+
+    public ExpiringUrl createViewUrl(String objectKey) {
+        return ExpiringUrl.from(
+                presignedUrlProvider.createPresignedGetUrl(objectKey, expiration),
+                expiration
+        );
+    }
+
+    public Map<Long, ExpiringUrl> createThumbnailUrls(List<Long> travelRecordIds) {
+        if (travelRecordIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, ExpiringUrl> thumbnailUrls = new HashMap<>();
+        List<RecordMedia> recordMedia = recordMediaRepository
+                .findByTravelRecordIdInOrderByTravelRecordIdAscSortOrderAscIdAsc(travelRecordIds);
+        for (RecordMedia media : recordMedia) {
+            thumbnailUrls.computeIfAbsent(
+                    media.getTravelRecordId(),
+                    ignored -> createViewUrl(media.getThumbnailObjectKey())
+            );
+        }
+        return Map.copyOf(thumbnailUrls);
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -214,13 +214,21 @@ public class TravelRecordService {
             }
         }
 
+        List<Long> travelRecordIds = travelRecords.getContent().stream()
+                .map(TravelRecord::getId)
+                .toList();
         Map<Long, List<Tag>> tagsByTravelRecordId =
-                travelRecordTagService.findByTravelRecordIds(
-                        travelRecords.getContent().stream().map(TravelRecord::getId).toList()
-                );
+                travelRecordTagService.findByTravelRecordIds(travelRecordIds);
+        Duration expiration = uploadPolicyProperties.presignedUrlExpiration();
+        Map<Long, String> thumbnailUrlsByTravelRecordId = createThumbnailUrls(
+                travelRecordIds,
+                expiration
+        );
         return TravelRecordListResponse.from(
                 travelRecords,
-                tagsByTravelRecordId
+                tagsByTravelRecordId,
+                thumbnailUrlsByTravelRecordId,
+                expiration.toSeconds()
         );
     }
 
@@ -343,6 +351,24 @@ public class TravelRecordService {
                 .toList();
 
         return TravelRecordDetailResponse.from(travelRecord, recordMedia, tags, media);
+    }
+
+    private Map<Long, String> createThumbnailUrls(
+            List<Long> travelRecordIds,
+            Duration expiration
+    ) {
+        if (travelRecordIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return recordMediaRepository.findByTravelRecordIdInAndSortOrder(travelRecordIds, 0).stream()
+                .collect(Collectors.toMap(
+                        RecordMedia::getTravelRecordId,
+                        media -> presignedUrlProvider.createPresignedGetUrl(
+                                media.getThumbnailObjectKey(),
+                                expiration
+                        ).toString()
+                ));
     }
 
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -4,8 +4,10 @@ import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.common.monitoring.MonitoredOperation;
 import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.ExpiringUrl;
 import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
+import com.mapmory.backend.recordmedia.RecordMediaUrlService;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.tag.Tag;
@@ -15,9 +17,6 @@ import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
-import com.mapmory.backend.upload.policy.UploadPolicyProperties;
-import com.mapmory.backend.upload.storage.PresignedUrlProvider;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,8 +42,7 @@ public class TravelRecordService {
     private final TravelRecordTagService travelRecordTagService;
     private final TagService tagService;
     private final OperationTimer operationTimer;
-    private final PresignedUrlProvider presignedUrlProvider;
-    private final UploadPolicyProperties uploadPolicyProperties;
+    private final RecordMediaUrlService recordMediaUrlService;
 
     public TravelRecordService(
             TravelRecordRepository travelRecordRepository,
@@ -53,8 +51,7 @@ public class TravelRecordService {
             TravelRecordTagService travelRecordTagService,
             TagService tagService,
             OperationTimer operationTimer,
-            PresignedUrlProvider presignedUrlProvider,
-            UploadPolicyProperties uploadPolicyProperties
+            RecordMediaUrlService recordMediaUrlService
     ) {
         this.travelRecordRepository = travelRecordRepository;
         this.regionResolver = regionResolver;
@@ -62,8 +59,7 @@ public class TravelRecordService {
         this.travelRecordTagService = travelRecordTagService;
         this.tagService = tagService;
         this.operationTimer = operationTimer;
-        this.presignedUrlProvider = presignedUrlProvider;
-        this.uploadPolicyProperties = uploadPolicyProperties;
+        this.recordMediaUrlService = recordMediaUrlService;
     }
 
     @Transactional
@@ -219,16 +215,12 @@ public class TravelRecordService {
                 .toList();
         Map<Long, List<Tag>> tagsByTravelRecordId =
                 travelRecordTagService.findByTravelRecordIds(travelRecordIds);
-        Duration expiration = uploadPolicyProperties.presignedUrlExpiration();
-        Map<Long, String> thumbnailUrlsByTravelRecordId = createThumbnailUrls(
-                travelRecordIds,
-                expiration
-        );
+        Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId =
+                recordMediaUrlService.createThumbnailUrls(travelRecordIds);
         return TravelRecordListResponse.from(
                 travelRecords,
                 tagsByTravelRecordId,
-                thumbnailUrlsByTravelRecordId,
-                expiration.toSeconds()
+                thumbnailUrlsByTravelRecordId
         );
     }
 
@@ -341,34 +333,14 @@ public class TravelRecordService {
             List<RecordMedia> recordMedia,
             List<Tag> tags
     ) {
-        Duration expiration = uploadPolicyProperties.presignedUrlExpiration();
         List<TravelRecordMediaResponse> media = recordMedia.stream()
                 .map(item -> TravelRecordMediaResponse.from(
                         item,
-                        presignedUrlProvider.createPresignedGetUrl(item.getObjectKey(), expiration),
-                        expiration
+                        recordMediaUrlService.createViewUrl(item.getObjectKey())
                 ))
                 .toList();
 
         return TravelRecordDetailResponse.from(travelRecord, recordMedia, tags, media);
-    }
-
-    private Map<Long, String> createThumbnailUrls(
-            List<Long> travelRecordIds,
-            Duration expiration
-    ) {
-        if (travelRecordIds.isEmpty()) {
-            return Map.of();
-        }
-
-        return recordMediaRepository.findByTravelRecordIdInAndSortOrder(travelRecordIds, 0).stream()
-                .collect(Collectors.toMap(
-                        RecordMedia::getTravelRecordId,
-                        media -> presignedUrlProvider.createPresignedGetUrl(
-                                media.getThumbnailObjectKey(),
-                                expiration
-                        ).toString()
-                ));
     }
 
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListItemResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListItemResponse.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.travelrecord.dto;
 
+import com.mapmory.backend.recordmedia.ExpiringUrl;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.TravelRecord;
@@ -19,8 +20,7 @@ public record TravelRecordListItemResponse(
     public static TravelRecordListItemResponse from(
             TravelRecord travelRecord,
             List<Tag> tags,
-            String thumbnailUrl,
-            Long thumbnailUrlExpiresIn
+            ExpiringUrl thumbnailUrl
     ) {
         return new TravelRecordListItemResponse(
                 travelRecord.getId(),
@@ -28,8 +28,8 @@ public record TravelRecordListItemResponse(
                 travelRecord.getRegion().getName(),
                 travelRecord.getStartDate(),
                 travelRecord.getEndDate(),
-                thumbnailUrl,
-                thumbnailUrlExpiresIn,
+                thumbnailUrl == null ? null : thumbnailUrl.url(),
+                thumbnailUrl == null ? null : thumbnailUrl.expiresIn(),
                 tags.stream().map(TagSummaryResponse::from).toList()
         );
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListItemResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListItemResponse.java
@@ -13,11 +13,14 @@ public record TravelRecordListItemResponse(
         LocalDate startDate,
         LocalDate endDate,
         String thumbnailUrl,
+        Long thumbnailUrlExpiresIn,
         List<TagSummaryResponse> tags
 ) {
     public static TravelRecordListItemResponse from(
             TravelRecord travelRecord,
-            List<Tag> tags
+            List<Tag> tags,
+            String thumbnailUrl,
+            Long thumbnailUrlExpiresIn
     ) {
         return new TravelRecordListItemResponse(
                 travelRecord.getId(),
@@ -25,7 +28,8 @@ public record TravelRecordListItemResponse(
                 travelRecord.getRegion().getName(),
                 travelRecord.getStartDate(),
                 travelRecord.getEndDate(),
-                null, // 다음 단계에서 첫 번째 미디어의 URL을 넣는다.
+                thumbnailUrl,
+                thumbnailUrlExpiresIn,
                 tags.stream().map(TagSummaryResponse::from).toList()
         );
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.travelrecord.dto;
 
+import com.mapmory.backend.recordmedia.ExpiringUrl;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.travelrecord.TravelRecord;
 import java.util.List;
@@ -17,18 +18,14 @@ public record TravelRecordListResponse(
     public static TravelRecordListResponse from(
             Page<TravelRecord> travelRecords,
             Map<Long, List<Tag>> tagsByTravelRecordId,
-            Map<Long, String> thumbnailUrlsByTravelRecordId,
-            long thumbnailUrlExpiresIn
+            Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId
     ) {
         return new TravelRecordListResponse(
                 travelRecords.getContent().stream()
                         .map(travelRecord -> TravelRecordListItemResponse.from(
                                 travelRecord,
                                 tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of()),
-                                thumbnailUrlsByTravelRecordId.get(travelRecord.getId()),
-                                thumbnailUrlsByTravelRecordId.containsKey(travelRecord.getId())
-                                        ? thumbnailUrlExpiresIn
-                                        : null
+                                thumbnailUrlsByTravelRecordId.get(travelRecord.getId())
                         ))
                         .toList(),
                 travelRecords.getNumber(),

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
@@ -16,13 +16,19 @@ public record TravelRecordListResponse(
 ) {
     public static TravelRecordListResponse from(
             Page<TravelRecord> travelRecords,
-            Map<Long, List<Tag>> tagsByTravelRecordId
+            Map<Long, List<Tag>> tagsByTravelRecordId,
+            Map<Long, String> thumbnailUrlsByTravelRecordId,
+            long thumbnailUrlExpiresIn
     ) {
         return new TravelRecordListResponse(
                 travelRecords.getContent().stream()
                         .map(travelRecord -> TravelRecordListItemResponse.from(
                                 travelRecord,
-                                tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of())
+                                tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of()),
+                                thumbnailUrlsByTravelRecordId.get(travelRecord.getId()),
+                                thumbnailUrlsByTravelRecordId.containsKey(travelRecord.getId())
+                                        ? thumbnailUrlExpiresIn
+                                        : null
                         ))
                         .toList(),
                 travelRecords.getNumber(),

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordMediaResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordMediaResponse.java
@@ -1,8 +1,7 @@
 package com.mapmory.backend.travelrecord.dto;
 
+import com.mapmory.backend.recordmedia.ExpiringUrl;
 import com.mapmory.backend.recordmedia.RecordMedia;
-import java.net.URI;
-import java.time.Duration;
 
 public record TravelRecordMediaResponse(
         Long id,
@@ -13,14 +12,13 @@ public record TravelRecordMediaResponse(
 ) {
     public static TravelRecordMediaResponse from(
             RecordMedia recordMedia,
-            URI viewUrl,
-            Duration expiration
+            ExpiringUrl viewUrl
     ) {
         return new TravelRecordMediaResponse(
                 recordMedia.getId(),
                 recordMedia.getObjectKey(),
-                viewUrl.toString(),
-                expiration.toSeconds(),
+                viewUrl.url(),
+                viewUrl.expiresIn(),
                 recordMedia.getSortOrder()
         );
     }

--- a/backend/src/test/java/com/mapmory/backend/recordmedia/RecordMediaTest.java
+++ b/backend/src/test/java/com/mapmory/backend/recordmedia/RecordMediaTest.java
@@ -1,0 +1,34 @@
+package com.mapmory.backend.recordmedia;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.mapmory.backend.travelrecord.TravelRecord;
+import org.junit.jupiter.api.Test;
+
+class RecordMediaTest {
+
+    @Test
+    void 썸네일_키가_있으면_썸네일_객체_키를_반환한다() {
+        RecordMedia media = RecordMedia.of(
+                mock(TravelRecord.class),
+                "mapmory/original.jpg",
+                "mapmory/thumbnail.jpg",
+                0
+        );
+
+        assertThat(media.getThumbnailObjectKey()).isEqualTo("mapmory/thumbnail.jpg");
+    }
+
+    @Test
+    void 썸네일_키가_없으면_원본_객체_키를_반환한다() {
+        RecordMedia media = RecordMedia.of(
+                mock(TravelRecord.class),
+                "mapmory/original.jpg",
+                null,
+                0
+        );
+
+        assertThat(media.getThumbnailObjectKey()).isEqualTo("mapmory/original.jpg");
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/recordmedia/RecordMediaUrlServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/recordmedia/RecordMediaUrlServiceTest.java
@@ -1,0 +1,126 @@
+package com.mapmory.backend.recordmedia;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.upload.policy.UploadPolicyProperties;
+import com.mapmory.backend.upload.storage.PresignedUrlProvider;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RecordMediaUrlServiceTest {
+
+    private final RecordMediaRepository recordMediaRepository = mock(RecordMediaRepository.class);
+    private final PresignedUrlProvider presignedUrlProvider = mock(PresignedUrlProvider.class);
+    private final UploadPolicyProperties uploadPolicyProperties = mock(UploadPolicyProperties.class);
+    private RecordMediaUrlService recordMediaUrlService;
+
+    @BeforeEach
+    void setUp() {
+        when(uploadPolicyProperties.presignedUrlExpiration()).thenReturn(Duration.ofMinutes(5));
+        recordMediaUrlService = new RecordMediaUrlService(
+                recordMediaRepository,
+                presignedUrlProvider,
+                uploadPolicyProperties
+        );
+    }
+
+    @Test
+    void 조회_URL과_만료_시간을_값_객체로_반환한다() {
+        when(presignedUrlProvider.createPresignedGetUrl("mapmory/original.jpg", Duration.ofMinutes(5)))
+                .thenReturn(URI.create("https://download.example/mapmory/original.jpg"));
+
+        ExpiringUrl result = recordMediaUrlService.createViewUrl("mapmory/original.jpg");
+
+        assertThat(result).isEqualTo(new ExpiringUrl(
+                "https://download.example/mapmory/original.jpg",
+                300L
+        ));
+    }
+
+    @Test
+    void 만료_URL은_빈_URL이나_유효하지_않은_만료_시간을_허용하지_않는다() {
+        assertThatThrownBy(() -> new ExpiringUrl(" ", 300L))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ExpiringUrl("https://download.example/file.jpg", 0L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 기록별_첫_미디어만_썸네일_URL로_변환한다() {
+        TravelRecord firstRecord = travelRecord(101L);
+        TravelRecord secondRecord = travelRecord(102L);
+        RecordMedia firstMedia = RecordMedia.of(
+                firstRecord,
+                "mapmory/first-original.jpg",
+                null,
+                0
+        );
+        RecordMedia laterMedia = RecordMedia.of(
+                firstRecord,
+                "mapmory/later.jpg",
+                null,
+                0
+        );
+        RecordMedia thumbnailMedia = RecordMedia.of(
+                secondRecord,
+                "mapmory/second-original.jpg",
+                "mapmory/second-thumbnail.jpg",
+                0
+        );
+        List<Long> travelRecordIds = List.of(101L, 102L);
+        when(recordMediaRepository.findByTravelRecordIdInOrderByTravelRecordIdAscSortOrderAscIdAsc(
+                travelRecordIds
+        )).thenReturn(List.of(firstMedia, laterMedia, thumbnailMedia));
+        when(presignedUrlProvider.createPresignedGetUrl(any(), any()))
+                .thenAnswer(invocation -> URI.create(
+                        "https://download.example/" + invocation.getArgument(0)
+                ));
+
+        Map<Long, ExpiringUrl> result = recordMediaUrlService.createThumbnailUrls(travelRecordIds);
+
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                101L,
+                new ExpiringUrl("https://download.example/mapmory/first-original.jpg", 300L),
+                102L,
+                new ExpiringUrl("https://download.example/mapmory/second-thumbnail.jpg", 300L)
+        ));
+        verify(presignedUrlProvider).createPresignedGetUrl(
+                "mapmory/first-original.jpg",
+                Duration.ofMinutes(5)
+        );
+        verify(presignedUrlProvider, never()).createPresignedGetUrl(
+                "mapmory/later.jpg",
+                Duration.ofMinutes(5)
+        );
+        verify(presignedUrlProvider).createPresignedGetUrl(
+                "mapmory/second-thumbnail.jpg",
+                Duration.ofMinutes(5)
+        );
+    }
+
+    @Test
+    void 기록_ID가_없으면_저장소를_조회하지_않는다() {
+        assertThat(recordMediaUrlService.createThumbnailUrls(List.of())).isEmpty();
+
+        verify(recordMediaRepository, never())
+                .findByTravelRecordIdInOrderByTravelRecordIdAscSortOrderAscIdAsc(any());
+        verify(presignedUrlProvider, never()).createPresignedGetUrl(any(), any());
+    }
+
+    private TravelRecord travelRecord(Long id) {
+        TravelRecord travelRecord = mock(TravelRecord.class);
+        when(travelRecord.getId()).thenReturn(id);
+        return travelRecord;
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -15,6 +15,8 @@ import com.mapmory.backend.travelrecord.dto.CreateTravelRecordResponse;
 import com.mapmory.backend.travelrecord.dto.RegionDetailResponse;
 import com.mapmory.backend.travelrecord.dto.RegionItemResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
+import com.mapmory.backend.travelrecord.dto.TravelRecordListItemResponse;
+import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecord.dto.TravelRecordResponse;
@@ -146,6 +148,35 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.data.media[0].viewUrl")
                         .value("https://download.example/mapmory/travel-records/a.jpg"))
                 .andExpect(jsonPath("$.data.media[0].viewUrlExpiresIn").value(300L));
+    }
+
+    @Test
+    void 여행_일지_목록에_썸네일_URL을_반환한다() throws Exception {
+        TravelRecordListResponse list = new TravelRecordListResponse(
+                List.of(new TravelRecordListItemResponse(
+                        101L,
+                        "제주 여행",
+                        "제주시",
+                        LocalDate.of(2026, 8, 11),
+                        LocalDate.of(2026, 8, 13),
+                        "https://download.example/mapmory/travel-records/a.jpg",
+                        300L,
+                        List.of()
+                )),
+                0,
+                20,
+                1,
+                1,
+                false
+        );
+        when(travelRecordService.findAll(MEMBER, null, null, null, null, 0, 20))
+                .thenReturn(list);
+
+        mockMvcWithLoginMember().perform(get("/api/v1/travel-records"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].thumbnailUrl")
+                        .value("https://download.example/mapmory/travel-records/a.jpg"))
+                .andExpect(jsonPath("$.data.items[0].thumbnailUrlExpiresIn").value(300L));
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
@@ -160,12 +160,11 @@ class TravelRecordRepositoryTest extends MySqlTestContainerSupport {
         assertThat(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(travelRecord.getId()))
                 .extracting(RecordMedia::getObjectKey)
                 .containsExactly("mapmory/detail/a.jpg", "mapmory/detail/b.jpg");
-        assertThat(recordMediaRepository.findByTravelRecordIdInAndSortOrder(
-                java.util.List.of(travelRecord.getId()),
-                0
+        assertThat(recordMediaRepository.findByTravelRecordIdInOrderByTravelRecordIdAscSortOrderAscIdAsc(
+                java.util.List.of(travelRecord.getId())
         ))
                 .extracting(RecordMedia::getObjectKey)
-                .containsExactly("mapmory/detail/a.jpg");
+                .containsExactly("mapmory/detail/a.jpg", "mapmory/detail/b.jpg");
         assertThat(recordMediaRepository.findByObjectKeyIn(
                 java.util.List.of("mapmory/detail/a.jpg")
         ))

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordRepositoryTest.java
@@ -160,6 +160,12 @@ class TravelRecordRepositoryTest extends MySqlTestContainerSupport {
         assertThat(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(travelRecord.getId()))
                 .extracting(RecordMedia::getObjectKey)
                 .containsExactly("mapmory/detail/a.jpg", "mapmory/detail/b.jpg");
+        assertThat(recordMediaRepository.findByTravelRecordIdInAndSortOrder(
+                java.util.List.of(travelRecord.getId()),
+                0
+        ))
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly("mapmory/detail/a.jpg");
         assertThat(recordMediaRepository.findByObjectKeyIn(
                 java.util.List.of("mapmory/detail/a.jpg")
         ))

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -380,16 +380,51 @@ class TravelRecordServiceTest {
         Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
         when(travelRecord.getRegion()).thenReturn(region);
+        RecordMedia thumbnail = RecordMedia.of(
+                travelRecord,
+                "mapmory/travel-records/a.jpg",
+                null,
+                0
+        );
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
+        when(recordMediaRepository.findByTravelRecordIdInAndSortOrder(List.of(101L), 0))
+                .thenReturn(List.of(thumbnail));
 
         TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
         assertThat(result.totalElements()).isEqualTo(1);
+        assertThat(result.items().getFirst().thumbnailUrl())
+                .isEqualTo("https://download.example/mapmory/travel-records/a.jpg");
+        assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isEqualTo(300L);
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
         verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(null), captor.capture());
         assertThat(captor.getValue().getPageSize()).isEqualTo(20);
+        verify(recordMediaRepository).findByTravelRecordIdInAndSortOrder(List.of(101L), 0);
+        verify(presignedUrlProvider).createPresignedGetUrl(
+                "mapmory/travel-records/a.jpg",
+                Duration.ofMinutes(5)
+        );
+    }
+
+    @Test
+    void 미디어가_없는_일지_목록은_썸네일_정보가_null이다() {
+        TravelRecord travelRecord = mock(TravelRecord.class);
+        Region region = mock(Region.class);
+        when(travelRecord.getId()).thenReturn(101L);
+        when(travelRecord.getRegion()).thenReturn(region);
+        Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
+        when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
+                .thenReturn(expected);
+        when(recordMediaRepository.findByTravelRecordIdInAndSortOrder(List.of(101L), 0))
+                .thenReturn(List.of());
+
+        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+
+        assertThat(result.items().getFirst().thumbnailUrl()).isNull();
+        assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isNull();
+        verify(presignedUrlProvider, never()).createPresignedGetUrl(anyString(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -16,8 +16,10 @@ import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.common.monitoring.MonitoredOperation;
 import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.ExpiringUrl;
 import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
+import com.mapmory.backend.recordmedia.RecordMediaUrlService;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.region.RegionType;
@@ -27,13 +29,10 @@ import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
-import com.mapmory.backend.upload.policy.UploadPolicyProperties;
-import com.mapmory.backend.upload.storage.PresignedUrlProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.net.URI;
-import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,10 +67,7 @@ class TravelRecordServiceTest {
     private TagService tagService;
 
     @Mock
-    private PresignedUrlProvider presignedUrlProvider;
-
-    @Mock
-    private UploadPolicyProperties uploadPolicyProperties;
+    private RecordMediaUrlService recordMediaUrlService;
 
     @Spy
     private OperationTimer operationTimer = new OperationTimer(new SimpleMeterRegistry());
@@ -85,9 +81,11 @@ class TravelRecordServiceTest {
     void setUp() {
         member = mock(Member.class);
         lenient().when(member.getId()).thenReturn(10L);
-        lenient().when(uploadPolicyProperties.presignedUrlExpiration()).thenReturn(Duration.ofMinutes(5));
-        lenient().when(presignedUrlProvider.createPresignedGetUrl(anyString(), any()))
-                .thenAnswer(invocation -> URI.create("https://download.example/" + invocation.getArgument(0)));
+        lenient().when(recordMediaUrlService.createViewUrl(anyString()))
+                .thenAnswer(invocation -> new ExpiringUrl(
+                        "https://download.example/" + invocation.getArgument(0),
+                        300L
+                ));
     }
 
     @Test
@@ -155,14 +153,8 @@ class TravelRecordServiceTest {
         assertThat(result.media())
                 .extracting(TravelRecordMediaResponse::sortOrder)
                 .containsExactly(0, 1);
-        verify(presignedUrlProvider).createPresignedGetUrl(
-                "mapmory/travel-records/a.jpg",
-                Duration.ofMinutes(5)
-        );
-        verify(presignedUrlProvider).createPresignedGetUrl(
-                "mapmory/travel-records/b.jpg",
-                Duration.ofMinutes(5)
-        );
+        verify(recordMediaUrlService).createViewUrl("mapmory/travel-records/a.jpg");
+        verify(recordMediaUrlService).createViewUrl("mapmory/travel-records/b.jpg");
     }
 
     @Test
@@ -189,7 +181,7 @@ class TravelRecordServiceTest {
         assertThat(result.region().district()).isNull();
         assertThat(result.objectKeys()).isEmpty();
         assertThat(result.media()).isEmpty();
-        verify(presignedUrlProvider, never()).createPresignedGetUrl(anyString(), any());
+        verify(recordMediaUrlService, never()).createViewUrl(anyString());
     }
 
     @Test
@@ -380,17 +372,17 @@ class TravelRecordServiceTest {
         Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
         when(travelRecord.getRegion()).thenReturn(region);
-        RecordMedia thumbnail = RecordMedia.of(
-                travelRecord,
-                "mapmory/travel-records/a.jpg",
-                null,
-                0
-        );
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
-        when(recordMediaRepository.findByTravelRecordIdInAndSortOrder(List.of(101L), 0))
-                .thenReturn(List.of(thumbnail));
+        when(recordMediaUrlService.createThumbnailUrls(List.of(101L)))
+                .thenReturn(Map.of(
+                        101L,
+                        new ExpiringUrl(
+                                "https://download.example/mapmory/travel-records/a.jpg",
+                                300L
+                        )
+                ));
 
         TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
@@ -401,11 +393,7 @@ class TravelRecordServiceTest {
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
         verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(null), captor.capture());
         assertThat(captor.getValue().getPageSize()).isEqualTo(20);
-        verify(recordMediaRepository).findByTravelRecordIdInAndSortOrder(List.of(101L), 0);
-        verify(presignedUrlProvider).createPresignedGetUrl(
-                "mapmory/travel-records/a.jpg",
-                Duration.ofMinutes(5)
-        );
+        verify(recordMediaUrlService).createThumbnailUrls(List.of(101L));
     }
 
     @Test
@@ -417,14 +405,13 @@ class TravelRecordServiceTest {
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
-        when(recordMediaRepository.findByTravelRecordIdInAndSortOrder(List.of(101L), 0))
-                .thenReturn(List.of());
+        when(recordMediaUrlService.createThumbnailUrls(List.of(101L))).thenReturn(Map.of());
 
         TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
         assertThat(result.items().getFirst().thumbnailUrl()).isNull();
         assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isNull();
-        verify(presignedUrlProvider, never()).createPresignedGetUrl(anyString(), any());
+        verify(recordMediaUrlService).createThumbnailUrls(List.of(101L));
     }
 
     @Test


### PR DESCRIPTION
## 요약

- 여행 기록 목록 응답에 대표 미디어의 `thumbnailUrl`과 `thumbnailUrlExpiresIn`을 추가합니다.
- 기록 상세 미디어와 목록 썸네일 URL 발급을 `RecordMediaUrlService`로 통합합니다.
- 썸네일 객체가 없으면 원본 객체의 Presigned GET URL을 반환합니다.

## 배경

여행 기록 목록에서 이미지를 표시하려면 클라이언트가 사용할 수 있는 썸네일 URL이 필요했습니다. URL 발급 로직이 여행 기록 서비스에 직접 섞이지 않도록 미디어 URL 책임을 별도 서비스와 값 객체로 분리했습니다.

## 주요 결정

- 현재 페이지의 기록 ID로 미디어를 한 번에 조회해 N+1 조회를 방지합니다.
- `sortOrder`, 미디어 ID 순으로 정렬한 뒤 기록별 첫 미디어를 선택해 중복 정렬값에도 결정적으로 동작합니다.
- `ExpiringUrl` 값 객체로 URL과 만료 시간을 함께 전달하고 빈 URL 및 0 이하 만료 시간을 허용하지 않습니다.
- `thumbKey`가 없거나 비어 있으면 원본 `objectKey`를 사용합니다.

## 한계

- 저장소 통합 테스트는 로컬 Docker/Testcontainers 초기화 실패로 실행되지 못했습니다. 관련 Java 컴파일과 Docker 비의존 테스트는 통과했습니다.

## 확인

- [x] 관련 서비스·컨트롤러·미디어 테스트 통과
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 새 환경변수 없음
- [x] DB 스키마 변경 없음
- [x] 실행 방법이나 환경 설정 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Travel record lists now include thumbnail URLs and their expiration times.
  * Thumbnails use dedicated images when available, with fallback to the original media.
  * Media view URLs now include expiration information.
  * Records without media return empty thumbnail fields.

* **Documentation**
  * Updated API documentation to describe thumbnail URL generation and response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->