### PR TITLE
fix: 사진 추천 지역 경계 조회 오류 수정

### DIFF
--- a/client/docs/map-data.md
+++ b/client/docs/map-data.md
@@ -56,6 +56,6 @@ python3 tools/map/generate_korea_map.py \
   --resource-output shared/src/commonMain/composeResources/files
 ```
 
-현재 생성 결과는 17개 시·도, 225개 표시 경계입니다. 2018년 원본에만 존재하는 인천의 과거 구역 4개는 현재 앱의 canonical `Location`과 대응하지 않아 생성에서 제외했습니다. 행정구역 데이터가 갱신되면 새 원본과 `KoreanDistrictCode.kt`를 함께 검토한 뒤 생성해야 합니다.
+현재 생성 결과는 17개 시·도, 225개 표시 경계입니다. 2018년 원본에만 존재하는 인천의 과거 구역은 현재 앱의 canonical `Location`과 대응하지 않아 생성에서 제외했습니다. 그 결과 2026년 기준 제물포구(`28125`), 영종구(`28155`), 미추홀구(`28177`), 서해구(`28275`), 검단구(`28290`)는 선택 가능한 지역이지만 번들 경계가 없습니다. 이 지역은 다른 구나 인천 전체 경계로 대체하지 않고 명시적인 경계 조회 실패로 처리합니다. 행정구역 데이터가 갱신되면 새 원본과 `KoreanDistrictCode.kt`를 함께 검토한 뒤 생성해야 합니다.
 
 경계 원본의 이용 조건과 출처 표기는 [원본 저장소 안내](https://github.com/southkorea/southkorea-maps)를 따릅니다. 경계 데이터는 앱 기능을 위한 정적 리소스이고 여행 기록·Location ID 같은 비즈니스 데이터의 소유자가 아닙니다.

--- a/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionDeviceTest.kt
+++ b/client/shared/src/androidDeviceTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionDeviceTest.kt
@@ -4,6 +4,7 @@ import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
 
 class PhotoRecommendationRegionDeviceTest {
@@ -18,7 +19,20 @@ class PhotoRecommendationRegionDeviceTest {
             type = LocationType.DISTRICT,
         )
 
-        assertEquals("11680", gangnam.photoRecommendationRegion()?.code)
+        assertEquals("11680", gangnam.photoRecommendationRegion().code)
+    }
+
+    @Test
+    fun `제주와_세종은_명시된_상위_시도_경계를_조회한다`() = runBlocking {
+        val locations = listOf(
+            Location(50110L, 1L, 19L, "50110", "제주시", LocationType.DISTRICT),
+            Location(50130L, 1L, 19L, "50130", "서귀포시", LocationType.DISTRICT),
+            Location(36110L, 1L, 10L, "36110", "세종시", LocationType.DISTRICT),
+        )
+
+        locations.forEach { location ->
+            assertEquals(location.regionCode, location.photoRecommendationRegion().code)
+        }
     }
 
     @Test
@@ -32,6 +46,9 @@ class PhotoRecommendationRegionDeviceTest {
             type = LocationType.DISTRICT,
         )
 
-        assertEquals(null, unknownDistrict.photoRecommendationRegion())
+        assertFailsWith<PhotoRecommendationRegionNotFoundException> {
+            unknownDistrict.photoRecommendationRegion()
+        }
+        Unit
     }
 }

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
@@ -36,6 +36,7 @@ import java.nio.ByteBuffer
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -61,16 +62,18 @@ actual fun rememberPhotoLibraryActions(
         latestLoadingChanged(true)
         scope.launch {
             try {
-                val result = withContext(Dispatchers.IO) {
-                    runCatching {
-                        context.recommendPhotos(target, parentName) { progress ->
-                            latestLoadingProgressChanged(progress)
-                        }
+                val photos = withContext(Dispatchers.IO) {
+                    context.recommendPhotos(target, parentName) { progress ->
+                        latestLoadingProgressChanged(progress)
                     }
                 }
-                result.onSuccess(latestRecommended).onFailure {
-                    latestMessage("사진 추천을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.")
-                }
+                latestRecommended(photos)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: PhotoRecommendationRegionNotFoundException) {
+                latestMessage(PhotoRecommendationRegionNotFoundMessage)
+            } catch (error: Exception) {
+                latestMessage("사진 추천을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.")
             } finally {
                 latestLoadingChanged(false)
             }
@@ -218,7 +221,7 @@ private suspend fun Context.recommendPhotos(
             cookie = TraceCookie.BoundaryLoad,
         ) {
             target.photoRecommendationRegion()
-        } ?: return emptyList()
+        }
         val boundaryLoadMillis = SystemClock.elapsedRealtime() - boundaryStartedAt
         val syncStartedAt = SystemClock.elapsedRealtime()
         val syncResult = syncPhotoMetadata(onProgress)
@@ -399,7 +402,7 @@ internal fun Context.readPhoto(
     knownName: String? = null,
     knownCoordinates: Pair<Double, Double>? = null,
     knownCapturedAtMillis: Long? = null,
-): SelectedPhoto? = runCatching {
+): SelectedPhoto? = try {
     val metadata = traceSection("photo.read.metadata") {
         if (knownName == null && knownCapturedAtMillis == null) {
             queryPhotoMetadata(uri)
@@ -428,15 +431,23 @@ internal fun Context.readPhoto(
         capturedAt = formatDate(knownCapturedAtMillis ?: metadata.second),
         originalBytes = encodedBytes,
     )
-}.getOrNull()
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Exception) {
+    null
+}
 
 private fun ByteArray.normalizeOrientation(): ByteArray {
-    val orientation = runCatching {
+    val orientation = try {
         ExifInterface(ByteArrayInputStream(this)).getAttributeInt(
             ExifInterface.TAG_ORIENTATION,
             ExifInterface.ORIENTATION_NORMAL,
         )
-    }.getOrDefault(ExifInterface.ORIENTATION_NORMAL)
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Exception) {
+        ExifInterface.ORIENTATION_NORMAL
+    }
     if (orientation == ExifInterface.ORIENTATION_NORMAL ||
         orientation == ExifInterface.ORIENTATION_UNDEFINED
     ) {
@@ -571,7 +582,7 @@ private fun Context.queryPhotoMetadata(uri: Uri): Pair<String?, Long?> {
     } ?: (null to null)
 }
 
-internal fun Context.readCoordinates(uri: Uri): Pair<Double, Double>? = runCatching {
+internal fun Context.readCoordinates(uri: Uri): Pair<Double, Double>? = try {
     val metadataUri = if (
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
         ContextCompat.checkSelfPermission(
@@ -586,7 +597,11 @@ internal fun Context.readCoordinates(uri: Uri): Pair<Double, Double>? = runCatch
     contentResolver.openInputStream(metadataUri)?.use { input ->
         ExifInterface(input).latLong?.let { it[0] to it[1] }
     }
-}.getOrNull()
+} catch (error: CancellationException) {
+    throw error
+} catch (error: Exception) {
+    null
+}
 
 private fun Cursor.getStringOrNull(columnName: String): String? =
     getColumnIndex(columnName).takeIf { it >= 0 }?.let(::getString)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegion.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegion.kt
@@ -2,6 +2,7 @@ package com.mapmory.shared.presentation.photo
 
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
+import com.mapmory.shared.domain.model.KoreanSelectableDistrictCodes
 import com.mapmory.shared.presentation.map.data.GeneratedKoreaDistrictMapData
 import com.mapmory.shared.presentation.map.data.GeneratedKoreaMapData
 import com.mapmory.shared.presentation.map.data.GeneratedWorldMapData
@@ -50,7 +51,13 @@ internal fun <T> selectPhotosInRegion(
         .toList()
 }
 
-internal suspend fun Location.photoRecommendationRegion(): PhotoRecommendationRegion? {
+internal class PhotoRecommendationRegionNotFoundException(
+    location: Location,
+) : IllegalStateException(
+    "사진 추천 지역 경계를 찾지 못했습니다: code=${location.regionCode}, type=${location.type}",
+)
+
+internal suspend fun Location.photoRecommendationRegion(): PhotoRecommendationRegion {
     val boundary = when {
         countryId != KoreaCountryId -> GeneratedWorldMapData.countries
             .firstOrNull { country -> country.code == regionCode }
@@ -60,11 +67,17 @@ internal suspend fun Location.photoRecommendationRegion(): PhotoRecommendationRe
             .firstOrNull { province -> province.code == regionCode }
             ?.let { province -> province.code to province.rings }
 
-        else -> GeneratedKoreaDistrictMapData
-            .forProvince(regionCode.take(KoreanProvinceCodeLength))
+        else -> KoreanSelectableDistrictCodes
             .firstOrNull { district -> district.code == regionCode }
+            ?.provinceCode
+            ?.let { provinceCode -> GeneratedKoreaDistrictMapData.forProvince(provinceCode) }
+            ?.firstOrNull { district -> district.code == regionCode }
             ?.let { district -> district.code to district.rings }
-    } ?: return null
+    } ?: throw PhotoRecommendationRegionNotFoundException(this)
+
+    if (boundary.second.none { ring -> ring.size >= MinimumRingPointCount }) {
+        throw PhotoRecommendationRegionNotFoundException(this)
+    }
 
     return PhotoRecommendationRegion(boundary.first, boundary.second)
 }
@@ -125,7 +138,7 @@ private fun pointOnSegment(point: GeoPoint, start: GeoPoint, end: GeoPoint): Boo
 }
 
 internal const val MaxRecommendedPhotos = 12
+internal const val PhotoRecommendationRegionNotFoundMessage = "선택한 장소의 경계를 확인하지 못했어요."
 private const val KoreaCountryId = 1L
-private const val KoreanProvinceCodeLength = 2
 private const val MinimumRingPointCount = 3
 private const val BoundaryEpsilon = 0.000001f

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoLibraryTest.kt
@@ -1,9 +1,13 @@
 package com.mapmory.shared.presentation.photo
 
+import com.mapmory.shared.domain.model.Location
+import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.map.data.GeneratedKoreaMapData
 import com.mapmory.shared.presentation.map.domain.GeoPoint
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -69,6 +73,23 @@ class PhotoLibraryTest {
 
         assertTrue(region.contains(latitude = 37.56, longitude = 126.98))
         assertFalse(region.contains(latitude = 37.40, longitude = 127.20))
+    }
+
+    @Test
+    fun `경계가_없는_지역은_빈_추천이_아니라_예외를_발생시킨다`() = runBlocking {
+        val unknown = Location(
+            id = -1,
+            countryId = 1,
+            parentId = null,
+            regionCode = "99999",
+            name = "알 수 없는 지역",
+            type = LocationType.DISTRICT,
+        )
+
+        assertFailsWith<PhotoRecommendationRegionNotFoundException> {
+            unknown.photoRecommendationRegion()
+        }
+        Unit
     }
 
     @Test

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionResourceAssertions.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionResourceAssertions.kt
@@ -1,0 +1,47 @@
+package com.mapmory.shared.presentation.photo
+
+import com.mapmory.shared.data.local.StaticRegionCatalog
+import com.mapmory.shared.domain.model.KoreanSelectableDistrictCodes
+import com.mapmory.shared.presentation.map.data.GeneratedKoreaDistrictMapData
+import kotlin.test.assertEquals
+
+internal suspend fun assertAllSelectableKoreanCityBoundaries() {
+    val missingBoundaries = mutableListOf<String>()
+
+    KoreanSelectableDistrictCodes
+        .filter { district -> district.provinceCode != null }
+        .groupBy { district -> requireNotNull(district.provinceCode) }
+        .forEach { (provinceCode, districts) ->
+            val boundaries = GeneratedKoreaDistrictMapData
+                .forProvince(provinceCode)
+                .associateBy { boundary -> boundary.code }
+
+            districts.forEach { district ->
+                val boundary = boundaries[district.code]
+                if (boundary == null || boundary.rings.none { ring -> ring.size >= 3 }) {
+                    missingBoundaries += "${district.code}(${district.name})@$provinceCode"
+                }
+            }
+        }
+
+    assertEquals(
+        listOf(
+            "28125(인천광역시 제물포구)@KR-28",
+            "28155(인천광역시 영종구)@KR-28",
+            "28177(인천광역시 미추홀구)@KR-28",
+            "28275(인천광역시 서해구)@KR-28",
+            "28290(인천광역시 검단구)@KR-28",
+        ),
+        missingBoundaries,
+    )
+}
+
+internal suspend fun assertJejuAndSejongBoundaries() {
+    val catalog = StaticRegionCatalog()
+
+    listOf("50110", "50130", "36110").forEach { regionCode ->
+        val location = catalog.locations.single { location -> location.regionCode == regionCode }
+
+        assertEquals(regionCode, location.photoRecommendationRegion().code)
+    }
+}

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
@@ -58,6 +58,7 @@ import platform.UIKit.UIWindow
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -182,15 +183,29 @@ private class IosPhotoLibraryController(
         val startedAtMillis = nowMillis()
         onLoadingChanged(true)
         recommendationJob = scope.launch {
-            val region = withContext(Dispatchers.Default) {
-                runCatching { location.photoRecommendationRegion() }.getOrNull()
-            }
-            if (region == null) {
-                logPhotoPerformance(
-                    "recommend_total_ms=${elapsedMillis(startedAtMillis)} recommended_photos=0",
-                )
-                onMessage("선택한 장소의 경계를 확인하지 못했어요.")
-                onLoadingChanged(false)
+            val region = try {
+                withContext(Dispatchers.Default) {
+                    location.photoRecommendationRegion()
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: PhotoRecommendationRegionNotFoundException) {
+                if (generation == recommendationGeneration) {
+                    logPhotoPerformance(
+                        "recommend_total_ms=${elapsedMillis(startedAtMillis)} recommended_photos=0",
+                    )
+                    onMessage(PhotoRecommendationRegionNotFoundMessage)
+                    onLoadingChanged(false)
+                }
+                return@launch
+            } catch (error: Exception) {
+                if (generation == recommendationGeneration) {
+                    logPhotoPerformance(
+                        "recommend_total_ms=${elapsedMillis(startedAtMillis)} recommended_photos=0",
+                    )
+                    onMessage("사진 추천을 불러오지 못했어요. 잠시 후 다시 시도해 주세요.")
+                    onLoadingChanged(false)
+                }
                 return@launch
             }
             val matchingAssets = withContext(Dispatchers.Default) {

--- a/client/shared/src/iosTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionResourceTest.kt
+++ b/client/shared/src/iosTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionResourceTest.kt
@@ -1,0 +1,16 @@
+package com.mapmory.shared.presentation.photo
+
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+class PhotoRecommendationRegionResourceTest {
+    @Test
+    fun `모든_선택_가능한_국내_도시의_경계를_전수_검사한다`() = runBlocking {
+        assertAllSelectableKoreanCityBoundaries()
+    }
+
+    @Test
+    fun `제주와_세종은_명시된_상위_시도_경계를_사용한다`() = runBlocking {
+        assertJejuAndSejongBoundaries()
+    }
+}

--- a/client/shared/src/jvmTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionResourceTest.kt
+++ b/client/shared/src/jvmTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationRegionResourceTest.kt
@@ -1,0 +1,16 @@
+package com.mapmory.shared.presentation.photo
+
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+class PhotoRecommendationRegionResourceTest {
+    @Test
+    fun `모든_선택_가능한_국내_도시의_경계를_전수_검사한다`() = runBlocking {
+        assertAllSelectableKoreanCityBoundaries()
+    }
+
+    @Test
+    fun `제주와_세종은_명시된_상위_시도_경계를_사용한다`() = runBlocking {
+        assertJejuAndSejongBoundaries()
+    }
+}


### PR DESCRIPTION
## 요약

제주·세종처럼 시·군·구 코드 앞자리와 시·도 코드가 다른 지역도 명시적 상위 코드로 사진 추천 경계를 조회합니다.
경계 조회 실패를 Android/iOS에서 동일하게 알리고, 사진 추천 코루틴의 CancellationException을 재전파합니다.

## 배경

제주시 50110을 앞 두 자리 50으로 추론해 세종 경계 리소스를 읽으면서 iOS에서 경계 오류 메시지가 표시됐습니다.
Android는 같은 실패를 빈 추천 결과로 처리했고 runCatching이 코루틴 취소까지 일반 실패로 변환할 수 있었습니다.

## 주요 결정

- regionCode 앞 두 자리 추론 대신 KoreanSelectableDistrictCodes의 명시적 provinceCode 사용
- 경계 없음 또는 유효 폴리곤 없음은 PhotoRecommendationRegionNotFoundException으로 구분
- Android/iOS에서 경계 실패 메시지를 표시하고 예상 밖 실패는 일반 오류 메시지로 처리
- CancellationException은 즉시 재전파
- JVM/iOS에서 모든 선택 가능 국내 도시 코드와 번들 경계를 전수 대조
- 현재 경계 원본에 없는 인천 5개 지역은 다른 경계로 대체하지 않고 알려진 누락으로 명시

## 한계

- 제물포구, 영종구, 미추홀구, 서해구, 검단구는 현재 번들 경계 원본에 없어 사진 추천 경계를 제공하지 않습니다.
- Android 실제 기기가 연결되지 않아 계측 테스트 실행은 못 했고, 계측 테스트 APK 빌드까지 확인했습니다.

## 확인

- [x] ./gradlew :shared:allTests :androidApp:assembleDebug :shared:assembleAndroidDeviceTest --no-daemon
- [x] JVM 전체 테스트
- [x] iOS Simulator Arm64 전체 테스트 및 국내 도시 경계 전수 검사
- [x] Android 앱 및 계측 테스트 APK 빌드
- [x] 비밀 정보 없음
- [x] 환경변수, DB 스키마, 백엔드 변경 없음
- [x] 지도 경계 데이터 한계 문서 갱신