### PR TITLE
feat(upload): 기록 저장 전 S3 객체 실존 검증

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
+++ b/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
@@ -1,6 +1,7 @@
 package com.mapmory.backend.common.monitoring;
 
 public enum MonitoredOperation {
+    MEDIA_EXISTENCE_CHECK,
     MEDIA_SYNC,
     MAP_SUMMARY_QUERY
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -14,6 +14,7 @@ import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
+import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ public class TravelRecordService {
     private final TagService tagService;
     private final OperationTimer operationTimer;
     private final Clock clock;
+    private final UploadedObjectVerifier uploadedObjectVerifier;
 
     public TravelRecordService(
             TravelRecordRepository travelRecordRepository,
@@ -51,7 +53,8 @@ public class TravelRecordService {
             TravelRecordTagService travelRecordTagService,
             TagService tagService,
             OperationTimer operationTimer,
-            Clock clock
+            Clock clock,
+            UploadedObjectVerifier uploadedObjectVerifier
     ) {
         this.travelRecordRepository = travelRecordRepository;
         this.regionResolver = regionResolver;
@@ -60,12 +63,15 @@ public class TravelRecordService {
         this.tagService = tagService;
         this.operationTimer = operationTimer;
         this.clock = clock;
+        this.uploadedObjectVerifier = uploadedObjectVerifier;
     }
 
     @Transactional
     public TravelRecord create(Member member, TravelRecordRequest request) {
         validateTravelDates(request.startDate(), request.endDate());
         validateTravelRecordRegion(request);
+        List<String> objectKeys = objectKeys(request);
+        uploadedObjectVerifier.verifyAllUploaded(objectKeys);
         Region region = resolveRegion(request);
 
         TravelRecord travelRecord = TravelRecord.of(
@@ -79,8 +85,6 @@ public class TravelRecordService {
 
         TravelRecord savedTravelRecord = travelRecordRepository.save(travelRecord);
         travelRecordTagService.replace(member, savedTravelRecord, request.tagIds());
-
-        List<String> objectKeys = request.objectKeys() == null ? List.of() : request.objectKeys();
 
         // TODO : save or saveAll 결정하고 적용하기
         for (int index = 0; index < objectKeys.size(); index++) {
@@ -121,13 +125,15 @@ public class TravelRecordService {
         validateTravelRecordRegion(request);
         TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
-        List<String> objectKeys = request.objectKeys() == null ? List.of() : request.objectKeys();
+        List<String> objectKeys = objectKeys(request);
         validateUniqueObjectKeys(objectKeys);
 
         Region region = resolveRegion(request);
         List<RecordMedia> existingMedia = recordMediaRepository
                 .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
-        validateObjectKeysAreAvailable(objectKeys, existingMedia);
+        List<String> newObjectKeys = newObjectKeys(objectKeys, existingMedia);
+        validateObjectKeysAreAvailable(newObjectKeys);
+        uploadedObjectVerifier.verifyAllUploaded(newObjectKeys);
 
         travelRecord.update(
                 region,
@@ -308,17 +314,23 @@ public class TravelRecordService {
         }
     }
 
-    private void validateObjectKeysAreAvailable(
+    private static List<String> objectKeys(TravelRecordRequest request) {
+        return request.objectKeys() == null ? List.of() : request.objectKeys();
+    }
+
+    private static List<String> newObjectKeys(
             List<String> objectKeys,
             List<RecordMedia> existingMedia
     ) {
         Set<String> existingObjectKeys = existingMedia.stream()
                 .map(RecordMedia::getObjectKey)
                 .collect(Collectors.toSet());
-        List<String> newObjectKeys = objectKeys.stream()
+        return objectKeys.stream()
                 .filter(objectKey -> !existingObjectKeys.contains(objectKey))
                 .toList();
+    }
 
+    private void validateObjectKeysAreAvailable(List<String> newObjectKeys) {
         if (!newObjectKeys.isEmpty()
                 && !recordMediaRepository.findByObjectKeyIn(newObjectKeys).isEmpty()) {
             throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);

--- a/backend/src/main/java/com/mapmory/backend/upload/UploadErrorCode.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/UploadErrorCode.java
@@ -6,29 +6,44 @@ import com.mapmory.backend.common.exception.ErrorKind;
 public enum UploadErrorCode implements ErrorCode {
 
     INVALID_FILE_TYPE(
+            ErrorKind.INVALID_INPUT,
             "허용되지 않은 파일 형식입니다.",
             "jpeg, png, webp, heic 형식의 이미지만 업로드할 수 있습니다."
     ),
     FILE_SIZE_EXCEEDED(
+            ErrorKind.INVALID_INPUT,
             "파일 크기가 너무 큽니다.",
             "파일 크기가 업로드 가능한 최대 크기를 초과했습니다."
     ),
     TOO_MANY_FILES(
+            ErrorKind.INVALID_INPUT,
             "파일 개수가 너무 많습니다.",
             "한 번에 업로드할 수 있는 최대 파일 개수를 초과했습니다."
+    ),
+    MEDIA_NOT_UPLOADED(
+            ErrorKind.INVALID_INPUT,
+            "업로드되지 않은 이미지입니다.",
+            "첨부한 이미지 중 업로드가 완료되지 않은 항목이 있습니다. 다시 업로드한 뒤 저장해 주세요."
+    ),
+    STORAGE_UNAVAILABLE(
+            ErrorKind.SERVICE_UNAVAILABLE,
+            "이미지 저장소를 확인할 수 없습니다.",
+            "이미지 저장소가 응답하지 않아 처리하지 못했습니다. 잠시 후 다시 시도해 주세요."
     );
 
+    private final ErrorKind kind;
     private final String title;
     private final String detail;
 
-    UploadErrorCode(String title, String detail) {
+    UploadErrorCode(ErrorKind kind, String title, String detail) {
+        this.kind = kind;
         this.title = title;
         this.detail = detail;
     }
 
     @Override
     public ErrorKind kind() {
-        return ErrorKind.INVALID_INPUT;
+        return kind;
     }
 
     @Override

--- a/backend/src/main/java/com/mapmory/backend/upload/service/UploadedObjectVerifier.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/service/UploadedObjectVerifier.java
@@ -1,0 +1,39 @@
+package com.mapmory.backend.upload.service;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.common.monitoring.MonitoredOperation;
+import com.mapmory.backend.common.monitoring.OperationTimer;
+import com.mapmory.backend.upload.UploadErrorCode;
+import com.mapmory.backend.upload.storage.UploadedObjectChecker;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UploadedObjectVerifier {
+
+    private final UploadedObjectChecker uploadedObjectChecker;
+    private final OperationTimer operationTimer;
+
+    public UploadedObjectVerifier(
+            UploadedObjectChecker uploadedObjectChecker,
+            OperationTimer operationTimer
+    ) {
+        this.uploadedObjectChecker = uploadedObjectChecker;
+        this.operationTimer = operationTimer;
+    }
+
+    public void verifyAllUploaded(List<String> objectKeys) {
+        if (objectKeys.isEmpty()) {
+            return;
+        }
+
+        operationTimer.record(MonitoredOperation.MEDIA_EXISTENCE_CHECK, () -> {
+            for (String objectKey : objectKeys) {
+                if (!uploadedObjectChecker.exists(objectKey)) {
+                    throw new BusinessException(UploadErrorCode.MEDIA_NOT_UPLOADED);
+                }
+            }
+            return null;
+        });
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/upload/storage/S3StorageConfig.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/storage/S3StorageConfig.java
@@ -4,11 +4,19 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @EnableConfigurationProperties(S3StorageProperties.class)
 public class S3StorageConfig {
+
+    @Bean
+    public S3Client s3Client(S3StorageProperties properties) {
+        return S3Client.builder()
+                .region(Region.of(properties.region()))
+                .build();
+    }
 
     @Bean
     public S3Presigner s3Presigner(S3StorageProperties properties) {

--- a/backend/src/main/java/com/mapmory/backend/upload/storage/S3UploadedObjectChecker.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/storage/S3UploadedObjectChecker.java
@@ -1,0 +1,53 @@
+package com.mapmory.backend.upload.storage;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.upload.UploadErrorCode;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+@Component
+public class S3UploadedObjectChecker implements UploadedObjectChecker {
+
+    private static final int NOT_FOUND = 404;
+
+    private final S3Client s3Client;
+    private final String bucket;
+
+    public S3UploadedObjectChecker(S3Client s3Client, S3StorageProperties properties) {
+        this.s3Client = s3Client;
+        this.bucket = properties.bucket();
+    }
+
+    @Override
+    public boolean exists(String objectKey) {
+        HeadObjectRequest request = HeadObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .build();
+        try {
+            s3Client.headObject(request);
+            return true;
+        } catch (NoSuchKeyException exception) {
+            return false;
+        } catch (S3Exception exception) {
+            if (exception.statusCode() == NOT_FOUND) {
+                return false;
+            }
+            throw storageUnavailable(exception);
+        } catch (SdkException exception) {
+            throw storageUnavailable(exception);
+        }
+    }
+
+    private BusinessException storageUnavailable(SdkException cause) {
+        return new BusinessException(
+                UploadErrorCode.STORAGE_UNAVAILABLE,
+                UploadErrorCode.STORAGE_UNAVAILABLE.detail(),
+                cause
+        );
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/upload/storage/UploadedObjectChecker.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/storage/UploadedObjectChecker.java
@@ -1,0 +1,11 @@
+package com.mapmory.backend.upload.storage;
+
+/**
+ * 업로드 저장소에 객체가 존재하는지 확인하는 포트.
+ *
+ * 저장소 확인 자체가 실패한 경우에는 객체가 없는 경우와 구분해 예외를 던진다.
+ */
+public interface UploadedObjectChecker {
+
+    boolean exists(String objectKey);
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -25,6 +25,7 @@ import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
+import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.LocalDate;
@@ -69,6 +70,8 @@ class TravelRecordServiceTest {
     @Mock
     private TagService tagService;
 
+    @Mock
+    private UploadedObjectVerifier uploadedObjectVerifier;
     @Spy
     private OperationTimer operationTimer = new OperationTimer(new SimpleMeterRegistry());
 
@@ -87,7 +90,8 @@ class TravelRecordServiceTest {
                 travelRecordTagService,
                 tagService,
                 operationTimer,
-                FIXED_CLOCK
+                FIXED_CLOCK,
+                uploadedObjectVerifier
         );
     }
 

--- a/backend/src/test/java/com/mapmory/backend/upload/UploadedObjectVerificationAcceptanceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/UploadedObjectVerificationAcceptanceTest.java
@@ -1,0 +1,156 @@
+package com.mapmory.backend.upload;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import com.mapmory.backend.IntegrationTest;
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.upload.storage.UploadedObjectChecker;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@AutoConfigureMockMvc
+class UploadedObjectVerificationAcceptanceTest extends IntegrationTest {
+
+    private static final String UPLOADED_KEY = "mapmory/travel-records/1/uploaded.jpg";
+    private static final String ANOTHER_UPLOADED_KEY = "mapmory/travel-records/1/uploaded-2.jpg";
+    private static final String MISSING_KEY = "mapmory/travel-records/1/missing.jpg";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UploadedObjectChecker uploadedObjectChecker;
+
+    @BeforeEach
+    void setUp() {
+        given(uploadedObjectChecker.exists(anyString())).willReturn(true);
+        given(uploadedObjectChecker.exists(MISSING_KEY)).willReturn(false);
+    }
+
+    @Test
+    void 업로드된_사진은_기록에_붙는다() throws Exception {
+        String accessToken = guestAccessToken();
+
+        mockMvc.perform(post("/api/v1/travel-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(recordBody(UPLOADED_KEY)))
+                .andExpect(status().isCreated());
+
+        verify(uploadedObjectChecker).exists(UPLOADED_KEY);
+    }
+
+    @Test
+    void 올라오지_않은_사진을_붙이려_하면_기록_전체가_저장되지_않는다() throws Exception {
+        String accessToken = guestAccessToken();
+
+        mockMvc.perform(post("/api/v1/travel-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(recordBody(UPLOADED_KEY, MISSING_KEY)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("MEDIA_NOT_UPLOADED"));
+
+        mockMvc.perform(get("/api/v1/travel-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items.length()").value(0));
+    }
+
+    @Test
+    void 사진이_없는_기록은_저장소를_확인하지_않고_저장된다() throws Exception {
+        String accessToken = guestAccessToken();
+
+        mockMvc.perform(post("/api/v1/travel-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(recordBody()))
+                .andExpect(status().isCreated());
+
+        verify(uploadedObjectChecker, never()).exists(anyString());
+    }
+
+    @Test
+    void 수정에서는_새로_추가한_사진만_확인한다() throws Exception {
+        String accessToken = guestAccessToken();
+        long recordId = createRecord(accessToken, UPLOADED_KEY);
+        clearInvocations(uploadedObjectChecker);
+
+        mockMvc.perform(put("/api/v1/travel-records/" + recordId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(recordBody(UPLOADED_KEY, ANOTHER_UPLOADED_KEY)))
+                .andExpect(status().isOk());
+
+        verify(uploadedObjectChecker).exists(ANOTHER_UPLOADED_KEY);
+        verify(uploadedObjectChecker, never()).exists(eq(UPLOADED_KEY));
+    }
+
+    @Test
+    void 저장소를_확인할_수_없으면_재시도할_수_있도록_503을_응답한다() throws Exception {
+        String accessToken = guestAccessToken();
+        willThrow(new BusinessException(UploadErrorCode.STORAGE_UNAVAILABLE))
+                .given(uploadedObjectChecker).exists(UPLOADED_KEY);
+
+        mockMvc.perform(post("/api/v1/travel-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(recordBody(UPLOADED_KEY)))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.code").value("STORAGE_UNAVAILABLE"));
+    }
+
+    private long createRecord(String accessToken, String... objectKeys) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/travel-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(recordBody(objectKeys)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Integer id = JsonPath.read(result.getResponse().getContentAsString(), "$.data.id");
+        return id.longValue();
+    }
+
+    private String recordBody(String... objectKeys) {
+        String keys = Arrays.stream(objectKeys)
+                .map("\"%s\""::formatted)
+                .collect(Collectors.joining(", "));
+        return """
+                {
+                  "countryCode": "JP",
+                  "title": "도쿄 여행",
+                  "content": "기록 본문",
+                  "startDate": "2026-08-01",
+                  "objectKeys": [%s]
+                }
+                """.formatted(keys);
+    }
+
+    private String guestAccessToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login/guest"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.accessToken");
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/upload/service/UploadedObjectVerifierTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/service/UploadedObjectVerifierTest.java
@@ -1,0 +1,57 @@
+package com.mapmory.backend.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.common.monitoring.OperationTimer;
+import com.mapmory.backend.upload.UploadErrorCode;
+import com.mapmory.backend.upload.storage.UploadedObjectChecker;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class UploadedObjectVerifierTest {
+
+    private final UploadedObjectChecker uploadedObjectChecker = mock(UploadedObjectChecker.class);
+    private final UploadedObjectVerifier verifier = new UploadedObjectVerifier(
+            uploadedObjectChecker,
+            new OperationTimer(new SimpleMeterRegistry())
+    );
+
+    @Test
+    void 모든_객체가_있으면_순서대로_확인한다() {
+        when(uploadedObjectChecker.exists("a.jpg")).thenReturn(true);
+        when(uploadedObjectChecker.exists("b.jpg")).thenReturn(true);
+
+        verifier.verifyAllUploaded(List.of("a.jpg", "b.jpg"));
+
+        InOrder order = inOrder(uploadedObjectChecker);
+        order.verify(uploadedObjectChecker).exists("a.jpg");
+        order.verify(uploadedObjectChecker).exists("b.jpg");
+    }
+
+    @Test
+    void 하나라도_없으면_나머지를_확인하지_않고_거절한다() {
+        when(uploadedObjectChecker.exists("a.jpg")).thenReturn(true);
+        when(uploadedObjectChecker.exists("missing.jpg")).thenReturn(false);
+
+        assertThatThrownBy(() -> verifier.verifyAllUploaded(List.of("a.jpg", "missing.jpg", "c.jpg")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode())
+                .isEqualTo(UploadErrorCode.MEDIA_NOT_UPLOADED);
+        verify(uploadedObjectChecker, never()).exists("c.jpg");
+    }
+
+    @Test
+    void 객체가_없으면_저장소를_호출하지_않는다() {
+        verifier.verifyAllUploaded(List.of());
+
+        verify(uploadedObjectChecker, never()).exists(org.mockito.ArgumentMatchers.anyString());
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/upload/storage/S3UploadedObjectCheckerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/storage/S3UploadedObjectCheckerTest.java
@@ -1,0 +1,96 @@
+package com.mapmory.backend.upload.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.upload.UploadErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+class S3UploadedObjectCheckerTest {
+
+    private final S3Client s3Client = mock(S3Client.class);
+    private S3UploadedObjectChecker checker;
+
+    @BeforeEach
+    void setUp() {
+        checker = new S3UploadedObjectChecker(
+                s3Client,
+                new S3StorageProperties("techcourse-project-2026", "ap-northeast-2", "mapmory")
+        );
+    }
+
+    @Test
+    void 설정된_버킷과_요청받은_키로_객체를_확인한다() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenReturn(HeadObjectResponse.builder().build());
+
+        assertThat(checker.exists("mapmory/travel-records/1/image.jpg")).isTrue();
+
+        ArgumentCaptor<HeadObjectRequest> request = ArgumentCaptor.forClass(HeadObjectRequest.class);
+        verify(s3Client).headObject(request.capture());
+        assertThat(request.getValue().bucket()).isEqualTo("techcourse-project-2026");
+        assertThat(request.getValue().key()).isEqualTo("mapmory/travel-records/1/image.jpg");
+    }
+
+    @Test
+    void 객체가_없으면_false를_반환한다() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(NoSuchKeyException.builder().message("not found").build());
+
+        assertThat(checker.exists("missing-key")).isFalse();
+    }
+
+    @Test
+    void 상태_코드만_담긴_404도_객체_없음으로_판단한다() {
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenThrow(s3Exception(404));
+
+        assertThat(checker.exists("missing-key")).isFalse();
+    }
+
+    @Test
+    void 권한이나_S3_장애는_객체_없음과_구분한다() {
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenThrow(s3Exception(403));
+
+        assertStorageUnavailable(() -> checker.exists("object-key"));
+    }
+
+    @Test
+    void 네트워크_오류는_저장소_장애로_알린다() {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(SdkClientException.create("connection reset"));
+
+        assertStorageUnavailable(() -> checker.exists("object-key"));
+    }
+
+    private static void assertStorageUnavailable(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode())
+                .isEqualTo(UploadErrorCode.STORAGE_UNAVAILABLE);
+    }
+
+    private static S3Exception s3Exception(int statusCode) {
+        return (S3Exception) S3Exception.builder()
+                .message("s3 failure")
+                .statusCode(statusCode)
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .sdkHttpResponse(SdkHttpResponse.builder().statusCode(statusCode).build())
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
## 요약

기록 생성·수정 시 첨부하려는 S3 객체가 실제로 존재하는지 `HeadObject`로 확인합니다.
하나라도 존재하지 않으면 기록 전체를 저장하지 않으며, 수정에서는 새롭게 추가된 객체만 검증합니다.

Closes #168

## 선행 PR

- #183이 `develop`에 먼저 병합되어야 합니다.
- 현재 `develop`에 아직 `main` 변경이 동기화되지 않아 그전까지는 이 PR의 변경 파일이 크게 보입니다.
- #183 병합 후에는 이 PR에서 추가한 S3 객체 검증 변경만 남습니다.

## 배경

이미지는 앱이 Presigned URL로 S3에 직접 업로드하고, 서버는 기록 저장 요청의 `objectKeys`만 받습니다.
기존에는 업로드가 실패해도 서버가 이를 알 수 없어 DB에는 키가 있지만 S3에는 객체가 없는 영구적인 깨진 이미지가 만들어질 수 있었습니다.

## 주요 결정

### 기록 저장 시점에 동기 검증

- 생성에서는 모든 `objectKey`를 확인합니다.
- 수정에서는 기존에 연결된 키를 제외하고 새로 추가된 키만 확인합니다.
- 이미지가 없으면 `400 MEDIA_NOT_UPLOADED`를 반환합니다.
- 권한·네트워크·S3 장애는 객체 없음과 구분해 `503 STORAGE_UNAVAILABLE`을 반환합니다.

### S3 의존성을 인터페이스 뒤로 분리

| 구성 요소 | 역할 |
| --- | --- |
| `UploadedObjectChecker` | 객체 존재 확인 포트 |
| `S3UploadedObjectChecker` | S3 `HeadObject` 구현 |
| `UploadedObjectVerifier` | 전체 객체 검증 및 실패 처리 |

기록 서비스는 AWS SDK와 버킷 정보를 직접 알지 않고, 테스트에서는 저장소 포트를 대역으로 교체합니다.

### 순차 호출과 계측

현재 최대 이미지 수가 작으므로 순차 호출로 시작합니다. `MEDIA_EXISTENCE_CHECK` 작업의 성공·실패와 실행 시간을 기존 `OperationTimer`로 측정하며, 지연이 문제가 될 때 병렬화를 검토합니다.

### IAM 사전 확인

운영 EC2에서 다음을 직접 확인했습니다.

- 존재하지 않는 키의 `HeadObject`가 `404` 반환
- `mapmory/travel-records/` 목록 조회 성공

따라서 객체 존재 여부를 404와 권한 오류로 구분할 수 있습니다. 신규 환경변수나 액세스 키는 추가하지 않고, EC2의 `ec2-project` 역할을 사용합니다.

## 테스트

ATDD 방식으로 인수 테스트가 실패하는 것을 먼저 확인한 뒤 구현했습니다.

- 업로드된 사진을 기록에 연결
- 누락된 사진이 하나라도 있으면 전체 저장 거절
- 사진 없는 기록은 S3를 호출하지 않음
- 수정에서는 새로 추가된 사진만 확인
- 저장소 장애는 503으로 응답
- S3 어댑터의 성공, 404, 403, 네트워크 오류 단위 테스트

```text
./gradlew test --no-daemon
BUILD SUCCESSFUL
```

## 한계

- 기록 저장 가용성이 S3 가용성에 영향을 받습니다.
- 객체의 존재만 확인하며 해당 회원이 업로드한 객체인지에 대한 소유권 검증은 범위 밖입니다.
- 업로드됐지만 기록에 연결되지 않은 고아 객체 정리는 #162에서 다룹니다.
- 기존 객체가 나중에 외부에서 삭제되는 경우까지 지속적으로 감시하지는 않습니다.

## 확인

- [x] 로컬 전체 백엔드 테스트 통과
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 신규 환경변수 없음
- [x] DB 스키마 변경 없음
- [x] 실행 방법 변경 없음
