### PR TITLE
refactor: TagService의 웹 계층 DTO 의존성 제거

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/tag/TagController.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagController.java
@@ -35,14 +35,18 @@ public class TagController {
             @LoginMember Member member,
             @Valid @RequestBody TagRequest request
     ) {
-        TagResponse response = tagService.create(member, request);
+        TagResponse response = TagResponse.from(tagService.create(member, request.name()));
         return ResponseEntity.created(URI.create("/api/v1/tags/" + response.id()))
                 .body(ApiResponse.from(response));
     }
 
     @GetMapping
     public ApiResponse<List<TagResponse>> findAll(@LoginMember Member member) {
-        return ApiResponse.from(tagService.findAll(member));
+        List<TagResponse> allTagsResponse = tagService.findAll(member).stream()
+                .map(TagResponse::from)
+                .toList();
+
+        return ApiResponse.from(allTagsResponse);
     }
 
     @PatchMapping("/{tagId}")
@@ -51,7 +55,8 @@ public class TagController {
             @PathVariable @Positive Long tagId,
             @Valid @RequestBody TagRequest request
     ) {
-        return ApiResponse.from(tagService.update(member, tagId, request));
+        Tag update = tagService.update(member, tagId, request.name());
+        return ApiResponse.from(TagResponse.from(update));
     }
 
     @DeleteMapping("/{tagId}")

--- a/backend/src/main/java/com/mapmory/backend/tag/TagService.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagService.java
@@ -21,32 +21,31 @@ public class TagService {
     }
 
     @Transactional
-    public TagResponse create(Member member, TagRequest request) {
-        Tag tag = Tag.of(member, request.name());
+    public Tag create(Member member, String name) {
+        Tag tag = Tag.of(member, name);
 
         validateTagLimit(member.getId());
         validateUniqueNameForCreate(member.getId(), tag.getNameKey());
 
-        return TagResponse.from(saveTag(tag));
+        return saveTag(tag);
     }
 
     @Transactional(readOnly = true)
-    public List<TagResponse> findAll(Member member) {
+    public List<Tag> findAll(Member member) {
         return tagRepository.findAllByMemberIdOrderByCreatedAtAscIdAsc(member.getId()).stream()
-                .map(TagResponse::from)
                 .toList();
     }
 
     @Transactional
-    public TagResponse update(Member member, Long tagId, TagRequest request) {
+    public Tag update(Member member, Long tagId, String name) {
         Tag tag = findOwnedTag(member, tagId);
 
-        String nameKey = Tag.nameKeyOf(request.name());
+        String nameKey = Tag.nameKeyOf(name);
         validateUniqueNameForUpdate(member.getId(), nameKey, tagId);
-        tag.rename(request.name());
+        tag.rename(name);
 
         flushTagChanges();
-        return TagResponse.from(tag);
+        return tag;
     }
 
     @Transactional

--- a/backend/src/main/java/com/mapmory/backend/tag/TagService.java
+++ b/backend/src/main/java/com/mapmory/backend/tag/TagService.java
@@ -2,8 +2,6 @@ package com.mapmory.backend.tag;
 
 import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.tag.dto.TagRequest;
-import com.mapmory.backend.tag.dto.TagResponse;
 import java.util.List;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;

--- a/backend/src/test/java/com/mapmory/backend/tag/TagServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagServiceTest.java
@@ -11,8 +11,6 @@ import static org.mockito.Mockito.when;
 
 import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.tag.dto.TagRequest;
-import com.mapmory.backend.tag.dto.TagResponse;
 import java.util.Optional;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;

--- a/backend/src/test/java/com/mapmory/backend/tag/TagServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/tag/TagServiceTest.java
@@ -51,10 +51,10 @@ class TagServiceTest {
             return tag;
         });
 
-        TagResponse response = tagService.create(member, new TagRequest("  Date   Course  "));
+        Tag created = tagService.create(member, "  Date   Course  ");
 
-        assertThat(response.id()).isEqualTo(1L);
-        assertThat(response.name()).isEqualTo("Date Course");
+        assertThat(created.getId()).isEqualTo(1L);
+        assertThat(created.getName()).isEqualTo("Date Course");
         verify(tagRepository).existsByMemberIdAndNameKey(10L, "date course");
     }
 
@@ -63,14 +63,14 @@ class TagServiceTest {
         when(member.getId()).thenReturn(10L);
         when(tagRepository.countByMemberId(10L)).thenReturn(10L);
 
-        assertError(() -> tagService.create(member, new TagRequest("연인")), "TAG_LIMIT_EXCEEDED");
+        assertError(() -> tagService.create(member, "연인"), "TAG_LIMIT_EXCEEDED");
 
         verify(tagRepository, never()).saveAndFlush(any(Tag.class));
     }
 
     @Test
     void 샵이_포함된_태그_이름을_거부한다() {
-        assertError(() -> tagService.create(member, new TagRequest("#연인")), "VALIDATION_ERROR");
+        assertError(() -> tagService.create(member, "#연인"), "VALIDATION_ERROR");
 
         verifyNoInteractions(tagRepository);
     }
@@ -85,7 +85,7 @@ class TagServiceTest {
                 .thenReturn(true);
 
         assertError(
-                () -> tagService.update(member, 1L, new TagRequest("  Date   Course  ")),
+                () -> tagService.update(member, 1L, "  Date   Course  "),
                 "TAG_NAME_CONFLICT"
         );
 
@@ -103,7 +103,7 @@ class TagServiceTest {
                 new DataIntegrityViolationException("이름 중복", constraintViolation);
         when(tagRepository.saveAndFlush(any(Tag.class))).thenThrow(integrityViolation);
 
-        assertError(() -> tagService.create(member, new TagRequest("친구")), "TAG_NAME_CONFLICT");
+        assertError(() -> tagService.create(member, "친구"), "TAG_NAME_CONFLICT");
     }
 
     @Test
@@ -114,7 +114,7 @@ class TagServiceTest {
         DataIntegrityViolationException integrityViolation = new DataIntegrityViolationException("FK 위반");
         when(tagRepository.saveAndFlush(any(Tag.class))).thenThrow(integrityViolation);
 
-        assertThatThrownBy(() -> tagService.create(member, new TagRequest("친구")))
+        assertThatThrownBy(() -> tagService.create(member, "친구"))
                 .isSameAs(integrityViolation);
     }
 


### PR DESCRIPTION
## 요약

`TagService`가 웹 계층 DTO(`TagRequest`, `TagResponse`)에 의존하지 않도록 정리했습니다.
서비스는 이제 원시 값을 받고 도메인 객체(`Tag`)를 반환하며, 요청 DTO 해체와 응답 조립은 `TagController`가 맡습니다.

## 배경

`TagRequest`는 `@NotBlank`와 JSON 바인딩을 포함한 **HTTP 요청 스펙**이고, `TagResponse`는 **HTTP 응답 스펙**입니다.
서비스가 이 둘을 직접 다루면 도메인 로직이 API 계약에 묶여서

- API 응답 필드가 바뀔 때마다 서비스 시그니처와 서비스 테스트가 함께 흔들리고,
- 웹이 아닌 경로(배치, 다른 서비스에서의 호출)에서 재사용하기 어려우며,
- 서비스 단위 테스트가 API 스펙을 알아야 합니다.

계층 간 의존 방향을 `Controller → Service → Domain` 한 방향으로 되돌리는 것이 목적입니다.

## 변경 내용

| 변경 전 | 변경 후 |
| --- | --- |
| `TagResponse create(Member, TagRequest)` | `Tag create(Member, String name)` |
| `List<TagResponse> findAll(Member)` | `List<Tag> findAll(Member)` |
| `TagResponse update(Member, Long, TagRequest)` | `Tag update(Member, Long, String name)` |

- `TagController`에서 `request.name()`으로 값을 풀어 서비스에 전달하고, 반환된 `Tag`를 `TagResponse.from()`으로 변환합니다.
- `TagService`, `TagServiceTest`에서 `tag.dto` import를 제거했습니다.
- `TagServiceTest`는 응답 DTO 대신 `Tag`의 상태(`getId()`, `getName()`)를 검증하도록 바꿨습니다.

## 주요 결정

**요청 값을 어떤 형태로 서비스에 넘길지** 세 가지를 검토했습니다.

1. **원시 값으로 풀어서 전달** (채택) — `TagRequest`가 `name` 한 필드뿐이라 별도 래퍼를 둘 이유가 없습니다.
2. 서비스 계층이 소유한 `Command` 객체 — 파라미터가 늘어나거나 웹 외 진입점이 생기면 그때 도입하는 게 맞다고 판단했습니다. 지금은 오버엔지니어링입니다.
3. 요청 DTO를 그대로 수용 — 이 PR이 없애려는 문제 그 자체라 제외했습니다.

**검증 책임 분리는 기존 구조를 유지**했습니다. 형식 검증(`@NotBlank`)은 컨트롤러의 `TagRequest`가, 도메인 불변식(이름 정규화·문자 제한)은 `TagName`이 담당합니다.

**엔티티를 컨트롤러까지 반환**하는 형태입니다. `Tag.member`가 `LAZY`지만 `TagResponse`가 이를 참조하지 않아 지연 로딩 문제는 없습니다.

## 한계

- API 스펙과 응답 형태는 그대로입니다. 동작 변경 없는 순수 리팩터링입니다.
- 같은 문제를 가진 `TravelRecordService`, `UploadService`, `LaunchWaitlistService`, `AuthService`는 이 PR 범위 밖입니다. 별도 PR로 이어가려 합니다.
- `TagService.getOwnedTag`는 이미 도메인을 반환하고 있어 변경이 없습니다.

## 확인

- [x] 로컬에서 실행 확인 (`./gradlew test --tests '*Tag*'` 통과)
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [ ] 새 환경변수를 추가했다면 `.env.example` 갱신 — 해당 없음
- [ ] DB 스키마를 변경했다면 **새 마이그레이션 파일**로 추가 (기존 파일 수정 X) — 해당 없음
- [ ] 실행 방법이나 환경 설정이 바뀌었다면 README 갱신 — 해당 없음

---

## 관련 이슈
#199 