### PR TITLE
docs: 개인정보 처리방침 상단 요약 제거

### DIFF
--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -37,13 +37,6 @@
     th, td { padding: 12px; border: 1px solid #dbe4e7; text-align: left; vertical-align: top; }
     th { background: #f0f7f5; color: #173e42; }
     .meta { margin-top: 12px; color: #526168; font-size: .95rem; }
-    .summary {
-      margin-top: 24px;
-      padding: 18px 20px;
-      border: 1px solid #cde5de;
-      border-radius: 10px;
-      background: #eef8f5;
-    }
     .toc {
       margin-top: 28px;
       padding: 18px 22px;
@@ -82,11 +75,6 @@
 <main>
   <h1>Mapmory 개인정보 처리방침</h1>
   <p class="meta">시행일: 2026년 8월 31일</p>
-
-  <div class="summary">
-    <strong>Mapmory는 여행 기록 동기화와 사진 첨부 기능을 제공하기 위해 이용자가 입력·선택한 정보를 서버에 저장합니다.</strong>
-    사진 추천을 위한 사진 메타데이터는 기기에서 처리하고, 여행 기록에 첨부한 사진 원본만 서버 저장소로 전송합니다.
-  </div>
 
   <p>Mapmory(이하 “서비스”)는 여행 기록을 지역 단위로 작성하고 확인할 수 있는 모바일 애플리케이션입니다. Mapmory는 「개인정보 보호법」 제30조에 따라 현재 제공되는 서비스의 개인정보 처리 현황과 이용자의 권리 보호에 관한 사항을 다음과 같이 공개합니다.</p>
 


### PR DESCRIPTION
## 요약

- 개인정보처리방침 상단의 서버 저장·사진 전송 요약 박스를 제거했습니다.
- 요약 박스 삭제 후 사용되지 않는 `.summary` 스타일도 함께 정리했습니다.

## 배경

개인정보 처리 항목과 보유기간은 본문의 표와 각 절에서 상세히 안내하고 있으므로, 상단에서 같은 내용을 별도로 강조하는 문구를 제거합니다.

## 확인

- [x] `git diff --check` 통과
- [x] `develop` 대비 `docs/privacy-policy.html` 1개 파일의 12줄 삭제만 포함
- [x] 비밀 정보와 코드·환경설정 변경 없음
