### PR TITLE
feat: 여행 통계 조회 API 추가

### DIFF
--- a/api.md
+++ b/api.md
@@ -1,6 +1,6 @@
 # Mapmory API 명세
 
-> 기준일: 2026-08-28 · 범위: 인증, 지역 선택, 지도 마킹, 여행 기록, 이미지 첨부, 사용자 생성 태그
+> 기준일: 2026-08-31 · 범위: 인증, 지역 선택, 지도 마킹, 여행 기록, 여행 통계, 이미지 첨부, 사용자 생성 태그
 
 이 문서는 Mapmory API의 기준 계약이다. API 목록의 `구현 전 설계` 항목은 구현에 앞서 합의한 목표 계약이며, 구현이 끝나면 `구현됨`으로 상태를 변경한다.
 
@@ -31,6 +31,7 @@
 | 구현됨 | `GET` | `/travel-records/{travelRecordId}` | 내 여행 기록 상세 조회 |
 | 구현됨 | `PUT` | `/travel-records/{travelRecordId}` | 내 여행 기록 전체 수정 |
 | 구현됨 | `DELETE` | `/travel-records/{travelRecordId}` | 내 여행 기록 삭제 |
+| 구현됨 | `GET` | `/travel-records/statistics` | 내 전체 여행 통계 조회 |
 | 구현됨 | `GET` | `/travel-records/map-summary/regions/roots` | 루트 Region별 지도 색칠 정보 조회 |
 | 구현됨 | `GET` | `/travel-records/map-summary/regions/{regionId}/children` | 직속 하위 Region별 지도 색칠 정보 조회 |
 | 구현 전 설계 | `POST` | `/tags` | 내 태그 생성 |
@@ -746,7 +747,63 @@ Authorization: Bearer {accessToken}
 - 기존 `count`와 `level` 계약은 유지한다. 태그 필터 적용 후의 `count`를 현재 `LevelPolicy` 기준으로 `NONE`, `LOW`, `MEDIUM`, `HIGH`로 변환한다.
 - 데이터 규모와 응답 시간을 측정하기 전에는 별도 태그–지역 집계 테이블을 만들지 않는다. 원본 관계를 실시간 집계해 기록·태그 변경과 지도 결과의 동기화 문제를 피한다.
 
-## 7. 구현 전 확인 사항
+## 7. 여행 통계 API
+
+여행 통계는 현재 회원이 작성한 전체 기간의 여행 기록을 기준으로 실시간 집계한다. 별도 통계
+테이블을 두지 않으므로 여행 기록과 미디어가 변경되면 다음 조회부터 바로 반영된다.
+
+### 내 전체 여행 통계 조회
+
+`GET /api/v1/travel-records/statistics`
+
+#### Response `200 OK`
+
+```json
+{
+  "data": {
+    "recordCount": 24,
+    "mediaCount": 138,
+    "visitedCountryCount": 3,
+    "visitedKoreaDistrictCount": 8,
+    "visitedCountryCodes": ["JP", "KR", "US"],
+    "topRegions": [
+      {
+        "regionId": 10,
+        "code": "11",
+        "regionType": "PROVINCE",
+        "name": "서울특별시",
+        "recordCount": 7
+      },
+      {
+        "regionId": 2,
+        "code": "JP",
+        "regionType": "COUNTRY",
+        "name": "일본",
+        "recordCount": 4
+      }
+    ]
+  }
+}
+```
+
+| 필드 | 설명 |
+| --- | --- |
+| `recordCount` | 현재 회원의 전체 여행 기록 수 |
+| `mediaCount` | 현재 회원의 여행 기록에 연결된 전체 미디어 수 |
+| `visitedCountryCount` | 기록이 하나 이상 있는 고유 국가 수 |
+| `visitedKoreaDistrictCount` | 기록이 하나 이상 있는 대한민국 고유 시·군·구 수 |
+| `visitedCountryCodes` | 방문 국가 ISO 코드의 오름차순 목록. 길이는 `visitedCountryCount`와 같음 |
+| `topRegions` | 현재 표시 단계로 합산한 기록 수 상위 3개 |
+
+`topRegions`는 `recordCount DESC, regionId ASC`로 정렬한다. 대한민국 `DISTRICT` 기록은 직속
+`PROVINCE`로 올려 합산하고, 해외 기록은 `COUNTRY`로 합산한다. 따라서 현재 응답은 대한민국 시·도와
+해외 국가가 함께 포함될 수 있다. 기록이 없으면 모든 숫자는 `0`, 목록은 빈 배열이다.
+
+이 집계 단계는 대한민국은 시·군·구, 해외는 국가 단위로 저장하는 현재 MVP 계약에 맞춘 것이다.
+해외 행정구역 저장을 지원할 때 필드와 집계 단계, API 버전을 함께 재검토해야 한다. 자세한 결정과
+변경 조건은 [ADR 0016](backend/docs/adr/0016-travel-statistics-read-model.md)을 참고한다.
+
+## 8. 구현 전 확인 사항
 
 - `tag`, `travel_record_tag` Flyway 마이그레이션과 JPA 모델 추가
 - 태그 이름 정규화 규칙을 서버와 클라이언트에서 동일하게 적용

--- a/backend/docs/adr/0016-travel-statistics-read-model.md
+++ b/backend/docs/adr/0016-travel-statistics-read-model.md
@@ -32,8 +32,6 @@
 - 집계 쿼리와 응답 조합은 `travelrecord.statistics` 패키지에 둔다.
 - Service는 HTTP 응답 DTO가 아닌 `TravelStatistics` 읽기 모델을 반환하고, Controller가 이를
   `TravelStatisticsResponse`로 변환한다.
-- 통계 조회는 중요한 내부 연산으로 측정하되 회원 ID 같은 고카디널리티 값은 메트릭 태그로 남기지
-  않는다.
 
 ### 필드별 집계 규칙
 

--- a/backend/docs/adr/0016-travel-statistics-read-model.md
+++ b/backend/docs/adr/0016-travel-statistics-read-model.md
@@ -1,0 +1,98 @@
+# ADR 0016. 여행 통계 읽기 모델과 지역 집계 단계
+
+- 상태: 채택
+- 날짜: 2026-08-31
+- 관련: ADR 0008, ADR 0009, `TravelStatisticsRepository`
+
+---
+
+## 문제
+
+마이페이지에서 전체 여행 기록 수, 첨부 미디어 수, 방문 국가와 국내 방문 지역, 자주 기록한
+지역을 한 번에 보여줄 필요가 있다. 이 값은 모두 `travel_record`, `record_media`, `region`의
+파생 값이므로 별도 통계 엔티티에 저장하면 기록 생성·수정·삭제와 통계 값 사이의 정합성을 추가로
+관리해야 한다.
+
+현재 여행 기록의 지역 정밀도는 국가에 따라 다르다.
+
+- 대한민국 기록은 `DISTRICT` Region에 저장한다.
+- 해외 기록은 MVP에서 `COUNTRY` Region에 저장한다.
+
+따라서 인기 지역을 하나의 목록으로 반환하려면 대한민국과 해외에 서로 다른 표시 단계를 적용해야
+한다. 이 비대칭을 숨기면 나중에 해외 `PROVINCE`·`DISTRICT` 저장을 지원할 때 같은 필드의 의미가
+조용히 달라질 수 있다.
+
+## 결정
+
+### API와 읽기 모델
+
+- `GET /api/v1/travel-records/statistics`에서 인증된 현재 회원의 전체 기간 통계를 반환한다.
+- 성공 응답은 기존 API와 같이 `data`로 감싼다.
+- 통계는 별도 엔티티나 테이블로 저장하지 않고 원본 테이블을 실시간 집계하는 읽기 모델로 구현한다.
+- 집계 쿼리와 응답 조합은 `travelrecord.statistics` 패키지에 둔다.
+- Service는 HTTP 응답 DTO가 아닌 `TravelStatistics` 읽기 모델을 반환하고, Controller가 이를
+  `TravelStatisticsResponse`로 변환한다.
+- 통계 조회는 중요한 내부 연산으로 측정하되 회원 ID 같은 고카디널리티 값은 메트릭 태그로 남기지
+  않는다.
+
+### 필드별 집계 규칙
+
+| 필드 | 규칙 |
+| --- | --- |
+| `recordCount` | 현재 회원의 `travel_record` 행 수 |
+| `mediaCount` | 현재 회원의 여행 기록에 연결된 `record_media` 행 수 |
+| `visitedCountryCount` | 기록 Region 자신 또는 `root_id`가 가리키는 `COUNTRY`의 고유 코드 개수 |
+| `visitedKoreaDistrictCount` | 국가 루트 코드가 `KR`이고 기록 Region 타입이 `DISTRICT`인 Region의 고유 개수 |
+| `visitedCountryCodes` | 방문 국가의 `region_code` 목록. 코드 오름차순이며 개수는 `visitedCountryCount`와 같다 |
+| `topRegions` | 현재 지역 표시 단계로 올려 집계한 기록 수 상위 3개 |
+
+`topRegions`의 현재 표시 단계는 다음과 같다.
+
+- 대한민국 `DISTRICT` 기록은 직속 부모 `PROVINCE`로 올려 집계한다.
+- 대한민국 `PROVINCE` 직접 기록이 남아 있으면 해당 `PROVINCE`에 집계한다.
+- 해외 기록은 국가 루트 `COUNTRY`로 집계한다.
+- `recordCount DESC, regionId ASC`로 정렬해 동률 결과를 결정적으로 만든다.
+- 각 항목은 이름만 반환하지 않고 `regionId`, `code`, `regionType`을 함께 반환한다.
+
+기록이 없는 회원에게는 오류 대신 숫자 `0`과 빈 배열을 반환한다.
+
+요약 쿼리는 `record_media`를 주 집계에 직접 조인하지 않는다. 한 기록에 미디어가 여러 개면 조인
+결과가 증폭되어 다른 카운트에도 `DISTINCT`가 필요해지기 때문이다. 기록·방문 지역은 회원의
+`travel_record` 집합에서 한 번 집계하고, 미디어 수만 인덱스 조회가 가능한 스칼라 서브쿼리에서
+계산한다. 방문 국가 코드 목록과 상위 지역은 반환 형태와 정렬 기준이 달라 별도 쿼리로 조회한다.
+`visitedCountryCount`는 이미 중복 제거된 `visitedCountryCodes`의 크기로 계산해 같은 국가 집계를 두 번
+수행하지 않고 두 필드가 항상 일치하도록 한다.
+
+## 해외 지역 확장 시 재검토
+
+현재 `topRegions`는 대한민국의 시·도와 해외 국가를 같은 목록에서 비교한다. 이는 해외 기록이 국가
+단위뿐인 MVP를 위한 의도적인 임시 규칙이며 모든 국가에 일반화된 통계 모델이 아니다.
+
+해외 `PROVINCE` 또는 `DISTRICT` 저장을 허용하는 작업을 시작할 때 다음 항목을 함께 재검토한다.
+
+1. 모든 국가를 동일한 Region 단계에서 비교할지, `topCountries`와 국가별 `topSubregions`로 분리할지
+   결정한다.
+2. 대한민국 전용 `visitedKoreaDistrictCount`를 국가별 하위 지역 통계 구조로 대체할지 결정한다.
+3. 기존 필드의 의미가 달라지면 응답을 조용히 변경하지 않고 새 필드 또는 API 버전을 사용한다.
+4. 국가별 행정 단계 차이를 `region_code` 접두사로 추론하지 않고 `region_type`, `parent_id`,
+   `root_id`와 별도 국가별 정책으로 처리한다.
+5. 외국 도시 이름을 인기 지역에 노출하려면 먼저 해당 도시를 Region으로 저장하는 쓰기 계약과
+   데이터 마이그레이션을 설계한다.
+
+이 재검토가 끝나기 전에는 해외 하위 Region 데이터가 존재하더라도 현재 통계에서는 국가 루트로
+올려 집계한다.
+
+## 테스트 범위
+
+- Controller MVC 테스트로 인증과 JSON 계약을 검증한다.
+- Service 단위 테스트로 Projection을 응답 DTO로 변환하는 흐름을 검증한다.
+- Repository 쿼리는 MySQL Testcontainers에서 다른 회원 제외, 중복 제거, 국내·해외 표시 단계와
+  상위 3개 정렬을 검증한다.
+
+## 결과
+
+- 기록 변경과 통계가 별도 동기화 작업 없이 즉시 일치한다.
+- 현재 국내 상세·해외 국가 단위 저장 정책에서 마이페이지가 필요한 통계를 한 번에 조회한다.
+- 대한민국 중심의 임시 집계 규칙과 해외 지역 확장 시의 변경 조건이 명시적으로 남는다.
+- 데이터가 커져 실시간 집계가 목표 응답 시간을 만족하지 못하면 실행 계획과 운영 메트릭을 근거로
+  인덱스 또는 사전 집계 읽기 모델을 별도 ADR에서 결정한다.

--- a/backend/docs/adr/README.md
+++ b/backend/docs/adr/README.md
@@ -19,3 +19,4 @@ Mapmory 백엔드의 주요 설계 결정을 기록한다.
 | [0013](0013-user-created-tags-and-travel-record-association.md) | 사용자 생성 태그와 여행 기록 연결 설계 | 채택 |
 | [0014](0014-application-logging-and-metrics.md) | 애플리케이션 로그와 메트릭 공통 관측 규칙 | 채택 |
 | [0015](0015-guest-login.md) | 게스트 로그인의 인증 파이프라인 재사용과 회원 승격 | 채택 |
+| [0016](0016-travel-statistics-read-model.md) | 여행 통계 읽기 모델과 지역 집계 단계 | 채택 |

--- a/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
+++ b/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
@@ -3,5 +3,6 @@ package com.mapmory.backend.common.monitoring;
 public enum MonitoredOperation {
     MEDIA_EXISTENCE_CHECK,
     MEDIA_SYNC,
-    MAP_SUMMARY_QUERY
+    MAP_SUMMARY_QUERY,
+    TRAVEL_STATISTICS_QUERY
 }

--- a/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
+++ b/backend/src/main/java/com/mapmory/backend/common/monitoring/MonitoredOperation.java
@@ -3,6 +3,5 @@ package com.mapmory.backend.common.monitoring;
 public enum MonitoredOperation {
     MEDIA_EXISTENCE_CHECK,
     MEDIA_SYNC,
-    MAP_SUMMARY_QUERY,
-    TRAVEL_STATISTICS_QUERY
+    MAP_SUMMARY_QUERY
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/controller/TravelStatisticsController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/controller/TravelStatisticsController.java
@@ -1,0 +1,28 @@
+package com.mapmory.backend.travelrecord.statistics.controller;
+
+import com.mapmory.backend.auth.security.LoginMember;
+import com.mapmory.backend.common.dto.ApiResponse;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.travelrecord.statistics.dto.TravelStatisticsResponse;
+import com.mapmory.backend.travelrecord.statistics.model.TravelStatistics;
+import com.mapmory.backend.travelrecord.statistics.service.TravelStatisticsService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/travel-records/statistics")
+public class TravelStatisticsController {
+
+    private final TravelStatisticsService travelStatisticsService;
+
+    public TravelStatisticsController(TravelStatisticsService travelStatisticsService) {
+        this.travelStatisticsService = travelStatisticsService;
+    }
+
+    @GetMapping
+    public ApiResponse<TravelStatisticsResponse> getStatistics(@LoginMember Member member) {
+        TravelStatistics statistics = travelStatisticsService.getStatistics(member);
+        return ApiResponse.from(TravelStatisticsResponse.from(statistics));
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/dto/TopRegionResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/dto/TopRegionResponse.java
@@ -1,0 +1,23 @@
+package com.mapmory.backend.travelrecord.statistics.dto;
+
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.statistics.model.TopRegionStatistics;
+
+public record TopRegionResponse(
+        Long regionId,
+        String code,
+        RegionType regionType,
+        String name,
+        long recordCount
+) {
+
+    public static TopRegionResponse from(TopRegionStatistics statistics) {
+        return new TopRegionResponse(
+                statistics.regionId(),
+                statistics.code(),
+                statistics.regionType(),
+                statistics.name(),
+                statistics.recordCount()
+        );
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/dto/TravelStatisticsResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/dto/TravelStatisticsResponse.java
@@ -1,0 +1,27 @@
+package com.mapmory.backend.travelrecord.statistics.dto;
+
+import com.mapmory.backend.travelrecord.statistics.model.TravelStatistics;
+import java.util.List;
+
+public record TravelStatisticsResponse(
+        long recordCount,
+        long mediaCount,
+        long visitedCountryCount,
+        long visitedKoreaDistrictCount,
+        List<String> visitedCountryCodes,
+        List<TopRegionResponse> topRegions
+) {
+
+    public static TravelStatisticsResponse from(TravelStatistics statistics) {
+        return new TravelStatisticsResponse(
+                statistics.recordCount(),
+                statistics.mediaCount(),
+                statistics.visitedCountryCount(),
+                statistics.visitedKoreaDistrictCount(),
+                List.copyOf(statistics.visitedCountryCodes()),
+                statistics.topRegions().stream()
+                        .map(TopRegionResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/model/TopRegionStatistics.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/model/TopRegionStatistics.java
@@ -1,0 +1,12 @@
+package com.mapmory.backend.travelrecord.statistics.model;
+
+import com.mapmory.backend.region.RegionType;
+
+public record TopRegionStatistics(
+        Long regionId,
+        String code,
+        RegionType regionType,
+        String name,
+        long recordCount
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/model/TravelStatistics.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/model/TravelStatistics.java
@@ -1,0 +1,18 @@
+package com.mapmory.backend.travelrecord.statistics.model;
+
+import java.util.List;
+
+public record TravelStatistics(
+        long recordCount,
+        long mediaCount,
+        long visitedCountryCount,
+        long visitedKoreaDistrictCount,
+        List<String> visitedCountryCodes,
+        List<TopRegionStatistics> topRegions
+) {
+
+    public TravelStatistics {
+        visitedCountryCodes = List.copyOf(visitedCountryCodes);
+        topRegions = List.copyOf(topRegions);
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/repository/TopRegionQueryResult.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/repository/TopRegionQueryResult.java
@@ -1,0 +1,14 @@
+package com.mapmory.backend.travelrecord.statistics.repository;
+
+public interface TopRegionQueryResult {
+
+    Long getRegionId();
+
+    String getRegionCode();
+
+    String getRegionType();
+
+    String getName();
+
+    long getRecordCount();
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/repository/TravelStatisticsRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/repository/TravelStatisticsRepository.java
@@ -1,0 +1,76 @@
+package com.mapmory.backend.travelrecord.statistics.repository;
+
+import com.mapmory.backend.travelrecord.TravelRecord;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface TravelStatisticsRepository extends Repository<TravelRecord, Long> {
+
+    @Query(value = """
+            SELECT COUNT(travel_record.id) AS recordCount,
+                   (
+                       SELECT COUNT(record_media.id)
+                       FROM record_media
+                       JOIN travel_record media_record
+                         ON media_record.id = record_media.travel_record_id
+                       WHERE media_record.member_id = :memberId
+                   ) AS mediaCount,
+                   COUNT(DISTINCT CASE
+                       WHEN country_region.region_code = 'KR'
+                        AND recorded_region.region_type = 'DISTRICT'
+                       THEN recorded_region.id
+                   END) AS visitedKoreaDistrictCount
+            FROM travel_record
+            JOIN region recorded_region
+              ON recorded_region.id = travel_record.region_id
+            JOIN region country_region
+              ON country_region.id = COALESCE(recorded_region.root_id, recorded_region.id)
+            WHERE travel_record.member_id = :memberId
+            """, nativeQuery = true)
+    TravelStatisticsSummaryQueryResult findSummary(@Param("memberId") Long memberId);
+
+    @Query(value = """
+            SELECT DISTINCT country_region.region_code
+            FROM travel_record
+            JOIN region recorded_region
+              ON recorded_region.id = travel_record.region_id
+            JOIN region country_region
+              ON country_region.id = COALESCE(recorded_region.root_id, recorded_region.id)
+            WHERE travel_record.member_id = :memberId
+            ORDER BY country_region.region_code
+            """, nativeQuery = true)
+    List<String> findVisitedCountryCodes(@Param("memberId") Long memberId);
+
+    @Query(value = """
+            SELECT aggregate_region.id AS regionId,
+                   aggregate_region.region_code AS regionCode,
+                   aggregate_region.region_type AS regionType,
+                   aggregate_region.name AS name,
+                   COUNT(travel_record.id) AS recordCount
+            FROM travel_record
+            JOIN region recorded_region
+              ON recorded_region.id = travel_record.region_id
+            JOIN region country_region
+              ON country_region.id = COALESCE(recorded_region.root_id, recorded_region.id)
+            JOIN region aggregate_region
+              ON aggregate_region.id = CASE
+                  WHEN country_region.region_code = 'KR'
+                   AND recorded_region.region_type = 'DISTRICT'
+                  THEN recorded_region.parent_id
+                  WHEN country_region.region_code = 'KR'
+                   AND recorded_region.region_type = 'PROVINCE'
+                  THEN recorded_region.id
+                  ELSE country_region.id
+              END
+            WHERE travel_record.member_id = :memberId
+            GROUP BY aggregate_region.id,
+                     aggregate_region.region_code,
+                     aggregate_region.region_type,
+                     aggregate_region.name
+            ORDER BY COUNT(travel_record.id) DESC, aggregate_region.id ASC
+            LIMIT 3
+            """, nativeQuery = true)
+    List<TopRegionQueryResult> findTopRegions(@Param("memberId") Long memberId);
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/repository/TravelStatisticsSummaryQueryResult.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/repository/TravelStatisticsSummaryQueryResult.java
@@ -1,0 +1,10 @@
+package com.mapmory.backend.travelrecord.statistics.repository;
+
+public interface TravelStatisticsSummaryQueryResult {
+
+    long getRecordCount();
+
+    long getMediaCount();
+
+    long getVisitedKoreaDistrictCount();
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/service/TravelStatisticsService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/service/TravelStatisticsService.java
@@ -1,7 +1,5 @@
 package com.mapmory.backend.travelrecord.statistics.service;
 
-import com.mapmory.backend.common.monitoring.MonitoredOperation;
-import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.travelrecord.statistics.model.TopRegionStatistics;
@@ -17,22 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class TravelStatisticsService {
 
     private final TravelStatisticsRepository travelStatisticsRepository;
-    private final OperationTimer operationTimer;
 
-    public TravelStatisticsService(
-            TravelStatisticsRepository travelStatisticsRepository,
-            OperationTimer operationTimer
-    ) {
+    public TravelStatisticsService(TravelStatisticsRepository travelStatisticsRepository) {
         this.travelStatisticsRepository = travelStatisticsRepository;
-        this.operationTimer = operationTimer;
     }
 
     @Transactional(readOnly = true)
     public TravelStatistics getStatistics(Member member) {
-        return operationTimer.record(
-                MonitoredOperation.TRAVEL_STATISTICS_QUERY,
-                () -> getStatistics(member.getId())
-        );
+        return getStatistics(member.getId());
     }
 
     private TravelStatistics getStatistics(Long memberId) {

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/service/TravelStatisticsService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/statistics/service/TravelStatisticsService.java
@@ -1,0 +1,64 @@
+package com.mapmory.backend.travelrecord.statistics.service;
+
+import com.mapmory.backend.common.monitoring.MonitoredOperation;
+import com.mapmory.backend.common.monitoring.OperationTimer;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.statistics.model.TopRegionStatistics;
+import com.mapmory.backend.travelrecord.statistics.model.TravelStatistics;
+import com.mapmory.backend.travelrecord.statistics.repository.TopRegionQueryResult;
+import com.mapmory.backend.travelrecord.statistics.repository.TravelStatisticsRepository;
+import com.mapmory.backend.travelrecord.statistics.repository.TravelStatisticsSummaryQueryResult;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TravelStatisticsService {
+
+    private final TravelStatisticsRepository travelStatisticsRepository;
+    private final OperationTimer operationTimer;
+
+    public TravelStatisticsService(
+            TravelStatisticsRepository travelStatisticsRepository,
+            OperationTimer operationTimer
+    ) {
+        this.travelStatisticsRepository = travelStatisticsRepository;
+        this.operationTimer = operationTimer;
+    }
+
+    @Transactional(readOnly = true)
+    public TravelStatistics getStatistics(Member member) {
+        return operationTimer.record(
+                MonitoredOperation.TRAVEL_STATISTICS_QUERY,
+                () -> getStatistics(member.getId())
+        );
+    }
+
+    private TravelStatistics getStatistics(Long memberId) {
+        TravelStatisticsSummaryQueryResult summary = travelStatisticsRepository.findSummary(memberId);
+        List<String> visitedCountryCodes = travelStatisticsRepository.findVisitedCountryCodes(memberId);
+        List<TopRegionStatistics> topRegions = travelStatisticsRepository.findTopRegions(memberId).stream()
+                .map(TravelStatisticsService::toTopRegionStatistics)
+                .toList();
+
+        return new TravelStatistics(
+                summary.getRecordCount(),
+                summary.getMediaCount(),
+                visitedCountryCodes.size(),
+                summary.getVisitedKoreaDistrictCount(),
+                visitedCountryCodes,
+                topRegions
+        );
+    }
+
+    private static TopRegionStatistics toTopRegionStatistics(TopRegionQueryResult result) {
+        return new TopRegionStatistics(
+                result.getRegionId(),
+                result.getRegionCode(),
+                RegionType.valueOf(result.getRegionType()),
+                result.getName(),
+                result.getRecordCount()
+        );
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/statistics/controller/TravelStatisticsControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/statistics/controller/TravelStatisticsControllerTest.java
@@ -1,0 +1,106 @@
+package com.mapmory.backend.travelrecord.statistics.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.mapmory.backend.auth.jwt.JwtConfig;
+import com.mapmory.backend.auth.jwt.JwtProvider;
+import com.mapmory.backend.common.ProblemDetailFactory;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.member.MemberRepository;
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.statistics.model.TopRegionStatistics;
+import com.mapmory.backend.travelrecord.statistics.model.TravelStatistics;
+import com.mapmory.backend.travelrecord.statistics.service.TravelStatisticsService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TravelStatisticsController.class)
+@Import({JwtConfig.class, JwtProvider.class, ProblemDetailFactory.class})
+@DisplayName("여행 통계 API")
+class TravelStatisticsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @MockitoBean
+    private TravelStatisticsService travelStatisticsService;
+
+    private Long memberId;
+    private Member member;
+
+    @BeforeEach
+    void setUpMember() {
+        memberId = 10L;
+        member = Member.of("통계 테스트 회원", UUID.randomUUID());
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    }
+
+    @Test
+    @DisplayName("현재 회원의 전체 여행 통계를 반환한다")
+    void returnsTravelStatistics() throws Exception {
+        when(travelStatisticsService.getStatistics(any(Member.class))).thenReturn(new TravelStatistics(
+                24L,
+                138L,
+                3L,
+                8L,
+                List.of("JP", "KR", "US"),
+                List.of(new TopRegionStatistics(
+                        10L,
+                        "11",
+                        RegionType.PROVINCE,
+                        "서울특별시",
+                        7L
+                ))
+        ));
+
+        mockMvc.perform(get("/api/v1/travel-records/statistics")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(memberId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.recordCount").value(24))
+                .andExpect(jsonPath("$.data.mediaCount").value(138))
+                .andExpect(jsonPath("$.data.visitedCountryCount").value(3))
+                .andExpect(jsonPath("$.data.visitedKoreaDistrictCount").value(8))
+                .andExpect(jsonPath("$.data.visitedCountryCodes[0]").value("JP"))
+                .andExpect(jsonPath("$.data.topRegions[0].regionId").value(10))
+                .andExpect(jsonPath("$.data.topRegions[0].code").value("11"))
+                .andExpect(jsonPath("$.data.topRegions[0].regionType").value("PROVINCE"))
+                .andExpect(jsonPath("$.data.topRegions[0].name").value("서울특별시"))
+                .andExpect(jsonPath("$.data.topRegions[0].recordCount").value(7));
+
+        verify(travelStatisticsService).getStatistics(same(member));
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청하면 401을 반환한다")
+    void rejectsUnauthenticatedRequest() throws Exception {
+        mockMvc.perform(get("/api/v1/travel-records/statistics"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_ACCESS_TOKEN"));
+    }
+
+    private String bearer(Long id) {
+        return "Bearer " + jwtProvider.issueAccessToken(id);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/statistics/repository/TravelStatisticsRepositoryTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/statistics/repository/TravelStatisticsRepositoryTest.java
@@ -1,0 +1,167 @@
+package com.mapmory.backend.travelrecord.statistics.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.support.MySqlTestContainerSupport;
+import com.mapmory.backend.travelrecord.TravelRecord;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+@DataJpaTest
+@DisplayName("여행 통계 Repository")
+class TravelStatisticsRepositoryTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private TravelStatisticsRepository travelStatisticsRepository;
+
+    @Test
+    @DisplayName("현재 회원의 기록·미디어·방문 국가·국내 시군구를 중복 없이 집계한다")
+    void aggregatesCurrentMemberStatistics() {
+        Scenario scenario = createScenario();
+
+        TravelStatisticsSummaryQueryResult summary =
+                travelStatisticsRepository.findSummary(scenario.member().getId());
+        List<String> countryCodes =
+                travelStatisticsRepository.findVisitedCountryCodes(scenario.member().getId());
+
+        assertThat(summary.getRecordCount()).isEqualTo(7L);
+        assertThat(summary.getMediaCount()).isEqualTo(4L);
+        assertThat(summary.getVisitedKoreaDistrictCount()).isEqualTo(3L);
+        assertThat(countryCodes).containsExactly("JP", "KR", "US");
+    }
+
+    @Test
+    @DisplayName("국내 기록은 시도로, 해외 기록은 국가로 올려 기록 수 상위 3개를 반환한다")
+    void findsTopThreeAggregateRegions() {
+        Scenario scenario = createScenario();
+
+        List<TopRegionQueryResult> topRegions =
+                travelStatisticsRepository.findTopRegions(scenario.member().getId());
+
+        assertThat(topRegions).hasSize(3);
+        assertRegion(topRegions.get(0), scenario.seoul(), 3L);
+        assertRegion(topRegions.get(1), scenario.japan(), 2L);
+        assertRegion(topRegions.get(2), scenario.busan(), 1L);
+    }
+
+    @Test
+    @DisplayName("기록이 없는 회원은 0과 빈 목록을 반환한다")
+    void returnsZerosAndEmptyListsForMemberWithoutRecords() {
+        Member member = persist(Member.of("기록 없는 회원", UUID.randomUUID()));
+        flushAndClear();
+
+        TravelStatisticsSummaryQueryResult summary = travelStatisticsRepository.findSummary(member.getId());
+
+        assertThat(summary.getRecordCount()).isZero();
+        assertThat(summary.getMediaCount()).isZero();
+        assertThat(summary.getVisitedKoreaDistrictCount()).isZero();
+        assertThat(travelStatisticsRepository.findVisitedCountryCodes(member.getId())).isEmpty();
+        assertThat(travelStatisticsRepository.findTopRegions(member.getId())).isEmpty();
+    }
+
+    private Scenario createScenario() {
+        Member member = persist(Member.of("통계 회원", UUID.randomUUID()));
+        Member otherMember = persist(Member.of("다른 회원", UUID.randomUUID()));
+
+        Region korea = country("KR", "대한민국");
+        Region seoul = province(korea, "11", "서울특별시");
+        Region busan = province(korea, "26", "부산광역시");
+        Region gangnam = district(korea, seoul, "11680", "강남구");
+        Region jongno = district(korea, seoul, "11110", "종로구");
+        Region haeundae = district(korea, busan, "26350", "해운대구");
+
+        Region japan = country("JP", "일본");
+        Region tokyo = province(japan, "JP-13", "도쿄도");
+        Region shinjuku = district(japan, tokyo, "JP-13-104", "신주쿠구");
+        Region unitedStates = country("US", "미국");
+
+        List<TravelRecord> gangnamRecords = saveRecords(member, gangnam, 2);
+        List<TravelRecord> jongnoRecords = saveRecords(member, jongno, 1);
+        saveRecords(member, haeundae, 1);
+        saveRecords(member, japan, 1);
+        saveRecords(member, shinjuku, 1);
+        saveRecords(member, unitedStates, 1);
+
+        saveMedia(gangnamRecords.get(0), 2);
+        saveMedia(gangnamRecords.get(1), 1);
+        saveMedia(jongnoRecords.get(0), 1);
+
+        TravelRecord otherRecord = saveRecords(otherMember, gangnam, 1).get(0);
+        saveMedia(otherRecord, 1);
+        flushAndClear();
+
+        return new Scenario(member, seoul, busan, japan);
+    }
+
+    private Region country(String code, String name) {
+        return persist(Region.of(null, null, code, name, RegionType.COUNTRY));
+    }
+
+    private Region province(Region country, String code, String name) {
+        return persist(Region.of(country, country, code, name, RegionType.PROVINCE));
+    }
+
+    private Region district(Region country, Region province, String code, String name) {
+        return persist(Region.of(province, country, code, name, RegionType.DISTRICT));
+    }
+
+    private List<TravelRecord> saveRecords(Member member, Region region, int count) {
+        java.util.ArrayList<TravelRecord> records = new java.util.ArrayList<>();
+        for (int sequence = 0; sequence < count; sequence++) {
+            records.add(persist(TravelRecord.of(
+                    member,
+                    region,
+                    "통계 기록 " + UUID.randomUUID(),
+                    "내용",
+                    LocalDate.of(2026, 8, 31),
+                    null
+            )));
+        }
+        return records;
+    }
+
+    private void saveMedia(TravelRecord travelRecord, int count) {
+        for (int sequence = 0; sequence < count; sequence++) {
+            persist(RecordMedia.of(
+                    travelRecord,
+                    "travel-records/test/" + UUID.randomUUID() + ".jpg",
+                    null,
+                    sequence
+            ));
+        }
+    }
+
+    private void assertRegion(TopRegionQueryResult result, Region region, long recordCount) {
+        assertThat(result.getRegionId()).isEqualTo(region.getId());
+        assertThat(result.getRegionCode()).isEqualTo(region.getRegionCode());
+        assertThat(result.getRegionType()).isEqualTo(region.getRegionType().name());
+        assertThat(result.getName()).isEqualTo(region.getName());
+        assertThat(result.getRecordCount()).isEqualTo(recordCount);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private <T> T persist(T entity) {
+        entityManager.persist(entity);
+        return entity;
+    }
+
+    private record Scenario(Member member, Region seoul, Region busan, Region japan) {
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/statistics/service/TravelStatisticsServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/statistics/service/TravelStatisticsServiceTest.java
@@ -3,7 +3,6 @@ package com.mapmory.backend.travelrecord.statistics.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.travelrecord.statistics.model.TopRegionStatistics;
@@ -11,7 +10,6 @@ import com.mapmory.backend.travelrecord.statistics.model.TravelStatistics;
 import com.mapmory.backend.travelrecord.statistics.repository.TopRegionQueryResult;
 import com.mapmory.backend.travelrecord.statistics.repository.TravelStatisticsRepository;
 import com.mapmory.backend.travelrecord.statistics.repository.TravelStatisticsSummaryQueryResult;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,8 +26,6 @@ class TravelStatisticsServiceTest {
 
     @Mock
     private TravelStatisticsRepository travelStatisticsRepository;
-
-    private final OperationTimer operationTimer = new OperationTimer(new SimpleMeterRegistry());
 
     @Test
     @DisplayName("조회 결과를 국가 코드와 인기 지역을 포함한 응답으로 변환한다")
@@ -57,7 +53,7 @@ class TravelStatisticsServiceTest {
     }
 
     private TravelStatisticsService service() {
-        return new TravelStatisticsService(travelStatisticsRepository, operationTimer);
+        return new TravelStatisticsService(travelStatisticsRepository);
     }
 
     private static TravelStatisticsSummaryQueryResult summary(

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/statistics/service/TravelStatisticsServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/statistics/service/TravelStatisticsServiceTest.java
@@ -1,0 +1,120 @@
+package com.mapmory.backend.travelrecord.statistics.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.mapmory.backend.common.monitoring.OperationTimer;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.statistics.model.TopRegionStatistics;
+import com.mapmory.backend.travelrecord.statistics.model.TravelStatistics;
+import com.mapmory.backend.travelrecord.statistics.repository.TopRegionQueryResult;
+import com.mapmory.backend.travelrecord.statistics.repository.TravelStatisticsRepository;
+import com.mapmory.backend.travelrecord.statistics.repository.TravelStatisticsSummaryQueryResult;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("여행 통계 서비스")
+class TravelStatisticsServiceTest {
+
+    @Mock
+    private Member member;
+
+    @Mock
+    private TravelStatisticsRepository travelStatisticsRepository;
+
+    private final OperationTimer operationTimer = new OperationTimer(new SimpleMeterRegistry());
+
+    @Test
+    @DisplayName("조회 결과를 국가 코드와 인기 지역을 포함한 응답으로 변환한다")
+    void returnsTravelStatistics() {
+        TravelStatisticsService service = service();
+        when(member.getId()).thenReturn(10L);
+        when(travelStatisticsRepository.findSummary(10L)).thenReturn(summary(7L, 4L, 3L));
+        when(travelStatisticsRepository.findVisitedCountryCodes(10L)).thenReturn(List.of("JP", "KR", "US"));
+        when(travelStatisticsRepository.findTopRegions(10L)).thenReturn(List.of(
+                topRegion(15L, "11", "PROVINCE", "서울특별시", 3L),
+                topRegion(2L, "JP", "COUNTRY", "일본", 2L)
+        ));
+
+        TravelStatistics statistics = service.getStatistics(member);
+
+        assertThat(statistics.recordCount()).isEqualTo(7L);
+        assertThat(statistics.mediaCount()).isEqualTo(4L);
+        assertThat(statistics.visitedCountryCount()).isEqualTo(3L);
+        assertThat(statistics.visitedKoreaDistrictCount()).isEqualTo(3L);
+        assertThat(statistics.visitedCountryCodes()).containsExactly("JP", "KR", "US");
+        assertThat(statistics.topRegions()).containsExactly(
+                new TopRegionStatistics(15L, "11", RegionType.PROVINCE, "서울특별시", 3L),
+                new TopRegionStatistics(2L, "JP", RegionType.COUNTRY, "일본", 2L)
+        );
+    }
+
+    private TravelStatisticsService service() {
+        return new TravelStatisticsService(travelStatisticsRepository, operationTimer);
+    }
+
+    private static TravelStatisticsSummaryQueryResult summary(
+            long recordCount,
+            long mediaCount,
+            long visitedKoreaDistrictCount
+    ) {
+        return new TravelStatisticsSummaryQueryResult() {
+            @Override
+            public long getRecordCount() {
+                return recordCount;
+            }
+
+            @Override
+            public long getMediaCount() {
+                return mediaCount;
+            }
+
+            @Override
+            public long getVisitedKoreaDistrictCount() {
+                return visitedKoreaDistrictCount;
+            }
+        };
+    }
+
+    private static TopRegionQueryResult topRegion(
+            Long regionId,
+            String regionCode,
+            String regionType,
+            String name,
+            long recordCount
+    ) {
+        return new TopRegionQueryResult() {
+            @Override
+            public Long getRegionId() {
+                return regionId;
+            }
+
+            @Override
+            public String getRegionCode() {
+                return regionCode;
+            }
+
+            @Override
+            public String getRegionType() {
+                return regionType;
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public long getRecordCount() {
+                return recordCount;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 요약

- 인증된 회원의 전체 여행 기록·미디어·방문 국가·국내 시군구 통계를 반환하는 `GET /api/v1/travel-records/statistics`를 추가합니다.
- 대한민국 기록은 시·도, 해외 기록은 국가 단위로 상위 지역 3개를 집계합니다.
- Service는 통계 읽기 모델을 반환하고 Controller에서 응답 DTO를 조립합니다.

## 배경

마이페이지에서 사용할 여행 통계를 기존 원본 테이블로부터 일관되게 조회할 API가 필요했습니다. 별도 통계 테이블을 두지 않고 `travel_record`, `record_media`, `region`을 실시간 집계해 기록 변경이 바로 반영되도록 했습니다.

## 주요 결정

- 미디어를 주 집계에 직접 조인하지 않고 스칼라 서브쿼리로 계산해 조인 행 증폭을 방지했습니다.
- `visitedCountryCount`는 중복 제거된 국가 코드 목록 크기로 계산해 중복 집계와 필드 불일치를 막았습니다.
- 인기 지역은 `recordCount DESC, regionId ASC`로 정렬해 결과를 결정적으로 만들었습니다.
- 현재 대한민국/해외 지역 정밀도 차이와 해외 행정구역 확장 시 API 재검토 조건을 ADR 0016에 기록했습니다.

## 한계

- 현재 해외 여행 기록은 국가 단위이므로 인기 지역도 해외는 국가까지만 반환합니다.
- Repository MySQL Testcontainers 테스트는 작성했지만 로컬 Docker Desktop named-pipe가 500을 반환해 이번 작업 환경에서는 실행하지 못했습니다. Controller/Service 테스트와 전체 컴파일·빌드는 통과했습니다.
- 운영 데이터 기반 `EXPLAIN ANALYZE`는 후속 성능 검증에서 확인해야 합니다.

## 확인

- [x] 로컬에서 실행 확인
  - `./gradlew.bat test --offline --tests "com.mapmory.backend.travelrecord.statistics.controller.TravelStatisticsControllerTest" --tests "com.mapmory.backend.travelrecord.statistics.service.TravelStatisticsServiceTest"`
  - `./gradlew.bat build --offline -x test`
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 새 환경변수 없음
- [x] DB 스키마 변경 없음
- [x] 실행 방법이나 환경 설정 변경 없음