### PR TITLE
refactor: 여행 일지 불변식을 애그리거트로 이동 (ADR 0017 2단계)

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/travelrecord/MediaSynchronization.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/MediaSynchronization.java
@@ -1,0 +1,14 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.RecordMedia;
+import java.util.List;
+
+/**
+ * 미디어 동기화 결과. {@code media}는 요청 순서대로 정렬된 최종 상태이고,
+ * {@code removed}는 더 이상 요청에 없어 제거해야 하는 미디어다.
+ */
+public record MediaSynchronization(
+        List<RecordMedia> media,
+        List<RecordMedia> removed
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecord.java
@@ -1,8 +1,11 @@
 package com.mapmory.backend.travelrecord;
 
 import com.mapmory.backend.common.entity.BaseEntity;
+import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.RecordMedia;
 import com.mapmory.backend.region.Region;
+import com.mapmory.backend.tag.TagErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -13,10 +16,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "travel_record")
 public class TravelRecord extends BaseEntity {
+    private static final int MAX_TAGS = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -78,6 +90,68 @@ public class TravelRecord extends BaseEntity {
         this.title = title;
         this.content = normalizeContent(content);
         this.period = TravelPeriod.of(startDate, endDate);
+    }
+
+    /**
+     * 한 일지 안에서 같은 Object Key를 두 번 가질 수 없다.
+     */
+    public void validateObjectKeys(List<String> objectKeys) {
+        if (new HashSet<>(objectKeys).size() != objectKeys.size()) {
+            throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
+        }
+    }
+
+    /**
+     * 요청된 Object Key 중 이 일지가 아직 가지고 있지 않은 것들.
+     */
+    public List<String> newObjectKeys(List<RecordMedia> currentMedia, List<String> objectKeys) {
+        Set<String> currentObjectKeys = currentMedia.stream()
+                .map(RecordMedia::getObjectKey)
+                .collect(Collectors.toSet());
+
+        return objectKeys.stream()
+                .filter(objectKey -> !currentObjectKeys.contains(objectKey))
+                .toList();
+    }
+
+    /**
+     * 요청된 Object Key 순서를 이 일지의 미디어 정렬 순서로 삼는다.
+     * 이미 가진 미디어는 순서만 바꾸고, 새 키는 미디어를 만들며, 빠진 것은 제거 대상이 된다.
+     */
+    public MediaSynchronization synchronizeMedia(
+            List<RecordMedia> currentMedia,
+            List<String> objectKeys
+    ) {
+        Map<String, RecordMedia> unusedMedia = new LinkedHashMap<>();
+        for (RecordMedia recordMedia : currentMedia) {
+            unusedMedia.put(recordMedia.getObjectKey(), recordMedia);
+        }
+
+        List<RecordMedia> orderedMedia = new ArrayList<>();
+        for (int sortOrder = 0; sortOrder < objectKeys.size(); sortOrder++) {
+            String objectKey = objectKeys.get(sortOrder);
+            RecordMedia recordMedia = unusedMedia.remove(objectKey);
+            if (recordMedia == null) {
+                recordMedia = RecordMedia.of(this, objectKey, null, sortOrder);
+            } else {
+                recordMedia.updateSortOrder(sortOrder);
+            }
+            orderedMedia.add(recordMedia);
+        }
+
+        return new MediaSynchronization(orderedMedia, List.copyOf(unusedMedia.values()));
+    }
+
+    /**
+     * 한 일지에 붙일 수 있는 태그는 최대 {@value #MAX_TAGS}개이며 중복될 수 없다.
+     */
+    public void validateTagIds(List<Long> tagIds) {
+        if (tagIds.size() > MAX_TAGS) {
+            throw new BusinessException(TagErrorCode.TOO_MANY_TAGS);
+        }
+        if (new HashSet<>(tagIds).size() != tagIds.size()) {
+            throw new BusinessException(TagErrorCode.INVALID_TAG_IDS);
+        }
     }
 
     private static String normalizeContent(String content) {

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -20,13 +20,8 @@ import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -132,12 +127,12 @@ public class TravelRecordService {
         TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
         List<String> objectKeys = objectKeys(request);
-        validateUniqueObjectKeys(objectKeys);
+        travelRecord.validateObjectKeys(objectKeys);
 
         Region region = resolveRegion(request);
         List<RecordMedia> existingMedia = recordMediaRepository
                 .findByTravelRecordIdOrderBySortOrderAsc(travelRecordId);
-        List<String> newObjectKeys = newObjectKeys(objectKeys, existingMedia);
+        List<String> newObjectKeys = travelRecord.newObjectKeys(existingMedia, objectKeys);
         validateObjectKeysAreAvailable(newObjectKeys);
         uploadedObjectVerifier.verifyAllUploaded(newObjectKeys);
 
@@ -152,10 +147,8 @@ public class TravelRecordService {
         List<RecordMedia> updatedMedia = operationTimer.record(
                 MonitoredOperation.MEDIA_SYNC,
                 () -> {
-                    List<RecordMedia> synchronizedMedia = synchronizeMedia(
-                            travelRecord,
-                            existingMedia,
-                            objectKeys
+                    List<RecordMedia> synchronizedMedia = applyMediaSynchronization(
+                            travelRecord.synchronizeMedia(existingMedia, objectKeys)
                     );
                     travelRecordRepository.flush();
                     return synchronizedMedia;
@@ -313,26 +306,8 @@ public class TravelRecordService {
         }
     }
 
-    private void validateUniqueObjectKeys(List<String> objectKeys) {
-        if (new HashSet<>(objectKeys).size() != objectKeys.size()) {
-            throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
-        }
-    }
-
     private static List<String> objectKeys(TravelRecordRequest request) {
         return request.objectKeys() == null ? List.of() : request.objectKeys();
-    }
-
-    private static List<String> newObjectKeys(
-            List<String> objectKeys,
-            List<RecordMedia> existingMedia
-    ) {
-        Set<String> existingObjectKeys = existingMedia.stream()
-                .map(RecordMedia::getObjectKey)
-                .collect(Collectors.toSet());
-        return objectKeys.stream()
-                .filter(objectKey -> !existingObjectKeys.contains(objectKey))
-                .toList();
     }
 
     private void validateObjectKeysAreAvailable(List<String> newObjectKeys) {
@@ -342,30 +317,9 @@ public class TravelRecordService {
         }
     }
 
-    private List<RecordMedia> synchronizeMedia(
-            TravelRecord travelRecord,
-            List<RecordMedia> existingMedia,
-            List<String> objectKeys
-    ) {
-        Map<String, RecordMedia> existingMediaByObjectKey = new HashMap<>();
-        for (RecordMedia recordMedia : existingMedia) {
-            existingMediaByObjectKey.put(recordMedia.getObjectKey(), recordMedia);
-        }
-
-        List<RecordMedia> updatedMedia = new ArrayList<>();
-        for (int index = 0; index < objectKeys.size(); index++) {
-            String objectKey = objectKeys.get(index);
-            RecordMedia recordMedia = existingMediaByObjectKey.remove(objectKey);
-            if (recordMedia == null) {
-                recordMedia = RecordMedia.of(travelRecord, objectKey, null, index);
-            } else {
-                recordMedia.updateSortOrder(index);
-            }
-            updatedMedia.add(recordMedia);
-        }
-
-        recordMediaRepository.deleteAll(existingMediaByObjectKey.values());
-        return recordMediaRepository.saveAll(updatedMedia);
+    private List<RecordMedia> applyMediaSynchronization(MediaSynchronization synchronization) {
+        recordMediaRepository.deleteAll(synchronization.removed());
+        return recordMediaRepository.saveAll(synchronization.media());
     }
 
     private TravelRecordDetailResponse createDetailResponse(

--- a/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecordtag/TravelRecordTagService.java
@@ -19,8 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class TravelRecordTagService {
-    private static final int MAX_TAGS_PER_RECORD = 5;
-
     private final TagRepository tagRepository;
     private final TravelRecordTagRepository travelRecordTagRepository;
 
@@ -34,7 +32,7 @@ public class TravelRecordTagService {
 
     @Transactional
     public List<Tag> replace(Member member, TravelRecord travelRecord, List<Long> requestedTagIds) {
-        Set<Long> tagIds = validateAndCollectTagIds(requestedTagIds);
+        Set<Long> tagIds = validateAndCollectTagIds(travelRecord, requestedTagIds);
         List<Tag> tags = findOwnedTags(member.getId(), tagIds);
 
         replaceAssociations(travelRecord, tags);
@@ -61,26 +59,11 @@ public class TravelRecordTagService {
         return result;
     }
 
-    private Set<Long> validateAndCollectTagIds(List<Long> requestedTagIds) {
+    private Set<Long> validateAndCollectTagIds(TravelRecord travelRecord, List<Long> requestedTagIds) {
         List<Long> tagIds = requestedTagIds == null ? List.of() : requestedTagIds;
-        validateTagCount(tagIds);
+        travelRecord.validateTagIds(tagIds);
 
-        Set<Long> uniqueTagIds = new HashSet<>(tagIds);
-        validateNoDuplicateTagIds(tagIds, uniqueTagIds);
-
-        return uniqueTagIds;
-    }
-
-    private void validateTagCount(List<Long> tagIds) {
-        if (tagIds.size() > MAX_TAGS_PER_RECORD) {
-            throw new BusinessException(TagErrorCode.TOO_MANY_TAGS);
-        }
-    }
-
-    private void validateNoDuplicateTagIds(List<Long> tagIds, Set<Long> uniqueTagIds) {
-        if (uniqueTagIds.size() != tagIds.size()) {
-            throw new BusinessException(TagErrorCode.INVALID_TAG_IDS);
-        }
+        return new HashSet<>(tagIds);
     }
 
     private List<Tag> findOwnedTags(Long memberId, Set<Long> tagIds) {

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -411,7 +411,15 @@ class TravelRecordServiceTest {
 
     @Test
     void 수정_요청의_중복_Object_Key를_거부한다() {
-        TravelRecord travelRecord = mock(TravelRecord.class);
+        Region japan = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
+        TravelRecord travelRecord = TravelRecord.of(
+                mock(Member.class),
+                japan,
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
         TravelRecordRequest request = new TravelRecordRequest(
                 "JP",
                 null,

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordTest.java
@@ -1,0 +1,152 @@
+package com.mapmory.backend.travelrecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.mapmory.backend.common.exception.BusinessException;
+import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.RecordMedia;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionType;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.Test;
+
+class TravelRecordTest {
+
+    private static final String KEY_A = "travel-records/10/a.jpg";
+    private static final String KEY_B = "travel-records/10/b.jpg";
+    private static final String KEY_C = "travel-records/10/c.jpg";
+
+    @Test
+    void 요청_순서를_미디어_정렬_순서로_삼는다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+        RecordMedia mediaB = RecordMedia.of(travelRecord, KEY_B, null, 1);
+
+        MediaSynchronization result = travelRecord.synchronizeMedia(
+                List.of(mediaA, mediaB),
+                List.of(KEY_B, KEY_A)
+        );
+
+        assertThat(result.media()).containsExactly(mediaB, mediaA);
+        assertThat(mediaB.getSortOrder()).isZero();
+        assertThat(mediaA.getSortOrder()).isEqualTo(1);
+        assertThat(result.removed()).isEmpty();
+    }
+
+    @Test
+    void 요청에_없는_미디어는_제거_대상이_된다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+        RecordMedia mediaB = RecordMedia.of(travelRecord, KEY_B, null, 1);
+
+        MediaSynchronization result = travelRecord.synchronizeMedia(
+                List.of(mediaA, mediaB),
+                List.of(KEY_B)
+        );
+
+        assertThat(result.media()).containsExactly(mediaB);
+        assertThat(result.removed()).containsExactly(mediaA);
+    }
+
+    @Test
+    void 새_Object_Key는_미디어를_만들어_붙인다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+
+        MediaSynchronization result = travelRecord.synchronizeMedia(
+                List.of(mediaA),
+                List.of(KEY_A, KEY_C)
+        );
+
+        assertThat(result.media()).hasSize(2);
+        assertThat(result.media())
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly(KEY_A, KEY_C);
+        assertThat(result.media().getLast().getSortOrder()).isEqualTo(1);
+        assertThat(result.removed()).isEmpty();
+    }
+
+    @Test
+    void 빈_Object_Key_목록은_모든_미디어를_제거_대상으로_삼는다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+
+        MediaSynchronization result = travelRecord.synchronizeMedia(List.of(mediaA), List.of());
+
+        assertThat(result.media()).isEmpty();
+        assertThat(result.removed()).containsExactly(mediaA);
+    }
+
+    @Test
+    void 한_일지_안에서_Object_Key가_중복되면_거부한다() {
+        TravelRecord travelRecord = travelRecord();
+
+        assertThatThrownBy(() -> travelRecord.validateObjectKeys(List.of(KEY_A, KEY_A)))
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo("INVALID_OBJECT_KEY");
+    }
+
+    @Test
+    void 이미_가진_Object_Key는_새_키가_아니다() {
+        TravelRecord travelRecord = travelRecord();
+        RecordMedia mediaA = RecordMedia.of(travelRecord, KEY_A, null, 0);
+
+        List<String> newObjectKeys = travelRecord.newObjectKeys(
+                List.of(mediaA),
+                List.of(KEY_A, KEY_C)
+        );
+
+        assertThat(newObjectKeys).containsExactly(KEY_C);
+    }
+
+    @Test
+    void 태그를_다섯_개까지_붙일_수_있다() {
+        TravelRecord travelRecord = travelRecord();
+
+        assertThatCode(() -> travelRecord.validateTagIds(tagIds(5))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 태그가_다섯_개를_넘으면_거부한다() {
+        TravelRecord travelRecord = travelRecord();
+
+        assertTagError(() -> travelRecord.validateTagIds(tagIds(6)), "TOO_MANY_TAGS");
+    }
+
+    @Test
+    void 같은_태그를_두_번_붙이면_거부한다() {
+        TravelRecord travelRecord = travelRecord();
+
+        assertTagError(() -> travelRecord.validateTagIds(List.of(1L, 1L)), "VALIDATION_ERROR");
+    }
+
+    private TravelRecord travelRecord() {
+        Region region = Region.of(null, null, "JP", "일본", RegionType.COUNTRY);
+
+        return TravelRecord.of(
+                mock(Member.class),
+                region,
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
+    }
+
+    private List<Long> tagIds(int count) {
+        return LongStream.rangeClosed(1, count).boxed().toList();
+    }
+
+    private void assertTagError(Runnable action, String errorCode) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo(errorCode);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/travelrecordtag/TravelRecordTagServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecordtag/TravelRecordTagServiceTest.java
@@ -10,9 +10,12 @@ import static org.mockito.Mockito.when;
 
 import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.TagRepository;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,15 +37,24 @@ class TravelRecordTagServiceTest {
     @Mock
     private Member member;
 
-    @Mock
-    private TravelRecord travelRecord;
-
     private TravelRecordTagService service;
+
+    // 태그 개수·중복 규칙이 TravelRecord 애그리거트에 있으므로 실제 엔티티를 쓴다.
+    private TravelRecord travelRecord;
 
     @BeforeEach
     void setUp() {
         service = new TravelRecordTagService(tagRepository, travelRecordTagRepository);
         lenient().when(member.getId()).thenReturn(10L);
+        travelRecord = TravelRecord.of(
+                member,
+                Region.of(null, null, "JP", "일본", RegionType.COUNTRY),
+                "일본 여행",
+                "본문",
+                LocalDate.of(2026, 8, 11),
+                null
+        );
+        ReflectionTestUtils.setField(travelRecord, "id", 100L);
     }
 
     @Test
@@ -77,7 +89,6 @@ class TravelRecordTagServiceTest {
         LocalDateTime now = LocalDateTime.now();
         Tag later = tag(2L, "라멘맛집", now.plusSeconds(1));
         Tag earlier = tag(1L, "연인", now);
-        when(travelRecord.getId()).thenReturn(100L);
         when(tagRepository.findAllByMemberIdAndIdInOrderByCreatedAtAscIdAsc(10L, java.util.Set.of(1L, 2L)))
                 .thenReturn(List.of(earlier, later));
 


### PR DESCRIPTION
관련 이슈: #213 (2단계 · 불변식 이동)

> ADR 0017 **2단계**. **1단계 PR 위에 쌓인 스택 PR**이라 base가 `be/refactor/travel-record-vo`입니다.
> 1단계가 병합되면 base를 `backend-develop`으로 바꾸겠습니다.

## 요약

미디어 정렬 순서와 태그 개수 제한을 `TravelRecord` 애그리거트로 옮깁니다.
`TravelRecordService` 60줄, `TravelRecordTagService` 25줄이 줄어듭니다.

ADR 0017이 **실질 이득의 대부분**이라고 본 단계입니다.

## 배경

네 규칙 모두 "이 일지가 어떤 상태여야 하는가"에 대한 것인데 응용 서비스에 있었습니다.
그래서 서비스를 거치지 않으면 적용되지 않고, 검증하려면 리포지토리 목이 필요했습니다.

## 주요 결정

### 애그리거트가 저장하지 않습니다

기존 `synchronizeMedia`는 마지막 두 줄에서 `deleteAll`·`saveAll`을 직접 불렀습니다.
그대로 옮기면 애그리거트가 리포지토리를 알게 되므로, **무엇을 남기고 무엇을 지울지만 판단해
`MediaSynchronization`으로 반환**하고 저장은 서비스가 하도록 갈랐습니다.

```java
// 애그리거트
public MediaSynchronization synchronizeMedia(List<RecordMedia> currentMedia, List<String> objectKeys)

// 서비스
private List<RecordMedia> applyMediaSynchronization(MediaSynchronization s) {
    recordMediaRepository.deleteAll(s.removed());
    return recordMediaRepository.saveAll(s.media());
}
```

### 태그 5개 제한은 TravelRecord의 규칙입니다

`TravelRecordTagService`는 연결을 만들고 지우는 일을 하지, "이 일지가 몇 개까지 가질 수 있나"를
정하는 주체가 아닙니다. **값은 5 그대로**고 위치만 옮겼습니다.
ADR 0013대로 이 값 자체는 여전히 잠정값입니다.

`null` 정규화(`null → List.of()`)는 서비스에 남겼습니다. 도메인 규칙이 아니라 요청 파싱의 잔재라,
애그리거트가 `null`을 방어하기 시작하면 어디까지 방어할지 기준이 사라집니다.

### 인자 순서를 통일했습니다

애그리거트 메서드 3개가 모두 `(현재 상태, 요청)` 순서를 갖도록 `newObjectKeys`의 인자를 뒤집었습니다.

### 부수 효과: 제거 순서가 결정적이 됐습니다

`HashMap` → `LinkedHashMap`으로 바뀌면서 제거 대상 미디어의 순서가 결정적입니다.
기존 동작보다 나아진 쪽이지만 의도한 변경임을 밝혀둡니다.

## 기존 테스트의 구멍이 드러났습니다

규칙을 옮기고 돌렸더니 테스트 3건이 깨졌는데, 그중 **둘은 리팩터링 실수가 아니었습니다.**

`TravelRecordTagServiceTest`와 `수정_요청의_중복_Object_Key를_거부한다`가 `TravelRecord`를
**목으로** 쓰고 있었습니다. 규칙이 엔티티로 옮겨가자 목이 아무것도 하지 않고 통과해버려서,
태그를 6개 넣어도 `TOO_MANY_TAGS` 대신 `TAG_NOT_FOUND`가 났습니다.
**규칙이 도메인에 있으면 목으로는 검증되지 않는다**는 걸 그대로 보여준 셈입니다.

실제 엔티티를 쓰도록 바꿨습니다. 참고로 `TravelRecordServiceTest`는 원래도 실제 엔티티 6곳 :
목 3곳으로 실제가 다수였고, 이번 변경은 그쪽으로 일관성을 맞춘 것입니다.
남은 목 3곳은 엔티티의 규칙을 건드리지 않고 id만 필요해서 그대로 뒀습니다.

## 한계

- **패키지 순환 참조가 생깁니다.** `TravelRecord`가 `RecordMedia`를 생성하므로
  `travelrecord` ↔ `recordmedia` 순환이 만들어집니다. 없애려면 `RecordMedia`를 옮겨야 하는데
  (ADR 4단계) import 12곳이 함께 흔들려 이 PR이 읽기 어려워집니다. 4단계에서 해소합니다.
- **`synchronizeMedia`의 첫 인자는 3단계에서 사라집니다.** 애그리거트가 아직 미디어 컬렉션을
  `@OneToMany`로 소유하지 않기 때문입니다. 소유하게 만드는 순간 cascade·orphanRemoval과
  리포지토리 흡수가 함께 오므로 3단계로 미뤘습니다. 이 시그니처는 한 번 더 바뀝니다.
- `create` 경로의 Object Key 중복 검증은 3단계로 넘겼습니다. 중복 요청이 500에서 400으로
  바뀌는 동작 변경이라 단독으로 처리하지 않습니다.

## 확인

- [x] 로컬에서 실행 확인 — `./gradlew test` 62개 클래스 / 276개 테스트 통과 (애그리거트 테스트 9건 추가)
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [ ] 새 환경변수를 추가했다면 `.env.example` 갱신 — 해당 없음
- [ ] DB 스키마를 변경했다면 **새 마이그레이션 파일**로 추가 — 해당 없음
- [ ] 실행 방법이나 환경 설정이 바뀌었다면 README 갱신 — 해당 없음

---
