### PR TITLE
fix: 3D 지구본 안내 화면 다시 표시

### DIFF
--- a/landing/AGENTS.md
+++ b/landing/AGENTS.md
@@ -25,6 +25,7 @@ When implementing from a selected generated mock, treat that image as the source
 - Keep the globe and photo preview concise. The next product-proof step must use the real app's 대한민국/전세계 scope pattern and the same 17-region boundary data as the Kotlin client.
 - Do not pin, lock, or hijack scrolling in the globe experience. The globe CTA should align the complete experience stage cleanly in the viewport, and the section title should stay on one line where the viewport allows it.
 - Confine the first-use globe instruction overlay to the globe canvas; never dim or block the entire landing viewport.
+- Show the globe instruction once on the first 3D experience entry of every page load. Dismiss it for the current page only; never persist its dismissal in session or local storage.
 - On mobile, keep the globe as the only default world-experience surface. Let the selected country's gold color and raised polygon motion finish before replacing the globe in-place with the separate memory panel. Make the return-to-globe control unmistakable, and never advance to the Korea experience without an explicit user action.
 - The Korea experience is hierarchical in one surface: 17-province map (level 2) → the selected province's real city/county/district boundary map (level 3) → back to the province map. Reuse the client district JSON instead of drawing approximate boundaries.
 - Do not show a fake editor, collection form, or recording workflow that differs from the shipping client.

--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -1196,13 +1196,7 @@ function App() {
   }, [isWorldMemoryOpen]);
 
   useEffect(() => {
-    let hasSeenGuide = false;
-    try {
-      hasSeenGuide = sessionStorage.getItem("mapmory-globe-guide-seen-v2") === "true";
-    } catch {
-      hasSeenGuide = false;
-    }
-    if (hasSeenGuide || !experienceRef.current) return undefined;
+    if (!experienceRef.current) return undefined;
 
     const observer = new IntersectionObserver(([entry]) => {
       if (!entry.isIntersecting || entry.intersectionRatio < 0.45) return;
@@ -1215,11 +1209,6 @@ function App() {
 
   const dismissGlobeGuide = () => {
     setIsGlobeGuideVisible(false);
-    try {
-      sessionStorage.setItem("mapmory-globe-guide-seen-v2", "true");
-    } catch {
-      // The guide can still be dismissed when session storage is unavailable.
-    }
   };
 
   const closeWorldMemory = () => {


### PR DESCRIPTION
## 변경 사항
- 지구본 안내 화면을 닫은 상태를 sessionStorage에 영구 보관하던 로직을 제거했습니다.
- 페이지를 열 때마다 첫 3D 체험 진입에서 `지구본을 돌려보세요` 안내가 한 번 표시됩니다.
- 안내를 누르면 현재 페이지에서는 정상적으로 사라집니다.

## 검증
- 안내 닫기 후 숨김 확인
- 같은 탭 새로고침 후 안내 재표시 확인
- `npm test` — 14 tests passed
- `npm run build` — passed