### PR TITLE
fix: 3D 안내의 직접 진입 조건 보완

### DIFF
--- a/landing/AGENTS.md
+++ b/landing/AGENTS.md
@@ -25,7 +25,7 @@ When implementing from a selected generated mock, treat that image as the source
 - Keep the globe and photo preview concise. The next product-proof step must use the real app's 대한민국/전세계 scope pattern and the same 17-region boundary data as the Kotlin client.
 - Do not pin, lock, or hijack scrolling in the globe experience. The globe CTA should align the complete experience stage cleanly in the viewport, and the section title should stay on one line where the viewport allows it.
 - Confine the first-use globe instruction overlay to the globe canvas; never dim or block the entire landing viewport.
-- Show the globe instruction once on the first 3D experience entry of every page load. Dismiss it for the current page only; never persist its dismissal in session or local storage.
+- Show the globe instruction once on the first 3D experience entry of every page load. Detect entry against the bounded globe panel rather than the longer experience section, dismiss it for the current page only, and never persist its dismissal in session or local storage.
 - On mobile, keep the globe as the only default world-experience surface. Let the selected country's gold color and raised polygon motion finish before replacing the globe in-place with the separate memory panel. Make the return-to-globe control unmistakable, and never advance to the Korea experience without an explicit user action.
 - The Korea experience is hierarchical in one surface: 17-province map (level 2) → the selected province's real city/county/district boundary map (level 3) → back to the province map. Reuse the client district JSON instead of drawing approximate boundaries.
 - Do not show a fake editor, collection form, or recording workflow that differs from the shipping client.

--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -1164,6 +1164,7 @@ function App() {
   const [isWorldSelecting, setIsWorldSelecting] = useState(false);
   const experienceRef = useRef(null);
   const experienceStageRef = useRef(null);
+  const globePanelRef = useRef(null);
   const worldSelectionTimerRef = useRef(null);
   const globeAnalytics = useExperienceAnalytics("globe");
 
@@ -1196,14 +1197,14 @@ function App() {
   }, [isWorldMemoryOpen]);
 
   useEffect(() => {
-    if (!experienceRef.current) return undefined;
+    if (!globePanelRef.current) return undefined;
 
     const observer = new IntersectionObserver(([entry]) => {
-      if (!entry.isIntersecting || entry.intersectionRatio < 0.45) return;
+      if (!entry.isIntersecting || entry.intersectionRatio < 0.25) return;
       setIsGlobeGuideVisible(true);
       observer.disconnect();
-    }, { threshold: [0.45] });
-    observer.observe(experienceRef.current);
+    }, { threshold: [0.25] });
+    observer.observe(globePanelRef.current);
     return () => observer.disconnect();
   }, []);
 
@@ -1245,7 +1246,7 @@ function App() {
             <div><p className="eyebrow">01 · 세계</p><h2>지구본을 돌려 기억을 찾아요.</h2></div>
           </div>
           <div className={`experience-stage ${isWorldMemoryOpen ? "is-memory-open" : ""}`} ref={experienceStageRef}>
-            <article className="globe-panel" id="globe-demo">
+            <article className="globe-panel" id="globe-demo" ref={globePanelRef}>
               <header><span><GlobeHemisphereEast size={19} weight="duotone" />3D 기억 지도</span></header>
               <InteractiveGlobe selected={selectedMemory} focusRequest={globeFocusRequest} onSelect={handleWorldSelect} onInteract={globeAnalytics.startExperience} theme={theme} guideVisible={isGlobeGuideVisible} onGuideDismiss={dismissGlobeGuide} isSelecting={isWorldSelecting} />
               <LocationSelector selected={selectedMemory} onSelect={handleWorldSelect} disabled={isWorldSelecting} />


### PR DESCRIPTION
## 변경 사항
- 안내 노출 IntersectionObserver 대상을 긴 경험 섹션에서 실제 3D 지구본 패널로 변경했습니다.
- `#experience` 직접 진입과 CTA 진입 모두에서 안내가 노출되도록 기준을 보완했습니다.

## 검증
- 로컬 `#experience` 직접 진입 시 안내 표시
- 첫 화면 CTA 진입 시 안내 표시
- `npm test` — 14 tests passed
- `npm run build` — passed