### PR TITLE
refactor: 여행 기간과 Object Key를 값 객체로 추출 (ADR 0017 1단계)

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/recordmedia/ObjectKey.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/ObjectKey.java
@@ -1,0 +1,45 @@
+package com.mapmory.backend.recordmedia;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.travelrecord.TravelRecordErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+/**
+ * S3에 저장된 미디어 객체의 키. 비어 있을 수 없고 저장 한계를 넘을 수 없다.
+ *
+ * <p>키의 생성 형식({keyPrefix}/travel-records/{memberId}/{UUID}.{ext})은 업로드 모듈이 정하므로
+ * 여기서는 검증하지 않는다. 형식은 설정에 따라 달라지지만 이 두 규칙은 항상 참이다.
+ */
+@Embeddable
+record ObjectKey(
+        @Column(name = "object_key", nullable = false, unique = true, length = 500)
+        String value
+) {
+    private static final int MAX_LENGTH = 500;
+
+    ObjectKey {
+        validateNotBlank(value);
+        validateLength(value);
+    }
+
+    static ObjectKey from(String rawObjectKey) {
+        return new ObjectKey(rawObjectKey);
+    }
+
+    private static void validateNotBlank(String value) {
+        if (value == null || value.isBlank()) {
+            throwInvalidObjectKey();
+        }
+    }
+
+    private static void validateLength(String value) {
+        if (value.length() > MAX_LENGTH) {
+            throwInvalidObjectKey();
+        }
+    }
+
+    private static void throwInvalidObjectKey() {
+        throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMedia.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMedia.java
@@ -2,6 +2,7 @@ package com.mapmory.backend.recordmedia;
 
 import com.mapmory.backend.travelrecord.TravelRecord;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -25,8 +26,8 @@ public class RecordMedia {
     @JoinColumn(name = "travel_record_id", nullable = false)
     private TravelRecord travelRecord;
 
-    @Column(name = "object_key", nullable = false, unique = true, length = 500)
-    private String objectKey;
+    @Embedded
+    private ObjectKey objectKey;
 
     @Column(name = "thumb_key", length = 500)
     private String thumbKey;
@@ -43,7 +44,7 @@ public class RecordMedia {
 
     private RecordMedia(TravelRecord travelRecord, String objectKey, String thumbKey, int sortOrder) {
         this.travelRecord = travelRecord;
-        this.objectKey = objectKey;
+        this.objectKey = ObjectKey.from(objectKey);
         this.thumbKey = thumbKey;
         this.sortOrder = sortOrder;
     }
@@ -61,7 +62,7 @@ public class RecordMedia {
     }
 
     public String getObjectKey() {
-        return objectKey;
+        return objectKey.value();
     }
 
     public Long travelRecordId() {
@@ -70,7 +71,7 @@ public class RecordMedia {
 
     public String getThumbnailObjectKey() {
         if (thumbKey == null || thumbKey.isBlank()) {
-            return objectKey;
+            return getObjectKey();
         }
         return thumbKey;
     }

--- a/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/recordmedia/RecordMediaRepository.java
@@ -3,6 +3,8 @@ package com.mapmory.backend.recordmedia;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecordMediaRepository extends JpaRepository<RecordMedia, Long> {
 
@@ -12,5 +14,10 @@ public interface RecordMediaRepository extends JpaRepository<RecordMedia, Long> 
             Collection<Long> travelRecordIds
     );
 
-    List<RecordMedia> findByObjectKeyIn(Collection<String> objectKeys);
+    @Query("""
+            SELECT rm
+            FROM RecordMedia rm
+            WHERE rm.objectKey.value IN :objectKeys
+            """)
+    List<RecordMedia> findByObjectKeyIn(@Param("objectKeys") Collection<String> objectKeys);
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/MediaSynchronization.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/MediaSynchronization.java
@@ -1,0 +1,14 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.RecordMedia;
+import java.util.List;
+
+/**
+ * 미디어 동기화 결과. {@code media}는 요청 순서대로 정렬된 최종 상태이고,
+ * {@code removed}는 더 이상 요청에 없어 제거해야 하는 미디어다.
+ */
+public record MediaSynchronization(
+        List<RecordMedia> media,
+        List<RecordMedia> removed
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelPeriod.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelPeriod.java
@@ -1,0 +1,53 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
+
+/**
+ * 여행 기간. 시작일은 필수이고 종료일은 선택이며, 종료일은 시작일보다 빠를 수 없다.
+ *
+ * <p>"미래일 수 없다"는 규칙은 기준일에 따라 달라지므로 생성 시점에 검증하지 않는다.
+ * 저장된 기록을 다시 읽을 때 기준일이 지나 있어도 유효한 기간이기 때문이다.
+ * 이 규칙이 필요한 호출자가 {@link #validateNotAfter(LocalDate)}로 기준일을 넘겨 검증한다.
+ */
+@Embeddable
+record TravelPeriod(
+        @Column(name = "start_date", nullable = false)
+        LocalDate startDate,
+
+        @Column(name = "end_date")
+        LocalDate endDate
+) {
+    TravelPeriod {
+        validateStartDatePresent(startDate);
+        validateEndDateNotBeforeStartDate(startDate, endDate);
+    }
+
+    static TravelPeriod of(LocalDate startDate, LocalDate endDate) {
+        return new TravelPeriod(startDate, endDate);
+    }
+
+    void validateNotAfter(LocalDate baseDate) {
+        if (startDate.isAfter(baseDate) || (endDate != null && endDate.isAfter(baseDate))) {
+            throwInvalidTravelDateRange();
+        }
+    }
+
+    private static void validateStartDatePresent(LocalDate startDate) {
+        if (startDate == null) {
+            throwInvalidTravelDateRange();
+        }
+    }
+
+    private static void validateEndDateNotBeforeStartDate(LocalDate startDate, LocalDate endDate) {
+        if (endDate != null && endDate.isBefore(startDate)) {
+            throwInvalidTravelDateRange();
+        }
+    }
+
+    private static void throwInvalidTravelDateRange() {
+        throw new BusinessException(TravelRecordErrorCode.INVALID_TRAVEL_DATE_RANGE);
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
@@ -4,6 +4,7 @@ import com.mapmory.backend.common.entity.BaseEntity;
 import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.Region;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,10 +35,8 @@ public class TravelRecord extends BaseEntity {
     @Column(nullable = false, columnDefinition = "text")
     private String content;
 
-    @Column(nullable = false)
-    private LocalDate startDate;
-
-    private LocalDate endDate;
+    @Embedded
+    private TravelPeriod period;
 
     protected TravelRecord() {
     }
@@ -54,8 +53,7 @@ public class TravelRecord extends BaseEntity {
         this.region = region;
         this.title = title;
         this.content = normalizeContent(content);
-        this.startDate = startDate;
-        this.endDate = endDate;
+        this.period = TravelPeriod.of(startDate, endDate);
     }
 
     public static TravelRecord of(
@@ -79,8 +77,7 @@ public class TravelRecord extends BaseEntity {
         this.region = region;
         this.title = title;
         this.content = normalizeContent(content);
-        this.startDate = startDate;
-        this.endDate = endDate;
+        this.period = TravelPeriod.of(startDate, endDate);
     }
 
     private static String normalizeContent(String content) {
@@ -104,10 +101,10 @@ public class TravelRecord extends BaseEntity {
     }
 
     public LocalDate getStartDate() {
-        return startDate;
+        return period.startDate();
     }
 
     public LocalDate getEndDate() {
-        return endDate;
+        return period.endDate();
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
@@ -1,8 +1,11 @@
 package com.mapmory.backend.travelrecord;
 
 import com.mapmory.backend.common.entity.BaseEntity;
+import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.region.Region;
+import com.mapmory.backend.tag.TagErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -13,10 +16,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "travel_record")
 public class TravelRecord extends BaseEntity {
+    private static final int MAX_TAGS = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -78,6 +90,68 @@ public class TravelRecord extends BaseEntity {
         this.title = title;
         this.content = normalizeContent(content);
         this.period = TravelPeriod.of(startDate, endDate);
+    }
+
+    /**
+     * 한 일지 안에서 같은 Object Key를 두 번 가질 수 없다.
+     */
+    public void validateObjectKeys(List<String> objectKeys) {
+        if (new HashSet<>(objectKeys).size() != objectKeys.size()) {
+            throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
+        }
+    }
+
+    /**
+     * 요청된 Object Key 중 이 일지가 아직 가지고 있지 않은 것들.
+     */
+    public List<String> newObjectKeys(List<RecordMedia> currentMedia, List<String> objectKeys) {
+        Set<String> currentObjectKeys = currentMedia.stream()
+                .map(RecordMedia::getObjectKey)
+                .collect(Collectors.toSet());
+
+        return objectKeys.stream()
+                .filter(objectKey -> !currentObjectKeys.contains(objectKey))
+                .toList();
+    }
+
+    /**
+     * 요청된 Object Key 순서를 이 일지의 미디어 정렬 순서로 삼는다.
+     * 이미 가진 미디어는 순서만 바꾸고, 새 키는 미디어를 만들며, 빠진 것은 제거 대상이 된다.
+     */
+    public MediaSynchronization synchronizeMedia(
+            List<RecordMedia> currentMedia,
+            List<String> objectKeys
+    ) {
+        Map<String, RecordMedia> unusedMedia = new LinkedHashMap<>();
+        for (RecordMedia recordMedia : currentMedia) {
+            unusedMedia.put(recordMedia.getObjectKey(), recordMedia);
+        }
+
+        List<RecordMedia> orderedMedia = new ArrayList<>();
+        for (int sortOrder = 0; sortOrder < objectKeys.size(); sortOrder++) {
+            String objectKey = objectKeys.get(sortOrder);
+            RecordMedia recordMedia = unusedMedia.remove(objectKey);
+            if (recordMedia == null) {
+                recordMedia = RecordMedia.of(this, objectKey, null, sortOrder);
+            } else {
+                recordMedia.updateSortOrder(sortOrder);
+            }
+            orderedMedia.add(recordMedia);
+        }
+
+        return new MediaSynchronization(orderedMedia, List.copyOf(unusedMedia.values()));
+    }
+
+    /**
+     * 한 일지에 붙일 수 있는 태그는 최대 {@value #MAX_TAGS}개이며 중복될 수 없다.
+     */
+    public void validateTagIds(List<Long> tagIds) {
+        if (tagIds.size() > MAX_TAGS) {
+            throw new BusinessException(TagErrorCode.TOO_MANY_TAGS);
+        }
+        if (new HashSet<>(tagIds).size() != tagIds.size()) {
+            throw new BusinessException(TagErrorCode.INVALID_TAG_IDS);
+        }
     }
 
     private static String normalizeContent(String content) {

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -20,13 +20,8 @@ import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -132,12 +127,12 @@ public class TravelRecordService {
         TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
         List<String> objectKeys = objectKeys(request);
-        validateUniqueObjectKeys(objectKeys);
+        travelRecord.validateObjectKeys(objectKeys);
 
         Region region = resolveRegion(request);
         List<RecordMedia> existingMedia = recordMediaRepository
                 .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
-        List<String> newObjectKeys = newObjectKeys(objectKeys, existingMedia);
+        List<String> newObjectKeys = travelRecord.newObjectKeys(existingMedia, objectKeys);
         validateObjectKeysAreAvailable(newObjectKeys);
         uploadedObjectVerifier.verifyAllUploaded(newObjectKeys);
 
@@ -152,10 +147,8 @@ public class TravelRecordService {
         List<RecordMedia> updatedMedia = operationTimer.record(
                 MonitoredOperation.MEDIA_SYNC,
                 () -> {
-                    List<RecordMedia> synchronizedMedia = synchronizeMedia(
-                            travelRecord,
-                            existingMedia,
-                            objectKeys
+                    List<RecordMedia> synchronizedMedia = applyMediaSynchronization(
+                            travelRecord.synchronizeMedia(existingMedia, objectKeys)
                     );
                     travelRecordRepository.flush();
                     return synchronizedMedia;
@@ -313,26 +306,8 @@ public class TravelRecordService {
         }
     }
 
-    private void validateUniqueObjectKeys(List<String> objectKeys) {
-        if (new HashSet<>(objectKeys).size() != objectKeys.size()) {
-            throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
-        }
-    }
-
     private static List<String> objectKeys(TravelRecordRequest request) {
         return request.objectKeys() == null ? List.of() : request.objectKeys();
-    }
-
-    private static List<String> newObjectKeys(
-            List<String> objectKeys,
-            List<RecordMedia> existingMedia
-    ) {
-        Set<String> existingObjectKeys = existingMedia.stream()
-                .map(RecordMedia::getObjectKey)
-                .collect(Collectors.toSet());
-        return objectKeys.stream()
-                .filter(objectKey -> !existingObjectKeys.contains(objectKey))
-                .toList();
     }
 
     private void validateObjectKeysAreAvailable(List<String> newObjectKeys) {
@@ -342,30 +317,9 @@ public class TravelRecordService {
         }
     }
 
-    private List<RecordMedia> synchronizeMedia(
-            TravelRecord travelRecord,
-            List<RecordMedia> existingMedia,
-            List<String> objectKeys
-    ) {
-        Map<String, RecordMedia> existingMediaByObjectKey = new HashMap<>();
-        for (RecordMedia recordMedia : existingMedia) {
-            existingMediaByObjectKey.put(recordMedia.getObjectKey(), recordMedia);
-        }
-
-        List<RecordMedia> updatedMedia = new ArrayList<>();
-        for (int index = 0; index < objectKeys.size(); index++) {
-            String objectKey = objectKeys.get(index);
-            RecordMedia recordMedia = existingMediaByObjectKey.remove(objectKey);
-            if (recordMedia == null) {
-                recordMedia = RecordMedia.of(travelRecord, objectKey, null, index);
-            } else {
-                recordMedia.updateSortOrder(index);
-            }
-            updatedMedia.add(recordMedia);
-        }
-
-        recordMediaRepository.deleteAll(existingMediaByObjectKey.values());
-        return recordMediaRepository.saveAll(updatedMedia);
+    private List<RecordMedia> applyMediaSynchronization(MediaSynchronization synchronization) {
+        recordMediaRepository.deleteAll(synchronization.removed());
+        return recordMediaRepository.saveAll(synchronization.media());
     }
 
     private TravelRecordDetailResponse createDetailResponse(

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -276,12 +276,7 @@ public class TravelRecordService {
     }
 
     private void validateTravelDates(LocalDate startDate, LocalDate endDate) {
-        LocalDate today = LocalDate.now(clock);
-        if (startDate == null
-                || startDate.isAfter(today)
-                || (endDate != null && (endDate.isBefore(startDate) || endDate.isAfter(today)))) {
-            throw new BusinessException(TravelRecordErrorCode.INVALID_TRAVEL_DATE_RANGE);
-        }
+        TravelPeriod.of(startDate, endDate).validateNotAfter(LocalDate.now(clock));
     }
 
     private Pageable createPageable(int page, int size) {

--- a/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagService.java
@@ -19,8 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class TravelRecordTagService {
-    private static final int MAX_TAGS_PER_RECORD = 5;
-
     private final TagRepository tagRepository;
     private final TravelRecordTagRepository travelRecordTagRepository;
 
@@ -34,7 +32,7 @@ public class TravelRecordTagService {
 
     @Transactional
     public List<Tag> replace(Member member, TravelRecord travelRecord, List<Long> requestedTagIds) {
-        Set<Long> tagIds = validateAndCollectTagIds(requestedTagIds);
+        Set<Long> tagIds = validateAndCollectTagIds(travelRecord, requestedTagIds);
         List<Tag> tags = findOwnedTags(member.getId(), tagIds);
 
         replaceAssociations(travelRecord, tags);
@@ -61,26 +59,11 @@ public class TravelRecordTagService {
         return result;
     }
 
-    private Set<Long> validateAndCollectTagIds(List<Long> requestedTagIds) {
+    private Set<Long> validateAndCollectTagIds(TravelRecord travelRecord, List<Long> requestedTagIds) {
         List<Long> tagIds = requestedTagIds == null ? List.of() : requestedTagIds;
-        validateTagCount(tagIds);
+        travelRecord.validateTagIds(tagIds);
 
-        Set<Long> uniqueTagIds = new HashSet<>(tagIds);
-        validateNoDuplicateTagIds(tagIds, uniqueTagIds);
-
-        return uniqueTagIds;
-    }
-
-    private void validateTagCount(List<Long> tagIds) {
-        if (tagIds.size() > MAX_TAGS_PER_RECORD) {
-            throw new BusinessException(TagErrorCode.TOO_MANY_TAGS);
-        }
-    }
-
-    private void validateNoDuplicateTagIds(List<Long> tagIds, Set<Long> uniqueTagIds) {
-        if (uniqueTagIds.size() != tagIds.size()) {
-            throw new BusinessException(TagErrorCode.INVALID_TAG_IDS);
-        }
+        return new HashSet<>(tagIds);
     }
 
     private List<Tag> findOwnedTags(Long memberId, Set<Long> tagIds) {

--- a/backend/src/test/java/com/mapmory/backend/recordmedia/ObjectKeyTest.java
+++ b/backend/src/test/java/com/mapmory/backend/recordmedia/ObjectKeyTest.java
@@ -1,0 +1,47 @@
+package com.mapmory.backend.recordmedia;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ObjectKeyTest {
+
+    private static final int MAX_LENGTH = 500;
+
+    @Test
+    void 업로드_모듈이_만든_키를_그대로_받는다() {
+        ObjectKey objectKey = ObjectKey.from("mapmory/travel-records/10/uuid.jpg");
+
+        assertThat(objectKey.value()).isEqualTo("mapmory/travel-records/10/uuid.jpg");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t"})
+    void 비어_있는_키를_거부한다(String rawObjectKey) {
+        assertInvalidObjectKey(() -> ObjectKey.from(rawObjectKey));
+    }
+
+    @Test
+    void 저장_한계_길이는_허용한다() {
+        assertThatCode(() -> ObjectKey.from("a".repeat(MAX_LENGTH))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 저장_한계를_넘는_키를_거부한다() {
+        assertInvalidObjectKey(() -> ObjectKey.from("a".repeat(MAX_LENGTH + 1)));
+    }
+
+    private void assertInvalidObjectKey(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo("INVALID_OBJECT_KEY");
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelPeriodTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelPeriodTest.java
@@ -1,0 +1,65 @@
+package com.mapmory.backend.travelrecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class TravelPeriodTest {
+
+    private static final LocalDate START = LocalDate.of(2026, 8, 11);
+
+    @Test
+    void 종료일이_없어도_기간을_만든다() {
+        TravelPeriod period = TravelPeriod.of(START, null);
+
+        assertThat(period.startDate()).isEqualTo(START);
+        assertThat(period.endDate()).isNull();
+    }
+
+    @Test
+    void 종료일이_시작일과_같으면_기간을_만든다() {
+        assertThatCode(() -> TravelPeriod.of(START, START)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 시작일이_없으면_거부한다() {
+        assertInvalidPeriod(() -> TravelPeriod.of(null, START));
+    }
+
+    @Test
+    void 종료일이_시작일보다_빠르면_거부한다() {
+        assertInvalidPeriod(() -> TravelPeriod.of(START, START.minusDays(1)));
+    }
+
+    @Test
+    void 기준일과_같은_날짜는_미래가_아니다() {
+        TravelPeriod period = TravelPeriod.of(START, START);
+
+        assertThatCode(() -> period.validateNotAfter(START)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 시작일이_기준일보다_미래이면_거부한다() {
+        TravelPeriod period = TravelPeriod.of(START, null);
+
+        assertInvalidPeriod(() -> period.validateNotAfter(START.minusDays(1)));
+    }
+
+    @Test
+    void 종료일이_기준일보다_미래이면_거부한다() {
+        TravelPeriod period = TravelPeriod.of(START, START.plusDays(2));
+
+        assertInvalidPeriod(() -> period.validateNotAfter(START.plusDays(1)));
+    }
+
+    private void assertInvalidPeriod(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo("INVALID_TRAVEL_DATE_RANGE");
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -411,7 +411,15 @@ class TravelRecordServiceTest {
 
     @Test
     void 수정_요청의_중복_Object_Key를_거부한다() {
-        TravelRecord travelRecord = mock(TravelRecord.class);
+        Region japan = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
+        TravelRecord travelRecord = TravelRecord.of(
+                mock(Member.class),
+                japan,
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
         TravelRecordRequest request = new TravelRecordRequest(
                 "JP",
                 null,

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordTest.java
@@ -1,0 +1,152 @@
+package com.mapmory.backend.travelrecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionType;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.Test;
+
+class TravelRecordTest {
+
+    private static final String KEY_A = "travel-records/10/a.jpg";
+    private static final String KEY_B = "travel-records/10/b.jpg";
+    private static final String KEY_C = "travel-records/10/c.jpg";
+
+    @Test
+    void 요청_순서를_미디어_정렬_순서로_삼는다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+        RecordMedia mediaB = RecordMedia.of(travelRecord, KEY_B, null, 1);
+
+        MediaSynchronization result = travelRecord.synchronizeMedia(
+                List.of(mediaA, mediaB),
+                List.of(KEY_B, KEY_A)
+        );
+
+        assertThat(result.media()).containsExactly(mediaB, mediaA);
+        assertThat(mediaB.getSortOrder()).isZero();
+        assertThat(mediaA.getSortOrder()).isEqualTo(1);
+        assertThat(result.removed()).isEmpty();
+    }
+
+    @Test
+    void 요청에_없는_미디어는_제거_대상이_된다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+        RecordMedia mediaB = RecordMedia.of(travelRecord, KEY_B, null, 1);
+
+        MediaSynchronization result = travelRecord.synchronizeMedia(
+                List.of(mediaA, mediaB),
+                List.of(KEY_B)
+        );
+
+        assertThat(result.media()).containsExactly(mediaB);
+        assertThat(result.removed()).containsExactly(mediaA);
+    }
+
+    @Test
+    void 새_Object_Key는_미디어를_만들어_붙인다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+
+        MediaSynchronization result = travelRecord.synchronizeMedia(
+                List.of(mediaA),
+                List.of(KEY_A, KEY_C)
+        );
+
+        assertThat(result.media()).hasSize(2);
+        assertThat(result.media())
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly(KEY_A, KEY_C);
+        assertThat(result.media().getLast().getSortOrder()).isEqualTo(1);
+        assertThat(result.removed()).isEmpty();
+    }
+
+    @Test
+    void 빈_Object_Key_목록은_모든_미디어를_제거_대상으로_삼는다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+
+        MediaSynchronization result = travelRecord.synchronizeMedia(List.of(mediaA), List.of());
+
+        assertThat(result.media()).isEmpty();
+        assertThat(result.removed()).containsExactly(mediaA);
+    }
+
+    @Test
+    void 한_일지_안에서_Object_Key가_중복되면_거부한다() {
+        TravelRecord travelRecord = travelRecord();
+
+        assertThatThrownBy(() -> travelRecord.validateObjectKeys(List.of(KEY_A, KEY_A)))
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo("INVALID_OBJECT_KEY");
+    }
+
+    @Test
+    void 이미_가진_Object_Key는_새_키가_아니다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+
+        List<String> newObjectKeys = travelRecord.newObjectKeys(
+                List.of(mediaA),
+                List.of(KEY_A, KEY_C)
+        );
+
+        assertThat(newObjectKeys).containsExactly(KEY_C);
+    }
+
+    @Test
+    void 태그를_다섯_개까지_붙일_수_있다() {
+        TravelRecord travelRecord = travelRecord();
+
+        assertThatCode(() -> travelRecord.validateTagIds(tagIds(5))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 태그가_다섯_개를_넘으면_거부한다() {
+        TravelRecord travelRecord = travelRecord();
+
+        assertTagError(() -> travelRecord.validateTagIds(tagIds(6)), "TOO_MANY_TAGS");
+    }
+
+    @Test
+    void 같은_태그를_두_번_붙이면_거부한다() {
+        TravelRecord travelRecord = travelRecord();
+
+        assertTagError(() -> travelRecord.validateTagIds(List.of(1L, 1L)), "VALIDATION_ERROR");
+    }
+
+    private TravelRecord travelRecord() {
+        Region region = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
+
+        return TravelRecord.of(
+                mock(Member.class),
+                region,
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
+    }
+
+    private List<Long> tagIds(int count) {
+        return LongStream.rangeClosed(1, count).boxed().toList();
+    }
+
+    private void assertTagError(Runnable action, String errorCode) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo(errorCode);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecordtag/TravelRecordTagServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecordtag/TravelRecordTagServiceTest.java
@@ -10,9 +10,12 @@ import static org.mockito.Mockito.when;
 
 import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.TagRepository;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,15 +37,24 @@ class TravelRecordTagServiceTest {
     @Mock
     private Member member;
 
-    @Mock
-    private TravelRecord travelRecord;
-
     private TravelRecordTagService service;
+
+    // 태그 개수·중복 규칙이 TravelRecord 애그리거트에 있으므로 실제 엔티티를 쓴다.
+    private TravelRecord travelRecord;
 
     @BeforeEach
     void setUp() {
         service = new TravelRecordTagService(tagRepository, travelRecordTagRepository);
         lenient().when(member.getId()).thenReturn(10L);
+        travelRecord = TravelRecord.of(
+                member,
+                Region.of(null, null, "JP", "일본", RegionType.COUNTRY),
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
+        ReflectionTestUtils.setField(travelRecord, "id", 100L);
     }
 
     @Test
@@ -77,7 +89,6 @@ class TravelRecordTagServiceTest {
         LocalDateTime now = LocalDateTime.now();
         Tag later = tag(2L, "라멘맛집", now.plusSeconds(1));
         Tag earlier = tag(1L, "연인", now);
-        when(travelRecord.getId()).thenReturn(100L);
         when(tagRepository.findAllByMemberIdAndIdInOrderByCreatedAtAscIdAsc(10L, java.util.Set.of(1L, 2L)))
                 .thenReturn(List.of(earlier, later));
 


### PR DESCRIPTION
관련 이슈: #213 (1단계 · VO 추출)

> ADR 0017 **1단계**. ADR은 #210 에서 함께 리뷰해주세요.

## 요약

여행 기간과 Object Key를 값 객체로 추출합니다.
**공개 시그니처는 하나도 바뀌지 않아** `TravelRecord.of(` 호출부 18곳이 그대로입니다.

## 배경

두 규칙이 응용 서비스에 있어, 서비스를 거치지 않으면 적용되지 않았습니다.

- **여행 기간** — 시작일 필수, 종료일 ≥ 시작일. `TravelRecordService.validateTravelDates` 7줄.
- **Object Key** — `TravelRecordRequest.objectKeys`에 원소 검증이 없어서, 빈 문자열이 그대로
  `record_media`에 저장됐습니다.

이미 `TagName`이라는 선례가 있어 판단 기준이 서 있는 부분부터 정리했습니다.

## 주요 결정

### 여행 기간의 두 규칙을 갈랐습니다

`TravelPeriod`의 생성자는 **시작일 필수**와 **종료일 ≥ 시작일**만 지킵니다.
"미래일 수 없다"는 `validateNotAfter(baseDate)`라는 별도 메서드로 뺐습니다.

앞의 두 규칙은 기준일과 무관하게 항상 참이라 생성자에 넣어도 안전합니다.
"미래 금지"는 다릅니다 — **작년에 저장한 기록을 오늘 다시 읽어도 유효해야 하는데,
생성자에 넣으면 DB에서 읽을 때마다 재검증되어 멀쩡한 데이터가 터집니다.**
그래서 기준일이 필요한 호출자가 `Clock`으로 오늘을 만들어 넘기게 했습니다.

### Object Key의 형식은 검증하지 않습니다

키 형식 `{keyPrefix}/travel-records/{memberId}/{UUID}.{ext}`는 `ObjectKeyGenerator`가
설정값 `keyPrefix`로 만듭니다. 설정에 따라 달라지는 규칙이라 여행 일지 도메인이 알 수 없습니다.
반면 **비어 있지 않다**와 **저장 한계(500자)를 넘지 않는다**는 항상 참이라 값 객체가 가집니다.

### 시그니처를 바꾸지 않았습니다

`of`/`update`가 `TravelPeriod`를 받게 하면 더 깔끔하지만 호출부가 18곳(대부분 테스트)이라,
1단계가 "되돌리기 쉬운 단계"가 아니게 됩니다.
`Tag`가 `TagName`을 감추고 `getName()`은 String을 주는 기존 패턴을 그대로 따랐습니다.
시그니처 변경은 애그리거트 API를 어차피 손보는 3단계에서 함께 다룹니다.

### 리포지토리는 명시 쿼리로 바꿨습니다

임베더블이 되면 파생 쿼리 `findByObjectKeyIn`이 `Collection<ObjectKey>`를 기대합니다.
`TagRepository`가 `t.tagName.nameKey` 경로로 `@Query`를 쓰는 선례를 따랐습니다.
**메서드명과 파라미터 타입이 그대로**라 호출부는 바뀌지 않습니다.

## 동작 변경 — 한 가지

지금까지 `objectKeys: [""]`가 그대로 저장됐으나 이제 `INVALID_OBJECT_KEY`(400)로 거부합니다.
**새 에러 코드가 아니라 기존 코드를 재사용**해서 API 계약 자체는 그대로입니다.

미디어를 안 올리는 경우는 영향이 없습니다. 검증이 `RecordMedia`를 만들 때만 돌기 때문입니다.

| 요청 | 결과 |
| --- | --- |
| `objectKeys` 없음 / `null` / `[]` | 미디어를 만들지 않음 — 기존과 동일 |
| `objectKeys: [""]` | **400** ← 여기만 바뀜 |

> **리뷰 요청:** 안드로이드가 "사진 없음"을 `[]`가 아니라 `[""]`로 보내고 있지는 않은지 확인 부탁드립니다.
> api.md 예시는 `"objectKeys": []`라 계약상으론 문제없습니다.

## 검증

매핑을 두 곳 바꿨기 때문에, MySQL 8.4 Testcontainers에 붙여 Hibernate가 실제로 만든 SQL을
변경 전 코드와 대조했습니다.

```sql
-- backend-develop(파생 쿼리)과 이 브랜치(@Query)가 문자 단위로 동일
select rm1_0.id, rm1_0.created_at, rm1_0.object_key,
       rm1_0.sort_order, rm1_0.thumb_key, rm1_0.travel_record_id
from record_media rm1_0
where rm1_0.object_key in (?,?)
```

```sql
-- 임베더블 전환 후에도 컬럼 그대로 → 마이그레이션 불필요
insert into travel_record (content,created_at,member_id,start_date,end_date,region_id,title,updated_at)
insert into record_media  (created_at,object_key,sort_order,thumb_key,travel_record_id)
```

확인용 프로브 테스트는 커밋에 남기지 않았습니다.

## 한계

- 값 객체는 package-private입니다. 공개하면 DTO가 참조하기 시작해 도메인 타입이 웹 계약으로 새는
  경로가 열립니다. `TagName`과 같은 가시성입니다.
- `create` 경로에는 여전히 Object Key 중복 검증이 없습니다. 기존 동작을 유지했으며 DB UNIQUE가 막습니다.
  3단계에서 두 경로를 함께 맞춥니다.

## 확인

- [x] 로컬에서 실행 확인 — `./gradlew test` 61개 클래스 / 267개 테스트 통과 (VO 테스트 11건 추가)
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [ ] 새 환경변수를 추가했다면 `.env.example` 갱신 — 해당 없음
- [x] DB 스키마 변경 없음 — 컬럼 매핑 동일함을 생성 SQL로 확인
- [ ] 실행 방법이나 환경 설정이 바뀌었다면 README 갱신 — 해당 없음
