### PR TITLE
refactor: TravelRecordService의 웹 계층 DTO 의존성 제거

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaView.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaView.java
@@ -1,0 +1,10 @@
+package com.mapmory.backend.recordmedia;
+
+/**
+ * 미디어 원본과 조회용 presigned URL을 함께 다루기 위한 조합이다.
+ */
+public record RecordMediaView(
+        RecordMedia recordMedia,
+        ExpiringUrl viewUrl
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordAssembler.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordAssembler.java
@@ -1,0 +1,74 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.recordmedia.RecordMediaRepository;
+import com.mapmory.backend.recordmedia.RecordMediaUrlService;
+import com.mapmory.backend.recordmedia.RecordMediaView;
+import com.mapmory.backend.tag.Tag;
+import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+/**
+ * 여행 일지에 딸린 미디어·태그·조회 URL을 모아 도메인 조합 결과를 만든다.
+ * 조회에 필요한 리포지토리를 직접 들고 있어, TravelRecordService는 유스케이스 흐름에만 집중한다.
+ */
+@Component
+public class TravelRecordAssembler {
+
+    private final RecordMediaRepository recordMediaRepository;
+    private final TravelRecordTagService travelRecordTagService;
+    private final RecordMediaUrlService recordMediaUrlService;
+
+    public TravelRecordAssembler(
+            RecordMediaRepository recordMediaRepository,
+            TravelRecordTagService travelRecordTagService,
+            RecordMediaUrlService recordMediaUrlService
+    ) {
+        this.recordMediaRepository = recordMediaRepository;
+        this.travelRecordTagService = travelRecordTagService;
+        this.recordMediaUrlService = recordMediaUrlService;
+    }
+
+    public TravelRecordDetail assembleDetail(TravelRecord travelRecord) {
+        Long travelRecordId = travelRecord.getId();
+        List<RecordMedia> recordMedia = recordMediaRepository
+                .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
+
+        return assembleDetail(
+                travelRecord,
+                recordMedia,
+                travelRecordTagService.findByTravelRecordId(travelRecordId)
+        );
+    }
+
+    public TravelRecordDetail assembleDetail(
+            TravelRecord travelRecord,
+            List<RecordMedia> recordMedia,
+            List<Tag> tags
+    ) {
+        return new TravelRecordDetail(travelRecord, toMediaViews(recordMedia), tags);
+    }
+
+    public TravelRecordSummaries assembleSummaries(Page<TravelRecord> travelRecords) {
+        List<Long> travelRecordIds = travelRecords.getContent().stream()
+                .map(TravelRecord::getId)
+                .toList();
+
+        return new TravelRecordSummaries(
+                travelRecords,
+                travelRecordTagService.findByTravelRecordIds(travelRecordIds),
+                recordMediaUrlService.createThumbnailUrls(travelRecordIds)
+        );
+    }
+
+    private List<RecordMediaView> toMediaViews(List<RecordMedia> recordMedia) {
+        return recordMedia.stream()
+                .map(media -> new RecordMediaView(
+                        media,
+                        recordMediaUrlService.createViewUrl(media.getObjectKey())
+                ))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordCommand.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordCommand.java
@@ -1,0 +1,25 @@
+package com.mapmory.backend.travelrecord;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 여행 일지 생성·수정에 필요한 값을 서비스 계층 형태로 담는다.
+ * 웹 요청 스펙(TravelRecordRequest)과 분리해 서비스가 API 계약에 의존하지 않게 한다.
+ */
+public record TravelRecordCommand(
+        String countryCode,
+        String provinceCode,
+        String districtCode,
+        String title,
+        String content,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> objectKeys,
+        List<Long> tagIds
+) {
+    public TravelRecordCommand {
+        objectKeys = objectKeys == null ? List.of() : objectKeys;
+        tagIds = tagIds == null ? List.of() : tagIds;
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -38,7 +38,7 @@ public class TravelRecordController {
             @LoginMember Member member,
             @Valid @RequestBody TravelRecordRequest travelRecordRequest
     ) {
-        TravelRecord travelRecord = travelRecordService.create(member, travelRecordRequest);
+        TravelRecord travelRecord = travelRecordService.create(member, travelRecordRequest.toCommand());
         CreateTravelRecordResponse response = CreateTravelRecordResponse.from(travelRecord);
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -55,7 +55,7 @@ public class TravelRecordController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
-        TravelRecordListResponse response = travelRecordService.findAll(
+        TravelRecordSummaries summaries = travelRecordService.findAll(
                 member,
                 countryCode,
                 provinceCode,
@@ -64,6 +64,7 @@ public class TravelRecordController {
                 page,
                 size
         );
+        TravelRecordListResponse response = TravelRecordListResponse.from(summaries);
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }
@@ -73,7 +74,9 @@ public class TravelRecordController {
             @LoginMember Member member,
             @PathVariable @Positive Long travelRecordId
     ) {
-        TravelRecordDetailResponse response = travelRecordService.findById(member, travelRecordId);
+        TravelRecordDetailResponse response = TravelRecordDetailResponse.from(
+                travelRecordService.findById(member, travelRecordId)
+        );
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }
@@ -84,11 +87,12 @@ public class TravelRecordController {
             @PathVariable @Positive Long travelRecordId,
             @Valid @RequestBody TravelRecordRequest travelRecordRequest
     ) {
-        TravelRecordDetailResponse response = travelRecordService.update(
+        TravelRecordDetail detail = travelRecordService.update(
                 member,
                 travelRecordId,
-                travelRecordRequest
+                travelRecordRequest.toCommand()
         );
+        TravelRecordDetailResponse response = TravelRecordDetailResponse.from(detail);
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordDetail.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordDetail.java
@@ -1,0 +1,22 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.recordmedia.RecordMediaView;
+import com.mapmory.backend.tag.Tag;
+import java.util.List;
+
+/**
+ * 여행 일지 상세를 이루는 도메인 조합 결과다.
+ * 표현 형식을 정하지 않으므로 응답 DTO 변환은 웹 계층이 담당한다.
+ */
+public record TravelRecordDetail(
+        TravelRecord travelRecord,
+        List<RecordMediaView> mediaViews,
+        List<Tag> tags
+) {
+    public List<RecordMedia> recordMedia() {
+        return mediaViews.stream()
+                .map(RecordMediaView::recordMedia)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -4,18 +4,12 @@ import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.common.monitoring.MonitoredOperation;
 import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.recordmedia.ExpiringUrl;
 import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.recordmedia.RecordMediaRepository;
-import com.mapmory.backend.recordmedia.RecordMediaUrlService;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import java.time.Clock;
@@ -46,7 +40,7 @@ public class TravelRecordService {
     private final TravelRecordTagService travelRecordTagService;
     private final TagService tagService;
     private final OperationTimer operationTimer;
-    private final RecordMediaUrlService recordMediaUrlService;
+    private final TravelRecordAssembler travelRecordAssembler;
     private final Clock clock;
     private final UploadedObjectVerifier uploadedObjectVerifier;
 
@@ -57,7 +51,7 @@ public class TravelRecordService {
             TravelRecordTagService travelRecordTagService,
             TagService tagService,
             OperationTimer operationTimer,
-            RecordMediaUrlService recordMediaUrlService,
+            TravelRecordAssembler travelRecordAssembler,
             Clock clock,
             UploadedObjectVerifier uploadedObjectVerifier
     ) {
@@ -67,30 +61,30 @@ public class TravelRecordService {
         this.travelRecordTagService = travelRecordTagService;
         this.tagService = tagService;
         this.operationTimer = operationTimer;
-        this.recordMediaUrlService = recordMediaUrlService;
+        this.travelRecordAssembler = travelRecordAssembler;
         this.clock = clock;
         this.uploadedObjectVerifier = uploadedObjectVerifier;
     }
 
     @Transactional
-    public TravelRecord create(Member member, TravelRecordRequest request) {
-        validateTravelDates(request.startDate(), request.endDate());
-        validateTravelRecordRegion(request);
-        List<String> objectKeys = objectKeys(request);
+    public TravelRecord create(Member member, TravelRecordCommand command) {
+        validateTravelDates(command.startDate(), command.endDate());
+        validateTravelRecordRegion(command);
+        List<String> objectKeys = command.objectKeys();
         uploadedObjectVerifier.verifyAllUploaded(objectKeys);
-        Region region = resolveRegion(request);
+        Region region = resolveRegion(command);
 
         TravelRecord travelRecord = TravelRecord.of(
                 member,
                 region,
-                request.title(),
-                request.content(),
-                request.startDate(),
-                request.endDate()
+                command.title(),
+                command.content(),
+                command.startDate(),
+                command.endDate()
         );
 
         TravelRecord savedTravelRecord = travelRecordRepository.save(travelRecord);
-        travelRecordTagService.replace(member, savedTravelRecord, request.tagIds());
+        travelRecordTagService.replace(member, savedTravelRecord, command.tagIds());
 
         // TODO : save or saveAll 결정하고 적용하기
         for (int index = 0; index < objectKeys.size(); index++) {
@@ -108,33 +102,25 @@ public class TravelRecordService {
     }
 
     @Transactional(readOnly = true)
-    public TravelRecordDetailResponse findById(Member member, Long travelRecordId) {
-        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
-                .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
-        List<RecordMedia> recordMedia = recordMediaRepository
-                .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
+    public TravelRecordDetail findById(Member member, Long travelRecordId) {
+        TravelRecord travelRecord = findOwnedTravelRecord(member, travelRecordId);
 
-        return createDetailResponse(
-                travelRecord,
-                recordMedia,
-                travelRecordTagService.findByTravelRecordId(travelRecordId)
-        );
+        return travelRecordAssembler.assembleDetail(travelRecord);
     }
 
     @Transactional
-    public TravelRecordDetailResponse update(
+    public TravelRecordDetail update(
             Member member,
             Long travelRecordId,
-            TravelRecordRequest request
+            TravelRecordCommand command
     ) {
-        validateTravelDates(request.startDate(), request.endDate());
-        validateTravelRecordRegion(request);
-        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
-                .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
-        List<String> objectKeys = objectKeys(request);
+        validateTravelDates(command.startDate(), command.endDate());
+        validateTravelRecordRegion(command);
+        TravelRecord travelRecord = findOwnedTravelRecord(member, travelRecordId);
+        List<String> objectKeys = command.objectKeys();
         validateUniqueObjectKeys(objectKeys);
 
-        Region region = resolveRegion(request);
+        Region region = resolveRegion(command);
         List<RecordMedia> existingMedia = recordMediaRepository
                 .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
         List<String> newObjectKeys = newObjectKeys(objectKeys, existingMedia);
@@ -143,12 +129,12 @@ public class TravelRecordService {
 
         travelRecord.update(
                 region,
-                request.title(),
-                request.content(),
-                request.startDate(),
-                request.endDate()
+                command.title(),
+                command.content(),
+                command.startDate(),
+                command.endDate()
         );
-        List<Tag> tags = travelRecordTagService.replace(member, travelRecord, request.tagIds());
+        List<Tag> tags = travelRecordTagService.replace(member, travelRecord, command.tagIds());
         List<RecordMedia> updatedMedia = operationTimer.record(
                 MonitoredOperation.MEDIA_SYNC,
                 () -> {
@@ -162,19 +148,16 @@ public class TravelRecordService {
                 }
         );
 
-        return createDetailResponse(travelRecord, updatedMedia, tags);
+        return travelRecordAssembler.assembleDetail(travelRecord, updatedMedia, tags);
     }
 
     @Transactional
     public void delete(Member member, Long travelRecordId) {
-        TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
-                .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
-
-        travelRecordRepository.delete(travelRecord);
+        travelRecordRepository.delete(findOwnedTravelRecord(member, travelRecordId));
     }
 
     @Transactional(readOnly = true)
-    public TravelRecordListResponse findAll(
+    public TravelRecordSummaries findAll(
             Member member,
             String countryCode,
             String provinceCode,
@@ -222,18 +205,12 @@ public class TravelRecordService {
             }
         }
 
-        List<Long> travelRecordIds = travelRecords.getContent().stream()
-                .map(TravelRecord::getId)
-                .toList();
-        Map<Long, List<Tag>> tagsByTravelRecordId =
-                travelRecordTagService.findByTravelRecordIds(travelRecordIds);
-        Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId =
-                recordMediaUrlService.createThumbnailUrls(travelRecordIds);
-        return TravelRecordListResponse.from(
-                travelRecords,
-                tagsByTravelRecordId,
-                thumbnailUrlsByTravelRecordId
-        );
+        return travelRecordAssembler.assembleSummaries(travelRecords);
+    }
+
+    private TravelRecord findOwnedTravelRecord(Member member, Long travelRecordId) {
+        return travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
+                .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
     }
 
     private void validateRegionFilterHierarchy(
@@ -292,18 +269,18 @@ public class TravelRecordService {
         );
     }
 
-    private Region resolveRegion(TravelRecordRequest request) {
+    private Region resolveRegion(TravelRecordCommand command) {
         return regionResolver.resolve(
-                request.countryCode(),
-                request.provinceCode(),
-                request.districtCode()
+                command.countryCode(),
+                command.provinceCode(),
+                command.districtCode()
         );
     }
 
-    private void validateTravelRecordRegion(TravelRecordRequest request) {
-        String countryCode = request.countryCode();
-        String provinceCode = request.provinceCode();
-        String districtCode = request.districtCode();
+    private void validateTravelRecordRegion(TravelRecordCommand command) {
+        String countryCode = command.countryCode();
+        String provinceCode = command.provinceCode();
+        String districtCode = command.districtCode();
         validateRegionCodeFormat(countryCode, provinceCode, districtCode);
 
         if (KOREA_COUNTRY_CODE.equals(countryCode)) {
@@ -322,10 +299,6 @@ public class TravelRecordService {
         if (new HashSet<>(objectKeys).size() != objectKeys.size()) {
             throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
         }
-    }
-
-    private static List<String> objectKeys(TravelRecordRequest request) {
-        return request.objectKeys() == null ? List.of() : request.objectKeys();
     }
 
     private static List<String> newObjectKeys(
@@ -371,21 +344,6 @@ public class TravelRecordService {
 
         recordMediaRepository.deleteAll(existingMediaByObjectKey.values());
         return recordMediaRepository.saveAll(updatedMedia);
-    }
-
-    private TravelRecordDetailResponse createDetailResponse(
-            TravelRecord travelRecord,
-            List<RecordMedia> recordMedia,
-            List<Tag> tags
-    ) {
-        List<TravelRecordMediaResponse> media = recordMedia.stream()
-                .map(item -> TravelRecordMediaResponse.from(
-                        item,
-                        recordMediaUrlService.createViewUrl(item.getObjectKey())
-                ))
-                .toList();
-
-        return TravelRecordDetailResponse.from(travelRecord, recordMedia, tags, media);
     }
 
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordSummaries.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordSummaries.java
@@ -1,0 +1,24 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.tag.Tag;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
+
+/**
+ * 여행 일지 목록 한 페이지와, 각 일지에 딸린 태그·썸네일을 묶은 도메인 조합 결과다.
+ */
+public record TravelRecordSummaries(
+        Page<TravelRecord> travelRecords,
+        Map<Long, List<Tag>> tagsByTravelRecordId,
+        Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId
+) {
+    public List<Tag> tagsOf(TravelRecord travelRecord) {
+        return tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of());
+    }
+
+    public ExpiringUrl thumbnailUrlOf(TravelRecord travelRecord) {
+        return thumbnailUrlsByTravelRecordId.get(travelRecord.getId());
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
@@ -1,9 +1,9 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.recordmedia.RecordMedia;
-import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.travelrecord.TravelRecordDetail;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,12 +35,9 @@ public record TravelRecordDetailResponse(
         this(id, title, content, region, startDate, endDate, objectKeys, List.of(), List.of(), createdAt, updatedAt);
     }
 
-    public static TravelRecordDetailResponse from(
-            TravelRecord travelRecord,
-            List<RecordMedia> recordMedia,
-            List<Tag> tags,
-            List<TravelRecordMediaResponse> media
-    ) {
+    public static TravelRecordDetailResponse from(TravelRecordDetail detail) {
+        TravelRecord travelRecord = detail.travelRecord();
+
         return new TravelRecordDetailResponse(
                 travelRecord.getId(),
                 travelRecord.getTitle(),
@@ -48,11 +45,13 @@ public record TravelRecordDetailResponse(
                 RegionDetailResponse.from(travelRecord.getRegion()),
                 travelRecord.getStartDate(),
                 travelRecord.getEndDate(),
-                recordMedia.stream()
+                detail.recordMedia().stream()
                         .map(RecordMedia::getObjectKey)
                         .toList(),
-                media,
-                tags.stream().map(TagSummaryResponse::from).toList(),
+                detail.mediaViews().stream()
+                        .map(TravelRecordMediaResponse::from)
+                        .toList(),
+                detail.tags().stream().map(TagSummaryResponse::from).toList(),
                 travelRecord.getCreatedAt(),
                 travelRecord.getUpdatedAt()
         );

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
@@ -1,10 +1,8 @@
 package com.mapmory.backend.travelrecord.dto;
 
-import com.mapmory.backend.recordmedia.ExpiringUrl;
-import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.travelrecord.TravelRecordSummaries;
 import java.util.List;
-import java.util.Map;
 import org.springframework.data.domain.Page;
 
 public record TravelRecordListResponse(
@@ -15,17 +13,15 @@ public record TravelRecordListResponse(
         int totalPages,
         boolean hasNext
 ) {
-    public static TravelRecordListResponse from(
-            Page<TravelRecord> travelRecords,
-            Map<Long, List<Tag>> tagsByTravelRecordId,
-            Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId
-    ) {
+    public static TravelRecordListResponse from(TravelRecordSummaries summaries) {
+        Page<TravelRecord> travelRecords = summaries.travelRecords();
+
         return new TravelRecordListResponse(
                 travelRecords.getContent().stream()
                         .map(travelRecord -> TravelRecordListItemResponse.from(
                                 travelRecord,
-                                tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of()),
-                                thumbnailUrlsByTravelRecordId.get(travelRecord.getId())
+                                summaries.tagsOf(travelRecord),
+                                summaries.thumbnailUrlOf(travelRecord)
                         ))
                         .toList(),
                 travelRecords.getNumber(),

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordMediaResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordMediaResponse.java
@@ -2,6 +2,7 @@ package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.recordmedia.ExpiringUrl;
 import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.recordmedia.RecordMediaView;
 
 public record TravelRecordMediaResponse(
         Long id,
@@ -10,6 +11,10 @@ public record TravelRecordMediaResponse(
         long viewUrlExpiresIn,
         int sortOrder
 ) {
+    public static TravelRecordMediaResponse from(RecordMediaView mediaView) {
+        return from(mediaView.recordMedia(), mediaView.viewUrl());
+    }
+
     public static TravelRecordMediaResponse from(
             RecordMedia recordMedia,
             ExpiringUrl viewUrl

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.travelrecord.dto;
 
+import com.mapmory.backend.travelrecord.TravelRecordCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -36,5 +37,19 @@ public record TravelRecordRequest(
             List<String> objectKeys
     ) {
         this(countryCode, provinceCode, districtCode, title, content, startDate, endDate, objectKeys, List.of());
+    }
+
+    public TravelRecordCommand toCommand() {
+        return new TravelRecordCommand(
+                countryCode,
+                provinceCode,
+                districtCode,
+                title,
+                content,
+                startDate,
+                endDate,
+                objectKeys,
+                tagIds
+        );
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -17,17 +17,18 @@ import com.mapmory.backend.auth.security.LoginMember;
 import com.mapmory.backend.common.ProblemDetailFactory;
 import com.mapmory.backend.common.handler.ValidationExceptionHandler;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.recordmedia.RecordMediaView;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.travelrecord.dto.CreateTravelRecordResponse;
-import com.mapmory.backend.travelrecord.dto.RegionDetailResponse;
-import com.mapmory.backend.travelrecord.dto.RegionItemResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListItemResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecord.dto.TravelRecordResponse;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -112,7 +115,7 @@ class TravelRecordControllerTest {
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
 
-        when(travelRecordService.create(MEMBER, request)).thenReturn(travelRecord);
+        when(travelRecordService.create(MEMBER, request.toCommand())).thenReturn(travelRecord);
 
         ResponseEntity<TravelRecordResponse<CreateTravelRecordResponse>> response =
                 travelRecordController.create(MEMBER, request);
@@ -121,7 +124,7 @@ class TravelRecordControllerTest {
         assertThat(response.getBody()).isEqualTo(
                 TravelRecordResponse.of(new CreateTravelRecordResponse(1L))
         );
-        verify(travelRecordService).create(MEMBER, request);
+        verify(travelRecordService).create(MEMBER, request.toCommand());
     }
 
     @ParameterizedTest
@@ -136,7 +139,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -155,7 +158,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -169,7 +172,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @ParameterizedTest
@@ -182,7 +185,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("countryCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -194,7 +197,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("provinceCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -206,7 +209,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("districtCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -220,7 +223,7 @@ class TravelRecordControllerTest {
                 null
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
-        when(travelRecordService.create(eq(MEMBER), any(TravelRecordRequest.class)))
+        when(travelRecordService.create(eq(MEMBER), any(TravelRecordCommand.class)))
                 .thenReturn(travelRecord);
 
         mockMvcWithLoginMember().perform(post("/api/v1/travel-records")
@@ -237,7 +240,7 @@ class TravelRecordControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.id").value(1L));
 
-        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -251,7 +254,7 @@ class TravelRecordControllerTest {
                 null
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
-        when(travelRecordService.create(eq(MEMBER), any(TravelRecordRequest.class)))
+        when(travelRecordService.create(eq(MEMBER), any(TravelRecordCommand.class)))
                 .thenReturn(travelRecord);
 
         mockMvcWithLoginMember().perform(post("/api/v1/travel-records")
@@ -260,12 +263,12 @@ class TravelRecordControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.id").value(1L));
 
-        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
     void 여행_일지_상세_조회를_서비스에_위임한다() {
-        TravelRecordDetailResponse detail = detail("제주 여행", "제주시를 걸었다.",
+        TravelRecordDetail detail = detail("제주 여행", "제주시를 걸었다.",
                 List.of("mapmory/travel-records/a.jpg"));
         when(travelRecordService.findById(MEMBER, 101L)).thenReturn(detail);
 
@@ -273,13 +276,15 @@ class TravelRecordControllerTest {
                 travelRecordController.findById(MEMBER, 101L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isEqualTo(TravelRecordResponse.of(detail));
+        assertThat(response.getBody()).isEqualTo(
+                TravelRecordResponse.of(TravelRecordDetailResponse.from(detail))
+        );
         verify(travelRecordService).findById(MEMBER, 101L);
     }
 
     @Test
     void 여행_일지_상세_HTTP_응답을_반환한다() throws Exception {
-        TravelRecordDetailResponse detail = detail("제주 여행", "제주시를 걸었다.",
+        TravelRecordDetail detail = detail("제주 여행", "제주시를 걸었다.",
                 List.of("mapmory/travel-records/a.jpg"));
         when(travelRecordService.findById(MEMBER, 101L)).thenReturn(detail);
 
@@ -300,25 +305,17 @@ class TravelRecordControllerTest {
 
     @Test
     void 여행_일지_목록에_썸네일_URL을_반환한다() throws Exception {
-        TravelRecordListResponse list = new TravelRecordListResponse(
-                List.of(new TravelRecordListItemResponse(
-                        101L,
-                        "제주 여행",
-                        "제주시",
-                        LocalDate.of(2026, 8, 11),
-                        LocalDate.of(2026, 8, 13),
+        TravelRecord travelRecord = travelRecord("제주 여행", "");
+        TravelRecordSummaries summaries = new TravelRecordSummaries(
+                new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1),
+                Map.of(),
+                Map.of(101L, new ExpiringUrl(
                         "https://download.example/mapmory/travel-records/a.jpg",
-                        300L,
-                        List.of()
-                )),
-                0,
-                20,
-                1,
-                1,
-                false
+                        300L
+                ))
         );
         when(travelRecordService.findAll(MEMBER, null, null, null, null, 0, 20))
-                .thenReturn(list);
+                .thenReturn(summaries);
 
         mockMvcWithLoginMember().perform(get("/api/v1/travel-records"))
                 .andExpect(status().isOk())
@@ -329,12 +326,12 @@ class TravelRecordControllerTest {
 
     @Test
     void 여행_일지를_수정한다() throws Exception {
-        TravelRecordDetailResponse detail = detail("수정된 제주 여행", "수정된 본문",
+        TravelRecordDetail detail = detail("수정된 제주 여행", "수정된 본문",
                 List.of("travel-records/10/b.jpg"));
         when(travelRecordService.update(
                 ArgumentMatchers.eq(MEMBER),
                 ArgumentMatchers.eq(101L),
-                ArgumentMatchers.any(TravelRecordRequest.class)
+                ArgumentMatchers.any(TravelRecordCommand.class)
         )).thenReturn(detail);
 
         mockMvcWithLoginMember().perform(put("/api/v1/travel-records/101")
@@ -369,32 +366,42 @@ class TravelRecordControllerTest {
         verify(travelRecordService).delete(MEMBER, 101L);
     }
 
-    private TravelRecordDetailResponse detail(String title, String content, List<String> objectKeys) {
-        return new TravelRecordDetailResponse(
-                101L,
+    private TravelRecordDetail detail(String title, String content, List<String> objectKeys) {
+        TravelRecord travelRecord = travelRecord(title, content);
+        List<RecordMediaView> mediaViews = IntStream.range(0, objectKeys.size())
+                .mapToObj(index -> {
+                    RecordMedia recordMedia = RecordMedia.of(
+                            travelRecord,
+                            objectKeys.get(index),
+                            null,
+                            index
+                    );
+                    ReflectionTestUtils.setField(recordMedia, "id", (long) index + 1);
+                    return new RecordMediaView(recordMedia, new ExpiringUrl(
+                            "https://download.example/" + objectKeys.get(index),
+                            300L
+                    ));
+                })
+                .toList();
+
+        return new TravelRecordDetail(travelRecord, mediaViews, List.of());
+    }
+
+    private TravelRecord travelRecord(String title, String content) {
+        Region country = Region.of(null, null, "KR", "대한민국", RegionType.COUNTRY);
+        Region province = Region.of(country, country, "49", "제주특별자치도", RegionType.PROVINCE);
+        Region district = Region.of(province, country, "50110", "제주시", RegionType.DISTRICT);
+        TravelRecord travelRecord = TravelRecord.of(
+                null,
+                district,
                 title,
                 content,
-                new RegionDetailResponse(
-                        new RegionItemResponse("KR", "대한민국"),
-                        new RegionItemResponse("49", "제주특별자치도"),
-                        new RegionItemResponse("50110", "제주시")
-                ),
                 LocalDate.of(2026, 8, 11),
-                LocalDate.of(2026, 8, 13),
-                objectKeys,
-                IntStream.range(0, objectKeys.size())
-                        .mapToObj(index -> new TravelRecordMediaResponse(
-                                (long) index + 1,
-                                objectKeys.get(index),
-                                "https://download.example/" + objectKeys.get(index),
-                                300L,
-                                index
-                        ))
-                        .toList(),
-                List.of(),
-                null,
-                null
+                LocalDate.of(2026, 8, 13)
         );
+        ReflectionTestUtils.setField(travelRecord, "id", 101L);
+
+        return travelRecord;
     }
 
     private String validCreateRequestBody(String title, String content) {

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -24,10 +24,6 @@ import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -103,7 +99,11 @@ class TravelRecordServiceTest {
                 travelRecordTagService,
                 tagService,
                 operationTimer,
-                recordMediaUrlService,
+                new TravelRecordAssembler(
+                        recordMediaRepository,
+                        travelRecordTagService,
+                        recordMediaUrlService
+                ),
                 FIXED_CLOCK,
                 uploadedObjectVerifier
         );
@@ -112,7 +112,7 @@ class TravelRecordServiceTest {
     @Test
     void 국가_단위_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP", null, null, "일본 여행", "", LocalDate.of(2026, 8, 11), null, List.of(), List.of(1L)
         );
 
@@ -120,7 +120,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result).isNotNull();
         verify(regionResolver).resolve("JP", null, null);
@@ -131,7 +131,7 @@ class TravelRecordServiceTest {
     @Test
     void 본문이_null이면_빈_문자열로_정규화해_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP", null, null, "일본 여행", null, LocalDate.of(2026, 8, 11), null, List.of(), List.of()
         );
 
@@ -139,7 +139,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getContent()).isEmpty();
     }
@@ -147,40 +147,40 @@ class TravelRecordServiceTest {
     @Test
     void 종료일이_시작일보다_빠르면_여행_일지를_생성하지_않는다() {
         LocalDate startDate = TODAY.minusDays(1);
-        TravelRecordRequest request = createRequest(startDate, startDate.minusDays(1));
+        TravelRecordCommand command = createCommand(startDate, startDate.minusDays(1));
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 시작일이_미래이면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest(
+        TravelRecordCommand command = createCommand(
                 TODAY.plusDays(1),
                 null
         );
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 종료일이_미래이면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest(
+        TravelRecordCommand command = createCommand(
                 TODAY,
                 TODAY.plusDays(1)
         );
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 시작일과_종료일이_오늘이면_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = createRequest(TODAY, TODAY);
+        TravelRecordCommand command = createCommand(TODAY, TODAY);
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getStartDate()).isEqualTo(TODAY);
         assertThat(result.getEndDate()).isEqualTo(TODAY);
@@ -188,34 +188,34 @@ class TravelRecordServiceTest {
 
     @Test
     void 대한민국_여행에_시도가_없으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("KR", null, null);
+        TravelRecordCommand command = createCommand("KR", null, null);
 
-        assertInvalidRegion(request, "REGION_REQUIRED");
+        assertInvalidRegion(command, "REGION_REQUIRED");
     }
 
     @Test
     void 대한민국_여행에_시군구가_없으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("KR", "49", null);
+        TravelRecordCommand command = createCommand("KR", "49", null);
 
-        assertInvalidRegion(request, "REGION_REQUIRED");
+        assertInvalidRegion(command, "REGION_REQUIRED");
     }
 
     @Test
     void 해외_여행에_하위_지역이_있으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("JP", "13", null);
+        TravelRecordCommand command = createCommand("JP", "13", null);
 
-        assertInvalidRegion(request, "INVALID_REGION_TYPE");
+        assertInvalidRegion(command, "INVALID_REGION_TYPE");
     }
 
     @Test
     void 대한민국_시군구_단위_여행_일지를_생성한다() {
         Region jejuCity = mock(Region.class);
-        TravelRecordRequest request = createRequest("KR", "49", "50110");
+        TravelRecordCommand command = createCommand("KR", "49", "50110");
         when(regionResolver.resolve("KR", "49", "50110")).thenReturn(jejuCity);
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getRegion()).isEqualTo(jejuCity);
         verify(travelRecordRepository).save(result);
@@ -244,35 +244,38 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(101L))
                 .thenReturn(recordMedia);
 
-        TravelRecordDetailResponse result = travelRecordService.findById(member, 101L);
+        TravelRecordDetail result = travelRecordService.findById(member, 101L);
 
-        assertThat(result.id()).isEqualTo(101L);
-        assertThat(result.content()).isEqualTo("제주시를 걸었다.");
-        assertThat(result.region().country().code()).isEqualTo("KR");
-        assertThat(result.region().province().code()).isEqualTo("49");
-        assertThat(result.region().district().code()).isEqualTo("50110");
-        assertThat(result.objectKeys()).containsExactly(
-                "mapmory/travel-records/a.jpg",
-                "mapmory/travel-records/b.jpg"
-        );
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::viewUrl)
+        Region resolvedRegion = result.travelRecord().getRegion();
+        assertThat(result.travelRecord().getId()).isEqualTo(101L);
+        assertThat(result.travelRecord().getContent()).isEqualTo("제주시를 걸었다.");
+        assertThat(resolvedRegion.getRoot().getRegionCode()).isEqualTo("KR");
+        assertThat(resolvedRegion.getParent().getRegionCode()).isEqualTo("49");
+        assertThat(resolvedRegion.getRegionCode()).isEqualTo("50110");
+        assertThat(result.recordMedia())
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly(
+                        "mapmory/travel-records/a.jpg",
+                        "mapmory/travel-records/b.jpg"
+                );
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.viewUrl().url())
                 .containsExactly(
                         "https://download.example/mapmory/travel-records/a.jpg",
                         "https://download.example/mapmory/travel-records/b.jpg"
                 );
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::viewUrlExpiresIn)
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.viewUrl().expiresIn())
                 .containsOnly(300L);
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::sortOrder)
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.recordMedia().getSortOrder())
                 .containsExactly(0, 1);
         verify(recordMediaUrlService).createViewUrl("mapmory/travel-records/a.jpg");
         verify(recordMediaUrlService).createViewUrl("mapmory/travel-records/b.jpg");
     }
 
-    private TravelRecordRequest createRequest(LocalDate startDate, LocalDate endDate) {
-        return new TravelRecordRequest(
+    private TravelRecordCommand createCommand(LocalDate startDate, LocalDate endDate) {
+        return new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -285,12 +288,12 @@ class TravelRecordServiceTest {
         );
     }
 
-    private TravelRecordRequest createRequest(
+    private TravelRecordCommand createCommand(
             String countryCode,
             String provinceCode,
             String districtCode
     ) {
-        return new TravelRecordRequest(
+        return new TravelRecordCommand(
                 countryCode,
                 provinceCode,
                 districtCode,
@@ -303,16 +306,16 @@ class TravelRecordServiceTest {
         );
     }
 
-    private void assertInvalidTravelDates(TravelRecordRequest request) {
-        assertThatThrownBy(() -> travelRecordService.create(member, request))
+    private void assertInvalidTravelDates(TravelRecordCommand command) {
+        assertThatThrownBy(() -> travelRecordService.create(member, command))
                 .isInstanceOfSatisfying(BusinessException.class, exception ->
                         assertThat(exception.getErrorCode().code())
                                 .isEqualTo("INVALID_TRAVEL_DATE_RANGE"));
         verify(travelRecordRepository, never()).save(any(TravelRecord.class));
     }
 
-    private void assertInvalidRegion(TravelRecordRequest request, String errorCode) {
-        assertThatThrownBy(() -> travelRecordService.create(member, request))
+    private void assertInvalidRegion(TravelRecordCommand command, String errorCode) {
+        assertThatThrownBy(() -> travelRecordService.create(member, command))
                 .isInstanceOfSatisfying(BusinessException.class, exception ->
                         assertThat(exception.getErrorCode().code()).isEqualTo(errorCode));
         verify(travelRecordRepository, never()).save(any(TravelRecord.class));
@@ -335,13 +338,12 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.findByTravelRecordIdOrderBySortOrderAsc(102L))
                 .thenReturn(List.of());
 
-        TravelRecordDetailResponse result = travelRecordService.findById(member, 102L);
+        TravelRecordDetail result = travelRecordService.findById(member, 102L);
 
-        assertThat(result.region().country().code()).isEqualTo("JP");
-        assertThat(result.region().province()).isNull();
-        assertThat(result.region().district()).isNull();
-        assertThat(result.objectKeys()).isEmpty();
-        assertThat(result.media()).isEmpty();
+        assertThat(result.travelRecord().getRegion().getRegionCode()).isEqualTo("JP");
+        assertThat(result.travelRecord().getRegion().getParent()).isNull();
+        assertThat(result.recordMedia()).isEmpty();
+        assertThat(result.mediaViews()).isEmpty();
         verify(recordMediaUrlService, never()).createViewUrl(anyString());
     }
 
@@ -370,7 +372,7 @@ class TravelRecordServiceTest {
         ReflectionTestUtils.setField(travelRecord, "id", 101L);
         RecordMedia mediaA = RecordMedia.of(travelRecord, "travel-records/10/a.jpg", null, 0);
         RecordMedia mediaB = RecordMedia.of(travelRecord, "travel-records/10/b.jpg", null, 1);
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "KR",
                 "49",
                 "50110",
@@ -378,8 +380,9 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 11),
                 LocalDate.of(2026, 8, 13),
-                List.of("travel-records/10/b.jpg", "travel-records/10/c.jpg")
-        );
+                List.of("travel-records/10/b.jpg", "travel-records/10/c.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("KR", "49", "50110")).thenReturn(district);
@@ -390,15 +393,17 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.saveAll(anyList()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecordDetailResponse result = travelRecordService.update(member, 101L, request);
+        TravelRecordDetail result = travelRecordService.update(member, 101L, command);
 
-        assertThat(result.title()).isEqualTo("수정된 제목");
-        assertThat(result.content()).isEqualTo("수정된 본문");
-        assertThat(result.region().district().code()).isEqualTo("50110");
-        assertThat(result.objectKeys()).containsExactly(
-                "travel-records/10/b.jpg",
-                "travel-records/10/c.jpg"
-        );
+        assertThat(result.travelRecord().getTitle()).isEqualTo("수정된 제목");
+        assertThat(result.travelRecord().getContent()).isEqualTo("수정된 본문");
+        assertThat(result.travelRecord().getRegion().getRegionCode()).isEqualTo("50110");
+        assertThat(result.recordMedia())
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly(
+                        "travel-records/10/b.jpg",
+                        "travel-records/10/c.jpg"
+                );
         assertThat(mediaB.getSortOrder()).isZero();
         verify(recordMediaRepository).deleteAll(org.mockito.ArgumentMatchers.argThat(records -> {
             java.util.Iterator<? extends RecordMedia> iterator = records.iterator();
@@ -412,7 +417,7 @@ class TravelRecordServiceTest {
     @Test
     void 수정_요청의_중복_Object_Key를_거부한다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -420,12 +425,13 @@ class TravelRecordServiceTest {
                 "본문",
                 LocalDate.of(2026, 8, 11),
                 null,
-                List.of("travel-records/10/a.jpg", "travel-records/10/a.jpg")
-        );
+                List.of("travel-records/10/a.jpg", "travel-records/10/a.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "INVALID_OBJECT_KEY");
+        assertError(() -> travelRecordService.update(member, 101L, command), "INVALID_OBJECT_KEY");
         verify(regionResolver, never()).resolve("JP", null, null);
     }
 
@@ -440,7 +446,7 @@ class TravelRecordServiceTest {
                 LocalDate.of(2026, 8, 11),
                 null
         );
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -448,8 +454,9 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 12),
                 null,
-                List.of("travel-records/20/used.jpg")
-        );
+                List.of("travel-records/20/used.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
@@ -458,7 +465,7 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.findByObjectKeyIn(List.of("travel-records/20/used.jpg")))
                 .thenReturn(List.of(mock(RecordMedia.class)));
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "INVALID_OBJECT_KEY");
+        assertError(() -> travelRecordService.update(member, 101L, command), "INVALID_OBJECT_KEY");
         assertThat(travelRecord.getTitle()).isEqualTo("일본 여행");
         verify(recordMediaRepository, never()).saveAll(anyList());
     }
@@ -480,7 +487,7 @@ class TravelRecordServiceTest {
                 null,
                 0
         );
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -488,8 +495,9 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 12),
                 null,
-                null
-        );
+                null,
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
@@ -498,9 +506,9 @@ class TravelRecordServiceTest {
         when(recordMediaRepository.saveAll(anyList()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecordDetailResponse result = travelRecordService.update(member, 101L, request);
+        TravelRecordDetail result = travelRecordService.update(member, 101L, command);
 
-        assertThat(result.objectKeys()).isEmpty();
+        assertThat(result.recordMedia()).isEmpty();
         verify(recordMediaRepository).deleteAll(org.mockito.ArgumentMatchers.argThat(records ->
                 records.iterator().hasNext()
         ));
@@ -509,7 +517,7 @@ class TravelRecordServiceTest {
 
     @Test
     void 없거나_다른_회원의_일지_수정을_거부한다() {
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -517,12 +525,13 @@ class TravelRecordServiceTest {
                 "본문",
                 LocalDate.of(2026, 8, 11),
                 null,
+                List.of(),
                 List.of()
-        );
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.empty());
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "TRAVEL_RECORD_NOT_FOUND");
+        assertError(() -> travelRecordService.update(member, 101L, command), "TRAVEL_RECORD_NOT_FOUND");
         verify(regionResolver, never()).resolve("JP", null, null);
         verify(recordMediaRepository, never()).findByTravelRecordIdOrderBySortOrderAsc(101L);
     }
@@ -530,9 +539,7 @@ class TravelRecordServiceTest {
     @Test
     void 지역_필터_없이_일지_목록을_조회한다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
-        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
@@ -545,12 +552,12 @@ class TravelRecordServiceTest {
                         )
                 ));
 
-        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+        TravelRecordSummaries result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result.totalElements()).isEqualTo(1);
-        assertThat(result.items().getFirst().thumbnailUrl())
+        assertThat(result.travelRecords().getTotalElements()).isEqualTo(1);
+        assertThat(result.thumbnailUrlOf(travelRecord).url())
                 .isEqualTo("https://download.example/mapmory/travel-records/a.jpg");
-        assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isEqualTo(300L);
+        assertThat(result.thumbnailUrlOf(travelRecord).expiresIn()).isEqualTo(300L);
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
         verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(null), captor.capture());
         assertThat(captor.getValue().getPageSize()).isEqualTo(20);
@@ -560,18 +567,15 @@ class TravelRecordServiceTest {
     @Test
     void 미디어가_없는_일지_목록은_썸네일_정보가_null이다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
-        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
         when(recordMediaUrlService.createThumbnailUrls(List.of(101L))).thenReturn(Map.of());
 
-        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+        TravelRecordSummaries result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result.items().getFirst().thumbnailUrl()).isNull();
-        assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isNull();
+        assertThat(result.thumbnailUrlOf(travelRecord)).isNull();
         verify(recordMediaUrlService).createThumbnailUrls(List.of(101L));
     }
 
@@ -584,7 +588,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(1L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", null, null, null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", null, null, null, 0, 20).travelRecords()).isEmpty();
     }
 
     @Test
@@ -597,7 +601,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(2L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", "49", null, null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", "49", null, null, 0, 20).travelRecords()).isEmpty();
     }
 
     @Test
@@ -611,7 +615,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(3L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", null, 0, 20).travelRecords()).isEmpty();
     }
 
     @Test
@@ -620,11 +624,11 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(7L), any(Pageable.class)))
                 .thenReturn(expected);
 
-        TravelRecordListResponse result = travelRecordService.findAll(
+        TravelRecordSummaries result = travelRecordService.findAll(
                 member, null, null, null, 7L, 0, 20
         );
 
-        assertThat(result.items()).isEmpty();
+        assertThat(result.travelRecords()).isEmpty();
         verify(tagService).getOwnedTag(member, 7L);
         verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(7L), any(Pageable.class));
     }


### PR DESCRIPTION
## 요약

`TravelRecordService`가 웹 계층 DTO(`TravelRecordRequest`, `TravelRecordDetailResponse`, `TravelRecordListResponse`)에 의존하지 않도록 정리했습니다.
입력은 서비스 계층이 소유한 **커맨드**로, 출력은 **도메인 조합 결과**로 바꾸고, 조합에 필요한 조회는 **어셈블러**로 분리했습니다.
API 스펙과 응답 JSON은 그대로입니다.

## 배경

[#200](https://github.com/woowacourse-teams/2026-Mapmory/pull/200)에서 `TagService`에 적용한 것과 같은 정리입니다.
요청·응답 DTO는 HTTP 계약이라, 서비스가 이를 직접 다루면 API 필드가 바뀔 때마다 서비스 시그니처와 서비스 테스트가 함께 흔들립니다.

다만 Tag와 달리 `TravelRecord`는 그대로 옮길 수 없었습니다.

- **입력**: `TravelRecordRequest`는 속성이 9개라 Tag처럼 원시 값으로 풀 수 없습니다.
- **출력**: 상세·목록 응답이 `TravelRecord` 하나가 아니라 **미디어 + 태그 + presigned URL**의 조합이라, 도메인 객체 하나를 반환하는 것으로는 부족합니다.

## 변경 내용

| 변경 전 | 변경 후 |
| --- | --- |
| `TravelRecord create(Member, TravelRecordRequest)` | `TravelRecord create(Member, TravelRecordCommand)` |
| `TravelRecordDetailResponse findById(Member, Long)` | `TravelRecordDetail findById(Member, Long)` |
| `TravelRecordDetailResponse update(Member, Long, TravelRecordRequest)` | `TravelRecordDetail update(Member, Long, TravelRecordCommand)` |
| `TravelRecordListResponse findAll(...)` | `TravelRecordSummaries findAll(...)` |

**새 타입** (모두 `com.mapmory.backend.travelrecord`, 웹 계층을 모릅니다)

- `TravelRecordCommand` — 생성·수정 입력 커맨드. `objectKeys`·`tagIds`의 null을 빈 리스트로 정규화해, 서비스에 흩어져 있던 null 처리를 한곳으로 모았습니다.
- `TravelRecordDetail` — `TravelRecord` + `List<RecordMediaView>` + `List<Tag>`.
- `TravelRecordSummaries` — `Page<TravelRecord>` + 태그 맵 + 썸네일 URL 맵. `tagsOf`, `thumbnailUrlOf`로 조회합니다.
- `TravelRecordAssembler` — 미디어·태그·조회 URL을 모아 위 두 결과를 조립합니다. `RecordMediaRepository`, `TravelRecordTagService`, `RecordMediaUrlService`를 직접 들고 있습니다.
- `RecordMediaView` (`recordmedia` 패키지) — 미디어와 presigned URL의 조합.

**웹 계층**

- `TravelRecordRequest.toCommand()`로 컨트롤러에서 커맨드로 변환합니다.
- `TravelRecordDetailResponse.from(TravelRecordDetail)`, `TravelRecordListResponse.from(TravelRecordSummaries)`로 응답을 조립합니다.

## 주요 결정

**커맨드를 만든 이유.** 속성이 하나뿐이던 Tag는 원시 값으로 풀었지만, 9개짜리 `TravelRecordRequest`를 그렇게 풀면 파라미터 순서만 바꿔도 컴파일이 통과하는 위험한 시그니처가 됩니다. 서비스 계층이 소유한 레코드를 두는 쪽이 안전합니다.

**변환 방향은 `Request → Command`.** `TravelRecordRequest`가 `TravelRecordCommand`를 알고, 그 반대는 아닙니다. 웹이 서비스를 아는 것은 정상적인 의존 방향이라 컨트롤러에 매핑 코드를 늘어놓지 않아도 됩니다.

**어셈블러를 분리한 이유.** `findById`와 `update`가 같은 조합(미디어 + 태그 + URL)을 필요로 하는데, `update`는 이미 트랜잭션 안에서 계산해 둔 미디어·태그를 그대로 써야 합니다. 그래서 어셈블러에 두 가지 진입점을 뒀습니다.

- `assembleDetail(TravelRecord)` — 리포지토리에서 직접 조회 (`findById`)
- `assembleDetail(TravelRecord, List<RecordMedia>, List<Tag>)` — 이미 가진 값을 사용 (`update`)

덕분에 `TravelRecordService`에서 `RecordMediaUrlService` 의존이 사라졌고, 응답 조립 책임이 서비스 밖으로 빠졌습니다.

**`RecordMediaView`로 순서를 보장.** URL을 `Map<String, ExpiringUrl>`로 넘기면 objectKey 중복·정렬 순서에 기대게 됩니다. 미디어와 URL을 짝지은 리스트로 넘겨 `sortOrder` 순서가 그대로 응답에 반영되도록 했습니다.

**서비스 테스트를 도메인 기준으로 다시 씀.** `result.region().district().code()` 같은 응답 DTO 검증을 `result.travelRecord().getRegion().getRegionCode()`처럼 도메인 검증으로 바꿨습니다. 이제 응답 필드가 바뀌어도 서비스 테스트는 흔들리지 않습니다. 어셈블러는 기존 mock들로 실제 인스턴스를 만들어 주입해, `createViewUrl`·`createThumbnailUrls` 호출 검증은 그대로 유지했습니다.

## 한계

- 동작 변경 없는 순수 리팩터링입니다. API 응답 JSON은 그대로고, 컨트롤러 테스트의 `jsonPath` 검증도 손대지 않았습니다.
- `findAll`의 파라미터 7개(지역 필터 3 + 태그 + 페이지네이션 2)는 그대로 뒀습니다. 요청 DTO가 아니라 쿼리 파라미터라 이번 범위 밖으로 봤는데, 조회 조건 커맨드로 묶는 편이 낫다면 후속으로 하겠습니다.
- `UploadService`, `LaunchWaitlistService`, `AuthService`, `RegionMapSummaryService`에 같은 문제가 남아 있습니다. 별도 PR로 이어가려 합니다.
- `TravelRecordAssembler`의 단위 테스트는 따로 추가하지 않았습니다. 기존 서비스 테스트가 실제 어셈블러 인스턴스를 거쳐 조합 결과를 검증하고 있습니다.

## 확인

- [x] 로컬에서 실행 확인 (`./gradlew test` — 56개 클래스 / 247개 테스트 전부 통과)
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [ ] 새 환경변수를 추가했다면 `.env.example` 갱신 — 해당 없음
- [ ] DB 스키마를 변경했다면 **새 마이그레이션 파일**로 추가 (기존 파일 수정 X) — 해당 없음
- [ ] 실행 방법이나 환경 설정이 바뀌었다면 README 갱신 — 해당 없음

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fwhim5hLJT6Ysjt7WVwv4o
