### PR TITLE
feat: 여행 통계 API 연결 및 재진입 로딩 최적화

### DIFF
--- a/client/androidApp/src/main/java/com/mapmory/android/MapmoryAppViewModel.kt
+++ b/client/androidApp/src/main/java/com/mapmory/android/MapmoryAppViewModel.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import com.mapmory.shared.data.auth.AndroidAuthTokenStore
 import com.mapmory.shared.data.media.AndroidPhotoPreviewCache
+import com.mapmory.shared.data.repository.AndroidTripStatisticsCache
+import com.mapmory.shared.data.repository.AndroidMapSummaryCache
 import com.mapmory.shared.app.AppContainer
 import com.mapmory.shared.app.MAPMORY_API_BASE_URL
 import com.mapmory.shared.app.createGuestRemoteAppContainer
@@ -17,6 +19,8 @@ class MapmoryAppViewModel(application: Application) : AndroidViewModel(applicati
         apiBaseUrl = configuredApiBaseUrl,
         tokenStore = AndroidAuthTokenStore(application),
         photoPreviewCache = AndroidPhotoPreviewCache(application),
+        mapSummaryCache = AndroidMapSummaryCache(application),
+        tripStatisticsCache = AndroidTripStatisticsCache(application),
     )
 
     override fun onCleared() {

--- a/client/docs/api-contract.md
+++ b/client/docs/api-contract.md
@@ -220,6 +220,47 @@ travel-records/{memberId}/{uuid}.{extension}
 
 헤더: `X-Member-Id` 필수. 성공 시 `204 No Content`를 반환한다.
 
+## 여행 통계 API
+
+### 내 전체 여행 통계 조회
+
+`GET /api/v1/travel-records/statistics`
+
+현재 회원이 작성한 전체 기간의 여행 기록과 연결된 미디어를 실시간 집계한다.
+
+```json
+{
+  "data": {
+    "recordCount": 24,
+    "mediaCount": 138,
+    "visitedCountryCount": 3,
+    "visitedKoreaDistrictCount": 8,
+    "visitedCountryCodes": ["JP", "KR", "US"],
+    "topRegions": [
+      {
+        "regionId": 10,
+        "code": "11",
+        "regionType": "PROVINCE",
+        "name": "서울특별시",
+        "recordCount": 7
+      }
+    ]
+  }
+}
+```
+
+| 필드 | 설명 |
+| --- | --- |
+| `recordCount` | 현재 회원의 전체 여행 기록 수 |
+| `mediaCount` | 여행 기록에 연결된 전체 미디어 수 |
+| `visitedCountryCount` | 기록이 하나 이상 있는 고유 국가 수 |
+| `visitedKoreaDistrictCount` | 기록이 하나 이상 있는 대한민국 고유 시·군·구 수 |
+| `visitedCountryCodes` | 방문 국가 ISO 코드의 오름차순 목록 |
+| `topRegions` | `recordCount DESC`, `regionId ASC` 순서의 상위 3개 지역 |
+
+대한민국 시·군·구 기록은 직속 시·도로 올려 합산하고, 해외 기록은 국가로 합산한다.
+기록이 없으면 숫자 필드는 `0`, 목록 필드는 빈 배열을 반환한다.
+
 ## 오류 코드
 
 클라이언트에서 우선 처리할 오류 코드는 다음과 같다.
@@ -246,6 +287,7 @@ travel-records/{memberId}/{uuid}.{extension}
 | GET | `/api/v1/travel-records/{travelRecordId}` | 내 여행 기록 상세 |
 | PUT | `/api/v1/travel-records/{travelRecordId}` | 여행 기록 전체 수정 |
 | DELETE | `/api/v1/travel-records/{travelRecordId}` | 여행 기록 삭제 |
+| GET | `/api/v1/travel-records/statistics` | 내 전체 여행 통계 조회 |
 
 ## 아직 결정할 운영 정책
 
@@ -259,7 +301,6 @@ travel-records/{memberId}/{uuid}.{extension}
 임의로 구현하지 않는다.
 
 - 지도 방문 지역 전용 API: `GET /travel-records/map` 추가 여부와 응답 형식
-- 여행 통계 API: `GET /travel-statistics` 추가 여부와 응답 형식
 
 ## 지도 데이터 경계
 

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/repository/AndroidMapSummaryCache.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/repository/AndroidMapSummaryCache.kt
@@ -1,0 +1,27 @@
+package com.mapmory.shared.data.repository
+
+import android.content.Context
+import kotlinx.serialization.json.Json
+
+class AndroidMapSummaryCache(context: Context) : MapSummaryCache {
+    private val preferences = context.applicationContext.getSharedPreferences(
+        PreferencesName,
+        Context.MODE_PRIVATE,
+    )
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun read(): MapSummarySnapshot? = preferences.getString(SnapshotKey, null)
+        ?.let { payload -> runCatching { json.decodeFromString<MapSummarySnapshot>(payload) }.getOrNull() }
+
+    override fun write(snapshot: MapSummarySnapshot) {
+        val payload = runCatching { json.encodeToString(snapshot) }.getOrNull() ?: return
+        preferences.edit().putString(SnapshotKey, payload).apply()
+    }
+
+    override fun clear() {
+        preferences.edit().remove(SnapshotKey).apply()
+    }
+}
+
+private const val PreferencesName = "mapmory_map_summary"
+private const val SnapshotKey = "latest_map_summary"

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/repository/AndroidTripStatisticsCache.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/data/repository/AndroidTripStatisticsCache.kt
@@ -1,0 +1,28 @@
+package com.mapmory.shared.data.repository
+
+import android.content.Context
+import com.mapmory.shared.domain.model.TripStatistics
+import kotlinx.serialization.json.Json
+
+class AndroidTripStatisticsCache(context: Context) : TripStatisticsCache {
+    private val preferences = context.applicationContext.getSharedPreferences(
+        PreferencesName,
+        Context.MODE_PRIVATE,
+    )
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun read(): TripStatistics? = preferences.getString(StatisticsKey, null)
+        ?.let { payload -> runCatching { json.decodeFromString<TripStatistics>(payload) }.getOrNull() }
+
+    override fun write(statistics: TripStatistics) {
+        val payload = runCatching { json.encodeToString(statistics) }.getOrNull() ?: return
+        preferences.edit().putString(StatisticsKey, payload).apply()
+    }
+
+    override fun clear() {
+        preferences.edit().remove(StatisticsKey).apply()
+    }
+}
+
+private const val PreferencesName = "mapmory_statistics"
+private const val StatisticsKey = "latest_statistics"

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/logging/MapmoryDebugLog.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/logging/MapmoryDebugLog.android.kt
@@ -1,0 +1,8 @@
+package com.mapmory.shared.logging
+
+import android.util.Log
+
+internal actual fun mapmoryDebugLog(tag: String, message: String) {
+    runCatching { Log.d(tag, message) }
+        .onFailure { println("D/$tag: $message") }
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/app/AppContainer.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/app/AppContainer.kt
@@ -20,9 +20,12 @@ import com.mapmory.shared.data.repository.AuthenticatedMapSummaryRepository
 import com.mapmory.shared.data.repository.AuthenticatedTripRecordRepository
 import com.mapmory.shared.data.repository.AuthenticatedTripStatisticsRepository
 import com.mapmory.shared.data.repository.CachedMediaTripRecordRepository
+import com.mapmory.shared.data.repository.CachedMapSummaryRepository
 import com.mapmory.shared.data.repository.CachedTripStatisticsRepository
 import com.mapmory.shared.data.repository.FakeTripRecordRepository
 import com.mapmory.shared.data.repository.MemoryTripStatisticsCache
+import com.mapmory.shared.data.repository.MapSummaryCache
+import com.mapmory.shared.data.repository.MemoryMapSummaryCache
 import com.mapmory.shared.data.repository.TripStatisticsCache
 import com.mapmory.shared.data.repository.UploadingTripRecordRepository
 import com.mapmory.shared.domain.region.RegionCatalog
@@ -130,6 +133,7 @@ private class DefaultAppContainer(
         regionCatalog = regionCatalog,
         thumbnailLoader = thumbnailLoader,
         onTripRecordsChanged = {
+            (mapSummaryRepository as? CachedMapSummaryRepository)?.invalidate()
             (tripStatisticsRepository as? CachedTripStatisticsRepository)?.invalidate()
             mutableTripRecordRevision.update { revision -> revision + 1 }
         },
@@ -143,6 +147,7 @@ fun createAppContainer(
     mapSummaryRepository: MapSummaryRepository = requireNotNull(
         tripRecordRepository as? MapSummaryRepository,
     ) { "지도 요약 Repository를 함께 전달해 주세요." },
+    mapSummaryCache: MapSummaryCache = MemoryMapSummaryCache(),
     tripStatisticsRepository: TripStatisticsRepository = requireNotNull(
         tripRecordRepository as? TripStatisticsRepository,
     ) { "여행 통계 Repository를 함께 전달해 주세요." },
@@ -155,10 +160,14 @@ fun createAppContainer(
         delegate = tripStatisticsRepository,
         cache = tripStatisticsCache,
     )
+    val cachedMapSummary = CachedMapSummaryRepository(
+        delegate = mapSummaryRepository,
+        cache = mapSummaryCache,
+    )
     return DefaultAppContainer(
         regionCatalog = regionCatalog,
         tripRecordRepository = tripRecordRepository,
-        mapSummaryRepository = mapSummaryRepository,
+        mapSummaryRepository = cachedMapSummary,
         tripStatisticsRepository = cachedTripStatistics,
         thumbnailLoader = thumbnailLoader,
         onClose = onClose,
@@ -213,6 +222,7 @@ fun createGuestRemoteAppContainer(
     apiBaseUrl: String = MAPMORY_API_BASE_URL,
     regionCatalog: RegionCatalog = StaticRegionCatalog(),
     photoPreviewCache: PhotoPreviewCache = MemoryPhotoPreviewCache(),
+    mapSummaryCache: MapSummaryCache = MemoryMapSummaryCache(),
     tripStatisticsCache: TripStatisticsCache = MemoryTripStatisticsCache(),
 ): AppContainer {
     val client = createHttpClient()
@@ -222,6 +232,7 @@ fun createGuestRemoteAppContainer(
         tokenStore = tokenStore,
         regionCatalog = regionCatalog,
         photoPreviewCache = photoPreviewCache,
+        mapSummaryCache = mapSummaryCache,
         tripStatisticsCache = tripStatisticsCache,
         onClose = client::close,
     )
@@ -233,10 +244,12 @@ internal fun createGuestRemoteAppContainer(
     tokenStore: AuthTokenStore,
     regionCatalog: RegionCatalog = StaticRegionCatalog(),
     photoPreviewCache: PhotoPreviewCache = MemoryPhotoPreviewCache(),
+    mapSummaryCache: MapSummaryCache = MemoryMapSummaryCache(),
     tripStatisticsCache: TripStatisticsCache = MemoryTripStatisticsCache(),
     onClose: () -> Unit = client::close,
 ): AppContainer {
     if (tokenStore.load() == null) {
+        mapSummaryCache.clear()
         tripStatisticsCache.clear()
     }
     val session = GuestSessionManager(
@@ -283,6 +296,7 @@ internal fun createGuestRemoteAppContainer(
     return createAppContainer(
         tripRecordRepository = AuthenticatedTripRecordRepository(session, cachedMediaTripRecords),
         mapSummaryRepository = AuthenticatedMapSummaryRepository(session, remoteMapSummary),
+        mapSummaryCache = mapSummaryCache,
         tripStatisticsRepository = AuthenticatedTripStatisticsRepository(session, remoteTripStatistics),
         tripStatisticsCache = tripStatisticsCache,
         regionCatalog = regionCatalog,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/app/AppContainer.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/app/AppContainer.kt
@@ -13,16 +13,22 @@ import com.mapmory.shared.data.remote.MapSummaryRemoteRepository
 import com.mapmory.shared.data.remote.PhotoUploadRemoteRepository
 import com.mapmory.shared.data.remote.PresignedPhotoRemoteSource
 import com.mapmory.shared.data.remote.TripRecordRemoteRepository
+import com.mapmory.shared.data.remote.TripStatisticsRemoteRepository
 import com.mapmory.shared.data.remote.createHttpClient
 import com.mapmory.shared.data.remote.installMapmoryAuthRetry
 import com.mapmory.shared.data.repository.AuthenticatedMapSummaryRepository
 import com.mapmory.shared.data.repository.AuthenticatedTripRecordRepository
+import com.mapmory.shared.data.repository.AuthenticatedTripStatisticsRepository
 import com.mapmory.shared.data.repository.CachedMediaTripRecordRepository
+import com.mapmory.shared.data.repository.CachedTripStatisticsRepository
 import com.mapmory.shared.data.repository.FakeTripRecordRepository
+import com.mapmory.shared.data.repository.MemoryTripStatisticsCache
+import com.mapmory.shared.data.repository.TripStatisticsCache
 import com.mapmory.shared.data.repository.UploadingTripRecordRepository
 import com.mapmory.shared.domain.region.RegionCatalog
 import com.mapmory.shared.domain.repository.MapSummaryRepository
 import com.mapmory.shared.domain.repository.TripRecordRepository
+import com.mapmory.shared.domain.repository.TripStatisticsRepository
 import com.mapmory.shared.domain.usecase.CreateTripRecordUseCase
 import com.mapmory.shared.domain.usecase.DeleteTripRecordUseCase
 import com.mapmory.shared.domain.usecase.GetTripRecordUseCase
@@ -32,6 +38,7 @@ import com.mapmory.shared.presentation.map.viewmodel.MapViewModel
 import com.mapmory.shared.presentation.triprecord.viewmodel.TripRecordDetailViewModel
 import com.mapmory.shared.presentation.triprecord.viewmodel.TripRecordEditorViewModel
 import com.mapmory.shared.presentation.triprecord.viewmodel.TripRecordListViewModel
+import com.mapmory.shared.presentation.triprecord.viewmodel.TripStatisticsViewModel
 import com.mapmory.shared.presentation.triprecord.thumbnail.TripRecordThumbnailLoader
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,6 +52,7 @@ interface AppContainer {
     val regionCatalog: RegionCatalog
     val tripRecordRepository: TripRecordRepository
     val mapSummaryRepository: MapSummaryRepository
+    val tripStatisticsRepository: TripStatisticsRepository
     val viewModelFactory: MapmoryViewModelFactory
     val tripRecordRevision: StateFlow<Long>
 
@@ -56,6 +64,8 @@ interface MapmoryViewModelFactory {
 
     fun createTripRecordListViewModel(): TripRecordListViewModel
 
+    fun createTripStatisticsViewModel(): TripStatisticsViewModel
+
     fun createTripRecordDetailViewModel(): TripRecordDetailViewModel
 
     fun createTripRecordEditorViewModel(): TripRecordEditorViewModel
@@ -64,6 +74,7 @@ interface MapmoryViewModelFactory {
 private class DefaultMapmoryViewModelFactory(
     private val repository: TripRecordRepository,
     private val mapSummaryRepository: MapSummaryRepository,
+    private val tripStatisticsRepository: TripStatisticsRepository,
     private val regionCatalog: RegionCatalog,
     private val thumbnailLoader: TripRecordThumbnailLoader?,
     private val onTripRecordsChanged: () -> Unit,
@@ -79,6 +90,9 @@ private class DefaultMapmoryViewModelFactory(
             regionCatalog = regionCatalog,
             thumbnailLoader = thumbnailLoader,
         )
+
+    override fun createTripStatisticsViewModel(): TripStatisticsViewModel =
+        TripStatisticsViewModel(tripStatisticsRepository)
 
     override fun createTripRecordDetailViewModel(): TripRecordDetailViewModel =
         TripRecordDetailViewModel(
@@ -102,6 +116,7 @@ private class DefaultAppContainer(
     override val regionCatalog: RegionCatalog,
     override val tripRecordRepository: TripRecordRepository,
     override val mapSummaryRepository: MapSummaryRepository,
+    override val tripStatisticsRepository: TripStatisticsRepository,
     private val thumbnailLoader: TripRecordThumbnailLoader?,
     private val onClose: () -> Unit,
 ) : AppContainer {
@@ -111,9 +126,11 @@ private class DefaultAppContainer(
     override val viewModelFactory: MapmoryViewModelFactory = DefaultMapmoryViewModelFactory(
         repository = tripRecordRepository,
         mapSummaryRepository = mapSummaryRepository,
+        tripStatisticsRepository = tripStatisticsRepository,
         regionCatalog = regionCatalog,
         thumbnailLoader = thumbnailLoader,
         onTripRecordsChanged = {
+            (tripStatisticsRepository as? CachedTripStatisticsRepository)?.invalidate()
             mutableTripRecordRevision.update { revision -> revision + 1 }
         },
     )
@@ -126,16 +143,27 @@ fun createAppContainer(
     mapSummaryRepository: MapSummaryRepository = requireNotNull(
         tripRecordRepository as? MapSummaryRepository,
     ) { "지도 요약 Repository를 함께 전달해 주세요." },
+    tripStatisticsRepository: TripStatisticsRepository = requireNotNull(
+        tripRecordRepository as? TripStatisticsRepository,
+    ) { "여행 통계 Repository를 함께 전달해 주세요." },
+    tripStatisticsCache: TripStatisticsCache = MemoryTripStatisticsCache(),
     regionCatalog: RegionCatalog = StaticRegionCatalog(),
     thumbnailLoader: TripRecordThumbnailLoader? = null,
     onClose: () -> Unit = {},
-): AppContainer = DefaultAppContainer(
-    regionCatalog = regionCatalog,
-    tripRecordRepository = tripRecordRepository,
-    mapSummaryRepository = mapSummaryRepository,
-    thumbnailLoader = thumbnailLoader,
-    onClose = onClose,
-)
+): AppContainer {
+    val cachedTripStatistics = CachedTripStatisticsRepository(
+        delegate = tripStatisticsRepository,
+        cache = tripStatisticsCache,
+    )
+    return DefaultAppContainer(
+        regionCatalog = regionCatalog,
+        tripRecordRepository = tripRecordRepository,
+        mapSummaryRepository = mapSummaryRepository,
+        tripStatisticsRepository = cachedTripStatistics,
+        thumbnailLoader = thumbnailLoader,
+        onClose = onClose,
+    )
+}
 
 fun createInMemoryAppContainer(
     now: () -> String = { "2026-08-24T00:00:00" },
@@ -169,6 +197,11 @@ fun createRemoteAppContainer(
             apiBaseUrl = apiBaseUrl,
             accessTokenProvider = accessTokenProvider,
         ),
+        tripStatisticsRepository = TripStatisticsRemoteRepository(
+            client = client,
+            apiBaseUrl = apiBaseUrl,
+            accessTokenProvider = accessTokenProvider,
+        ),
         regionCatalog = regionCatalog,
         onClose = client::close,
     )
@@ -180,6 +213,7 @@ fun createGuestRemoteAppContainer(
     apiBaseUrl: String = MAPMORY_API_BASE_URL,
     regionCatalog: RegionCatalog = StaticRegionCatalog(),
     photoPreviewCache: PhotoPreviewCache = MemoryPhotoPreviewCache(),
+    tripStatisticsCache: TripStatisticsCache = MemoryTripStatisticsCache(),
 ): AppContainer {
     val client = createHttpClient()
     return createGuestRemoteAppContainer(
@@ -188,6 +222,7 @@ fun createGuestRemoteAppContainer(
         tokenStore = tokenStore,
         regionCatalog = regionCatalog,
         photoPreviewCache = photoPreviewCache,
+        tripStatisticsCache = tripStatisticsCache,
         onClose = client::close,
     )
 }
@@ -198,8 +233,12 @@ internal fun createGuestRemoteAppContainer(
     tokenStore: AuthTokenStore,
     regionCatalog: RegionCatalog = StaticRegionCatalog(),
     photoPreviewCache: PhotoPreviewCache = MemoryPhotoPreviewCache(),
+    tripStatisticsCache: TripStatisticsCache = MemoryTripStatisticsCache(),
     onClose: () -> Unit = client::close,
 ): AppContainer {
+    if (tokenStore.load() == null) {
+        tripStatisticsCache.clear()
+    }
     val session = GuestSessionManager(
         gateway = AuthRemoteRepository(client, apiBaseUrl),
         tokenStore = tokenStore,
@@ -215,6 +254,11 @@ internal fun createGuestRemoteAppContainer(
         regionCatalog = regionCatalog,
     )
     val remoteMapSummary = MapSummaryRemoteRepository(
+        client = client,
+        apiBaseUrl = apiBaseUrl,
+        accessTokenProvider = session,
+    )
+    val remoteTripStatistics = TripStatisticsRemoteRepository(
         client = client,
         apiBaseUrl = apiBaseUrl,
         accessTokenProvider = session,
@@ -239,6 +283,8 @@ internal fun createGuestRemoteAppContainer(
     return createAppContainer(
         tripRecordRepository = AuthenticatedTripRecordRepository(session, cachedMediaTripRecords),
         mapSummaryRepository = AuthenticatedMapSummaryRepository(session, remoteMapSummary),
+        tripStatisticsRepository = AuthenticatedTripStatisticsRepository(session, remoteTripStatistics),
+        tripStatisticsCache = tripStatisticsCache,
         regionCatalog = regionCatalog,
         thumbnailLoader = CachedTripRecordThumbnailLoader(photoPreviewLoader),
         onClose = onClose,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/auth/AuthSession.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/auth/AuthSession.kt
@@ -3,6 +3,7 @@ package com.mapmory.shared.data.auth
 import com.mapmory.shared.data.remote.AccessTokenProvider
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.time.Clock
 
 data class AuthTokens(
     val accessToken: String,
@@ -35,13 +36,14 @@ internal interface AuthGateway {
 /**
  * 첫 보호 API 호출 전에 게스트 세션을 준비한다.
  *
- * 저장된 세션이 있으면 앱 실행 중 한 번만 갱신하고, 없으면 게스트 로그인을 한 번만
- * 수행한다. Mutex는 동시에 여러 화면이 초기화돼도 회전형 리프레시 토큰이 중복 사용되는
- * 것을 막는다.
+ * 저장된 Access Token의 수명이 충분하면 즉시 재사용하고, 만료됐거나 형식을 확인할 수 없을
+ * 때만 앱 실행 중 한 번 갱신한다. 저장된 세션이 없으면 게스트 로그인을 한 번 수행한다.
+ * Mutex는 동시에 여러 화면이 초기화돼도 회전형 리프레시 토큰이 중복 사용되는 것을 막는다.
  */
 internal class GuestSessionManager(
     private val gateway: AuthGateway,
     private val tokenStore: AuthTokenStore,
+    private val nowEpochSeconds: () -> Long = { Clock.System.now().epochSeconds },
 ) : AccessTokenProvider {
     private val authenticationMutex = Mutex()
     private var didLoadStoredTokens = false
@@ -56,6 +58,10 @@ internal class GuestSessionManager(
         if (!didLoadStoredTokens) {
             tokens = tokenStore.load()
             didLoadStoredTokens = true
+            if (tokens?.accessToken?.hasUsableJwtLifetime(nowEpochSeconds()) == true) {
+                isAuthenticated = true
+                return@withLock Result.success(Unit)
+            }
         }
 
         val authentication = tokens

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/auth/JwtAccessToken.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/auth/JwtAccessToken.kt
@@ -1,0 +1,47 @@
+package com.mapmory.shared.data.auth
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+internal fun String.hasUsableJwtLifetime(
+    nowEpochSeconds: Long,
+    minimumRemainingSeconds: Long = MinimumRemainingAccessTokenSeconds,
+): Boolean {
+    val payload = split('.').takeIf { parts -> parts.size == JwtPartCount }?.get(1) ?: return false
+    val expiration = runCatching {
+        Json.parseToJsonElement(payload.decodeBase64Url().decodeToString())
+            .jsonObject[ExpirationClaim]
+            ?.jsonPrimitive
+            ?.longOrNull
+    }.getOrNull() ?: return false
+    return expiration > nowEpochSeconds + minimumRemainingSeconds
+}
+
+private fun String.decodeBase64Url(): ByteArray {
+    val output = ArrayList<Byte>((length * 3) / 4)
+    var buffer = 0
+    var bitCount = 0
+    for (character in this) {
+        if (character == '=') break
+        val value = Base64UrlAlphabet.indexOf(character)
+        require(value >= 0) { "올바르지 않은 Base64 URL 문자입니다." }
+        buffer = (buffer shl BitsPerBase64Character) or value
+        bitCount += BitsPerBase64Character
+        if (bitCount >= BitsPerByte) {
+            bitCount -= BitsPerByte
+            output += ((buffer shr bitCount) and ByteMask).toByte()
+        }
+    }
+    return output.toByteArray()
+}
+
+private const val ExpirationClaim = "exp"
+private const val JwtPartCount = 3
+private const val MinimumRemainingAccessTokenSeconds = 30L
+private const val BitsPerBase64Character = 6
+private const val BitsPerByte = 8
+private const val ByteMask = 0xFF
+private const val Base64UrlAlphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/TripStatisticsRemoteRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/TripStatisticsRemoteRepository.kt
@@ -5,6 +5,7 @@ import com.mapmory.shared.data.remote.model.TripStatisticsDto
 import com.mapmory.shared.data.remote.model.toDomain
 import com.mapmory.shared.domain.model.TripStatistics
 import com.mapmory.shared.domain.repository.TripStatisticsRepository
+import com.mapmory.shared.logging.mapmoryDebugLog
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -16,12 +17,32 @@ class TripStatisticsRemoteRepository(
 ) : TripStatisticsRepository {
     private val statisticsUrl = "${apiBaseUrl.trimEnd('/')}/travel-records/statistics"
 
-    override suspend fun getStatistics(): Result<TripStatistics> = apiCall {
-        client.get(statisticsUrl) {
-            authorizeWith(accessTokenProvider)
-        }.requireSuccess()
-            .body<ApiResponseDto<TripStatisticsDto>>()
-            .data
-            .toDomain()
+    override suspend fun getStatistics(): Result<TripStatistics> {
+        mapmoryDebugLog(StatisticsLogTag, "request GET /travel-records/statistics")
+        return apiCall {
+            val response = client.get(statisticsUrl) {
+                authorizeWith(accessTokenProvider)
+            }.requireSuccess()
+                .body<ApiResponseDto<TripStatisticsDto>>()
+                .data
+            mapmoryDebugLog(
+                StatisticsLogTag,
+                "response " +
+                    "recordCount=${response.recordCount}, " +
+                    "mediaCount=${response.mediaCount}, " +
+                    "visitedCountryCount=${response.visitedCountryCount}, " +
+                    "visitedKoreaDistrictCount=${response.visitedKoreaDistrictCount}, " +
+                    "visitedCountryCodes=${response.visitedCountryCodes}, " +
+                    "topRegions=${response.topRegions.map { "${it.name}:${it.recordCount}" }}",
+            )
+            response.toDomain()
+        }.onFailure { error ->
+            mapmoryDebugLog(
+                StatisticsLogTag,
+                "request failed: ${error::class.simpleName}: ${error.message}",
+            )
+        }
     }
 }
+
+private const val StatisticsLogTag = "MapmoryStatistics"

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/TripStatisticsRemoteRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/TripStatisticsRemoteRepository.kt
@@ -1,0 +1,27 @@
+package com.mapmory.shared.data.remote
+
+import com.mapmory.shared.data.remote.model.ApiResponseDto
+import com.mapmory.shared.data.remote.model.TripStatisticsDto
+import com.mapmory.shared.data.remote.model.toDomain
+import com.mapmory.shared.domain.model.TripStatistics
+import com.mapmory.shared.domain.repository.TripStatisticsRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+
+class TripStatisticsRemoteRepository(
+    private val client: HttpClient,
+    apiBaseUrl: String,
+    private val accessTokenProvider: AccessTokenProvider,
+) : TripStatisticsRepository {
+    private val statisticsUrl = "${apiBaseUrl.trimEnd('/')}/travel-records/statistics"
+
+    override suspend fun getStatistics(): Result<TripStatistics> = apiCall {
+        client.get(statisticsUrl) {
+            authorizeWith(accessTokenProvider)
+        }.requireSuccess()
+            .body<ApiResponseDto<TripStatisticsDto>>()
+            .data
+            .toDomain()
+    }
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/TripStatisticsRemoteRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/TripStatisticsRemoteRepository.kt
@@ -25,21 +25,12 @@ class TripStatisticsRemoteRepository(
             }.requireSuccess()
                 .body<ApiResponseDto<TripStatisticsDto>>()
                 .data
-            mapmoryDebugLog(
-                StatisticsLogTag,
-                "response " +
-                    "recordCount=${response.recordCount}, " +
-                    "mediaCount=${response.mediaCount}, " +
-                    "visitedCountryCount=${response.visitedCountryCount}, " +
-                    "visitedKoreaDistrictCount=${response.visitedKoreaDistrictCount}, " +
-                    "visitedCountryCodes=${response.visitedCountryCodes}, " +
-                    "topRegions=${response.topRegions.map { "${it.name}:${it.recordCount}" }}",
-            )
+            mapmoryDebugLog(StatisticsLogTag, "request succeeded")
             response.toDomain()
         }.onFailure { error ->
             mapmoryDebugLog(
                 StatisticsLogTag,
-                "request failed: ${error::class.simpleName}: ${error.message}",
+                "request failed: ${error::class.simpleName}",
             )
         }
     }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/model/ApiDtoMappers.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/model/ApiDtoMappers.kt
@@ -11,6 +11,8 @@ import com.mapmory.shared.domain.model.TripRecordMedia
 import com.mapmory.shared.domain.model.TripRecordPage
 import com.mapmory.shared.domain.model.TripRecordQuery
 import com.mapmory.shared.domain.model.TripRecordSummary
+import com.mapmory.shared.domain.model.TripStatistics
+import com.mapmory.shared.domain.model.TopRegionStatistics
 import com.mapmory.shared.domain.model.dateValidationError
 import com.mapmory.shared.domain.region.RegionCatalog
 
@@ -151,6 +153,23 @@ fun MapRegionSummaryDto.toDomain(): MapRegionSummary = MapRegionSummary(
     name = name,
     count = count,
     level = MapRegionLevel.valueOf(level),
+)
+
+fun TripStatisticsDto.toDomain(): TripStatistics = TripStatistics(
+    recordCount = recordCount,
+    mediaCount = mediaCount,
+    visitedCountryCount = visitedCountryCount,
+    visitedKoreaDistrictCount = visitedKoreaDistrictCount,
+    visitedCountryCodes = visitedCountryCodes,
+    topRegions = topRegions.map { region ->
+        TopRegionStatistics(
+            regionId = region.regionId,
+            code = region.code,
+            type = MapRegionType.valueOf(region.regionType),
+            name = region.name,
+            recordCount = region.recordCount,
+        )
+    },
 )
 
 private const val KoreaCountryCode = "KR"

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/model/ApiDtos.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/model/ApiDtos.kt
@@ -150,3 +150,22 @@ data class MapRegionSummaryDto(
     val count: Long,
     val level: String,
 )
+
+@Serializable
+data class TripStatisticsDto(
+    val recordCount: Long,
+    val mediaCount: Long,
+    val visitedCountryCount: Long,
+    val visitedKoreaDistrictCount: Long,
+    val visitedCountryCodes: List<String>,
+    val topRegions: List<TopRegionStatisticsDto>,
+)
+
+@Serializable
+data class TopRegionStatisticsDto(
+    val regionId: Long,
+    val code: String,
+    val regionType: String,
+    val name: String,
+    val recordCount: Long,
+)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/AuthenticatedRepositories.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/AuthenticatedRepositories.kt
@@ -6,8 +6,10 @@ import com.mapmory.shared.domain.model.TripRecordData
 import com.mapmory.shared.domain.model.TripRecordDraft
 import com.mapmory.shared.domain.model.TripRecordPage
 import com.mapmory.shared.domain.model.TripRecordQuery
+import com.mapmory.shared.domain.model.TripStatistics
 import com.mapmory.shared.domain.repository.MapSummaryRepository
 import com.mapmory.shared.domain.repository.TripRecordRepository
+import com.mapmory.shared.domain.repository.TripStatisticsRepository
 
 internal class AuthenticatedTripRecordRepository(
     private val session: GuestSessionManager,
@@ -54,4 +56,15 @@ internal class AuthenticatedMapSummaryRepository(
         onSuccess = { request() },
         onFailure = Result.Companion::failure,
     )
+}
+
+internal class AuthenticatedTripStatisticsRepository(
+    private val session: GuestSessionManager,
+    private val delegate: TripStatisticsRepository,
+) : TripStatisticsRepository {
+    override suspend fun getStatistics(): Result<TripStatistics> =
+        session.ensureAuthenticated().fold(
+            onSuccess = { delegate.getStatistics() },
+            onFailure = Result.Companion::failure,
+        )
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/CachedMapSummaryRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/CachedMapSummaryRepository.kt
@@ -1,0 +1,65 @@
+package com.mapmory.shared.data.repository
+
+import com.mapmory.shared.domain.model.MapRegionSummary
+import com.mapmory.shared.domain.repository.MapSummaryRepository
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MapSummarySnapshot(
+    val roots: List<MapRegionSummary> = emptyList(),
+    val childrenByRegionId: Map<Long, List<MapRegionSummary>> = emptyMap(),
+)
+
+interface MapSummaryCache {
+    fun read(): MapSummarySnapshot?
+
+    fun write(snapshot: MapSummarySnapshot)
+
+    fun clear()
+}
+
+class MemoryMapSummaryCache : MapSummaryCache {
+    private var snapshot: MapSummarySnapshot? = null
+
+    override fun read(): MapSummarySnapshot? = snapshot
+
+    override fun write(snapshot: MapSummarySnapshot) {
+        this.snapshot = snapshot
+    }
+
+    override fun clear() {
+        snapshot = null
+    }
+}
+
+internal class CachedMapSummaryRepository(
+    private val delegate: MapSummaryRepository,
+    private val cache: MapSummaryCache,
+) : MapSummaryRepository {
+    private var snapshot = cache.read() ?: MapSummarySnapshot()
+
+    override fun getCachedRootRegions(): List<MapRegionSummary>? =
+        snapshot.roots.takeIf { roots -> roots.isNotEmpty() }
+
+    override fun getCachedChildRegions(regionId: Long): List<MapRegionSummary>? =
+        snapshot.childrenByRegionId[regionId]
+
+    override suspend fun getRootRegions(): Result<List<MapRegionSummary>> =
+        delegate.getRootRegions().onSuccess { roots ->
+            snapshot = snapshot.copy(roots = roots)
+            runCatching { cache.write(snapshot) }
+        }
+
+    override suspend fun getChildRegions(regionId: Long): Result<List<MapRegionSummary>> =
+        delegate.getChildRegions(regionId).onSuccess { children ->
+            snapshot = snapshot.copy(
+                childrenByRegionId = snapshot.childrenByRegionId + (regionId to children),
+            )
+            runCatching { cache.write(snapshot) }
+        }
+
+    fun invalidate() {
+        snapshot = MapSummarySnapshot()
+        runCatching(cache::clear)
+    }
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/CachedTripStatisticsRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/CachedTripStatisticsRepository.kt
@@ -1,0 +1,42 @@
+package com.mapmory.shared.data.repository
+
+import com.mapmory.shared.domain.model.TripStatistics
+import com.mapmory.shared.domain.repository.TripStatisticsRepository
+
+interface TripStatisticsCache {
+    fun read(): TripStatistics?
+
+    fun write(statistics: TripStatistics)
+
+    fun clear()
+}
+
+class MemoryTripStatisticsCache : TripStatisticsCache {
+    private var statistics: TripStatistics? = null
+
+    override fun read(): TripStatistics? = statistics
+
+    override fun write(statistics: TripStatistics) {
+        this.statistics = statistics
+    }
+
+    override fun clear() {
+        statistics = null
+    }
+}
+
+internal class CachedTripStatisticsRepository(
+    private val delegate: TripStatisticsRepository,
+    private val cache: TripStatisticsCache,
+) : TripStatisticsRepository {
+    override fun getCachedStatistics(): TripStatistics? = cache.read()
+
+    override suspend fun getStatistics(): Result<TripStatistics> =
+        delegate.getStatistics().onSuccess { statistics ->
+            runCatching { cache.write(statistics) }
+        }
+
+    fun invalidate() {
+        runCatching(cache::clear)
+    }
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepository.kt
@@ -12,16 +12,19 @@ import com.mapmory.shared.domain.model.TripRecordMedia
 import com.mapmory.shared.domain.model.TripRecordPage
 import com.mapmory.shared.domain.model.TripRecordQuery
 import com.mapmory.shared.domain.model.TripRecordSummary
+import com.mapmory.shared.domain.model.TripStatistics
+import com.mapmory.shared.domain.model.TopRegionStatistics
 import com.mapmory.shared.domain.model.dateValidationError
 import com.mapmory.shared.domain.region.RegionCatalog
 import com.mapmory.shared.domain.repository.MapSummaryRepository
 import com.mapmory.shared.domain.repository.TripRecordRepository
+import com.mapmory.shared.domain.repository.TripStatisticsRepository
 
 /** 서버 API를 연결하기 전 기록 흐름을 확인하는 메모리 기반 구현이다. */
 class FakeTripRecordRepository(
     private val regionCatalog: RegionCatalog = StaticRegionCatalog(),
     private val now: () -> String,
-) : TripRecordRepository, MapSummaryRepository {
+) : TripRecordRepository, MapSummaryRepository, TripStatisticsRepository {
     private val records = mutableListOf<TripRecordData>()
     private var nextRecordId = 1L
     private var nextMediaId = 1L
@@ -114,6 +117,51 @@ class FakeTripRecordRepository(
         }
     }
 
+    override suspend fun getStatistics(): Result<TripStatistics> = runCatching {
+        val visitedCountryCodes = records.mapNotNull { record ->
+            rootLocation(regionCatalog.findById(record.locationId))?.regionCode
+        }.distinct().sorted()
+        val visitedKoreaDistrictCount = records.mapNotNull { record ->
+            regionCatalog.findById(record.locationId)?.takeIf { location ->
+                location.countryId == KoreaCountryId && location.type == LocationType.DISTRICT
+            }?.id
+        }.distinct().size
+        val topRegions = records.groupBy { record ->
+            val location = regionCatalog.findById(record.locationId)
+            when {
+                location == null -> null
+                location.countryId == KoreaCountryId -> location.parentId?.let(regionCatalog::findById)
+                else -> rootLocation(location)
+            }
+        }.mapNotNull { (location, regionRecords) ->
+            location?.let { region ->
+                TopRegionStatistics(
+                    regionId = region.id,
+                    code = region.regionCode.removePrefix(KoreanProvincePrefix),
+                    type = if (region.countryId == KoreaCountryId) {
+                        MapRegionType.PROVINCE
+                    } else {
+                        MapRegionType.COUNTRY
+                    },
+                    name = region.name,
+                    recordCount = regionRecords.size.toLong(),
+                )
+            }
+        }.sortedWith(
+            compareByDescending<TopRegionStatistics>(TopRegionStatistics::recordCount)
+                .thenBy(TopRegionStatistics::regionId),
+        ).take(TopRegionLimit)
+
+        TripStatistics(
+            recordCount = records.size.toLong(),
+            mediaCount = records.sumOf { record -> record.media.size }.toLong(),
+            visitedCountryCount = visitedCountryCodes.size.toLong(),
+            visitedKoreaDistrictCount = visitedKoreaDistrictCount.toLong(),
+            visitedCountryCodes = visitedCountryCodes,
+            topRegions = topRegions,
+        )
+    }
+
     private fun createMedia(draft: TripRecordDraft): List<TripRecordMedia> {
         val localMediaByObjectKey = draft.localMedia.associateBy { it.objectKey }
         return draft.mediaObjectKeys.mapIndexed { index, objectKey ->
@@ -192,3 +240,4 @@ private const val KoreaCountryCode = "KR"
 private const val KoreanProvincePrefix = "KR-"
 private const val CountryCodeLength = 2
 private const val MaxPageSize = 100
+private const val TopRegionLimit = 3

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/MapRegionSummary.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/MapRegionSummary.kt
@@ -1,5 +1,8 @@
 package com.mapmory.shared.domain.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class MapRegionSummary(
     val regionId: Long,
     val code: String,
@@ -9,12 +12,14 @@ data class MapRegionSummary(
     val level: MapRegionLevel,
 )
 
+@Serializable
 enum class MapRegionType {
     COUNTRY,
     PROVINCE,
     DISTRICT,
 }
 
+@Serializable
 enum class MapRegionLevel {
     NONE,
     LOW,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/TripStatistics.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/TripStatistics.kt
@@ -1,0 +1,22 @@
+package com.mapmory.shared.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TripStatistics(
+    val recordCount: Long,
+    val mediaCount: Long,
+    val visitedCountryCount: Long,
+    val visitedKoreaDistrictCount: Long,
+    val visitedCountryCodes: List<String>,
+    val topRegions: List<TopRegionStatistics>,
+)
+
+@Serializable
+data class TopRegionStatistics(
+    val regionId: Long,
+    val code: String,
+    val type: MapRegionType,
+    val name: String,
+    val recordCount: Long,
+)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/repository/MapSummaryRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/repository/MapSummaryRepository.kt
@@ -3,6 +3,10 @@ package com.mapmory.shared.domain.repository
 import com.mapmory.shared.domain.model.MapRegionSummary
 
 interface MapSummaryRepository {
+    fun getCachedRootRegions(): List<MapRegionSummary>? = null
+
+    fun getCachedChildRegions(regionId: Long): List<MapRegionSummary>? = null
+
     suspend fun getRootRegions(): Result<List<MapRegionSummary>>
 
     suspend fun getChildRegions(regionId: Long): Result<List<MapRegionSummary>>

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/repository/TripStatisticsRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/repository/TripStatisticsRepository.kt
@@ -1,0 +1,9 @@
+package com.mapmory.shared.domain.repository
+
+import com.mapmory.shared.domain.model.TripStatistics
+
+interface TripStatisticsRepository {
+    fun getCachedStatistics(): TripStatistics? = null
+
+    suspend fun getStatistics(): Result<TripStatistics>
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/logging/MapmoryDebugLog.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/logging/MapmoryDebugLog.kt
@@ -1,0 +1,3 @@
+package com.mapmory.shared.logging
+
+internal expect fun mapmoryDebugLog(tag: String, message: String)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/navigation/MapmoryNavHost.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/navigation/MapmoryNavHost.kt
@@ -97,8 +97,13 @@ internal fun MapmoryNavHost(
         }
 
         composable<ProfileRoute> {
+            val viewModel = viewModel {
+                container.viewModelFactory.createTripStatisticsViewModel()
+            }
             TripProfileRoute(
                 modifier = Modifier.windowInsetsPadding(contentWindowInsets),
+                viewModel = viewModel,
+                tripRecordRevision = tripRecordRevision,
                 onOpenMap = navigator::navigateToMap,
                 onOpenRecords = navigator::navigateToRecords,
                 onOpenEditor = { navigator.navigateToEditor() },

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/navigation/MapmoryNavHost.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/navigation/MapmoryNavHost.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -14,6 +15,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.mapmory.shared.app.AppContainer
+import com.mapmory.shared.logging.mapmoryDebugLog
 import com.mapmory.shared.presentation.map.route.MapRoute as MapScreenRoute
 import com.mapmory.shared.presentation.triprecord.route.TripProfileRoute
 import com.mapmory.shared.presentation.triprecord.route.TripRecordDetailRoute
@@ -33,7 +35,10 @@ internal fun MapmoryNavHost(
         navController = navController,
         startDestination = MapRoute,
     ) {
-        composable<MapRoute> {
+        composable<MapRoute> { backStackEntry ->
+            LaunchedEffect(backStackEntry) {
+                mapmoryDebugLog(NavigationLogTag, "screen=map")
+            }
             val viewModel = viewModel {
                 container.viewModelFactory.createMapViewModel()
             }
@@ -53,6 +58,12 @@ internal fun MapmoryNavHost(
 
         composable<RecordsRoute> { backStackEntry ->
             val route = backStackEntry.toRoute<RecordsRoute>()
+            LaunchedEffect(backStackEntry) {
+                mapmoryDebugLog(
+                    NavigationLogTag,
+                    "screen=records, locationId=${route.locationId}",
+                )
+            }
             val viewModel = viewModel {
                 container.viewModelFactory.createTripRecordListViewModel()
             }
@@ -70,6 +81,13 @@ internal fun MapmoryNavHost(
 
         composable<EditorRoute> { backStackEntry ->
             val route = backStackEntry.toRoute<EditorRoute>()
+            LaunchedEffect(backStackEntry) {
+                mapmoryDebugLog(
+                    NavigationLogTag,
+                    "screen=editor, recordId=${route.recordId}, " +
+                        "selectedLocationId=${route.selectedLocationId}",
+                )
+            }
             val viewModel = viewModel {
                 container.viewModelFactory.createTripRecordEditorViewModel()
             }
@@ -96,7 +114,10 @@ internal fun MapmoryNavHost(
             )
         }
 
-        composable<ProfileRoute> {
+        composable<ProfileRoute> { backStackEntry ->
+            LaunchedEffect(backStackEntry) {
+                mapmoryDebugLog(NavigationLogTag, "screen=profile")
+            }
             val viewModel = viewModel {
                 container.viewModelFactory.createTripStatisticsViewModel()
             }
@@ -113,6 +134,12 @@ internal fun MapmoryNavHost(
 
         composable<DetailRoute> { backStackEntry ->
             val route = backStackEntry.toRoute<DetailRoute>()
+            LaunchedEffect(backStackEntry) {
+                mapmoryDebugLog(
+                    NavigationLogTag,
+                    "screen=detail, recordId=${route.recordId}",
+                )
+            }
             val viewModel = viewModel {
                 container.viewModelFactory.createTripRecordDetailViewModel()
             }
@@ -138,3 +165,5 @@ internal fun MapmoryNavHost(
         }
     }
 }
+
+private const val NavigationLogTag = "MapmoryNavigation"

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/viewmodel/MapViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/viewmodel/MapViewModel.kt
@@ -26,7 +26,7 @@ class MapViewModel(
     private val mapSummaryRepository: MapSummaryRepository,
     private val regionCatalog: RegionCatalog,
 ) : ViewModel() {
-    var uiState by mutableStateOf(MapUiState())
+    var uiState by mutableStateOf(mapSummaryRepository.cachedUiState())
         private set
 
     suspend fun refresh() {
@@ -150,6 +150,16 @@ class MapViewModel(
             .toSet()
 
     fun visitedDistrictCount(provinceCode: String): Int = visitedDistrictCodes(provinceCode).size
+}
+
+private fun MapSummaryRepository.cachedUiState(): MapUiState {
+    val roots = getCachedRootRegions().orEmpty()
+    val korea = roots.firstOrNull { region -> region.code == KoreaCountryCode }
+    val provinces = korea?.let { region -> getCachedChildRegions(region.regionId) }.orEmpty()
+    return MapUiState(
+        rootRegions = roots,
+        koreaProvinces = provinces,
+    )
 }
 
 private const val KoreaCountryCode = "KR"

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/route/TripProfileRoute.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/route/TripProfileRoute.kt
@@ -21,7 +21,7 @@ internal fun TripProfileRoute(
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(viewModel, tripRecordRevision) {
-        viewModel.refresh()
+        viewModel.refresh(dataRevision = tripRecordRevision)
     }
 
     TripProfileScreen(
@@ -32,7 +32,7 @@ internal fun TripProfileRoute(
         onCreateClick = onOpenEditor,
         onProfileClick = onOpenProfile,
         onRetryClick = {
-            scope.launch { viewModel.refresh() }
+            scope.launch { viewModel.refresh(dataRevision = tripRecordRevision) }
         },
     )
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/route/TripProfileRoute.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/route/TripProfileRoute.kt
@@ -1,22 +1,38 @@
 package com.mapmory.shared.presentation.triprecord.route
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import com.mapmory.shared.presentation.triprecord.screen.TripProfileScreen
+import com.mapmory.shared.presentation.triprecord.viewmodel.TripStatisticsViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun TripProfileRoute(
+    viewModel: TripStatisticsViewModel,
+    tripRecordRevision: Long,
     onOpenMap: () -> Unit,
     onOpenRecords: () -> Unit,
     onOpenEditor: () -> Unit,
     onOpenProfile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(viewModel, tripRecordRevision) {
+        viewModel.refresh()
+    }
+
     TripProfileScreen(
         modifier = modifier,
+        statisticsUiState = viewModel.uiState,
         onMapClick = onOpenMap,
         onRecordClick = onOpenRecords,
         onCreateClick = onOpenEditor,
         onProfileClick = onOpenProfile,
+        onRetryClick = {
+            scope.launch { viewModel.refresh() }
+        },
     )
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripProfileScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripProfileScreen.kt
@@ -61,6 +61,7 @@ fun TripProfileScreen(
     onRecordClick: () -> Unit,
     onCreateClick: () -> Unit,
     onProfileClick: () -> Unit,
+    onRetryClick: () -> Unit = {},
     statisticsUiState: TripStatisticsUiState = TripStatisticsUiState.Success(TripStatisticsUiModel.Empty),
     modifier: Modifier = Modifier,
 ) {
@@ -88,7 +89,16 @@ fun TripProfileScreen(
                     modifier = Modifier.fillMaxWidth().weight(1f).padding(24.dp),
                     contentAlignment = Alignment.Center,
                 ) {
-                    Text(statisticsUiState.message, color = TripRecordPalette.current.secondaryText, fontSize = 13.sp)
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            statisticsUiState.message,
+                            color = TripRecordPalette.current.secondaryText,
+                            fontSize = 13.sp,
+                        )
+                        TextButton(onClick = onRetryClick, modifier = Modifier.padding(top = 6.dp)) {
+                            Text("다시 시도", color = TripRecordPalette.current.primary)
+                        }
+                    }
                 }
 
                 is TripStatisticsUiState.Success -> StatisticsContent(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.mapmory.shared.domain.repository.TripStatisticsRepository
+import com.mapmory.shared.logging.mapmoryDebugLog
 import com.mapmory.shared.presentation.triprecord.state.TopLocationUiModel
 import com.mapmory.shared.presentation.triprecord.state.TripStatisticsUiModel
 import com.mapmory.shared.presentation.triprecord.state.TripStatisticsUiState
@@ -23,23 +24,54 @@ class TripStatisticsViewModel(
     )
         private set
 
+    init {
+        cachedStatistics?.let { statistics ->
+            mapmoryDebugLog(
+                StatisticsLogTag,
+                "cache " +
+                    "visitedCountryCount=${statistics.visitedCountryCount}, " +
+                    "visitedKoreaDistrictCount=${statistics.visitedKoreaDistrictCount}",
+            )
+        }
+    }
+
     suspend fun refresh() {
         val generation = ++loadGeneration
         val hasVisibleStatistics = uiState is TripStatisticsUiState.Success
+        mapmoryDebugLog(
+            StatisticsLogTag,
+            "refresh start generation=$generation, hasCachedState=$hasVisibleStatistics",
+        )
         if (!hasVisibleStatistics) {
             uiState = TripStatisticsUiState.Loading
         }
 
         val result = tripStatisticsRepository.getStatistics()
-        if (generation != loadGeneration) return
+        if (generation != loadGeneration) {
+            mapmoryDebugLog(StatisticsLogTag, "refresh ignored generation=$generation")
+            return
+        }
         val statistics = result.getOrElse { error ->
+            mapmoryDebugLog(
+                StatisticsLogTag,
+                "refresh failed, retainedCache=$hasVisibleStatistics: " +
+                    "${error::class.simpleName}: ${error.message}",
+            )
             if (!hasVisibleStatistics) {
                 uiState = error.toUiState("여행 통계를 불러오지 못했습니다.")
             }
             return
         }
 
-        uiState = statistics.toUiState()
+        val nextState = statistics.toUiState()
+        uiState = nextState
+        mapmoryDebugLog(
+            StatisticsLogTag,
+            "ui state " +
+                "worldVisitedCount=${nextState.statistics.worldVisitedCount}, " +
+                "koreaVisitedCount=${nextState.statistics.koreaVisitedCount}, " +
+                "recordCount=${nextState.statistics.recordCount}",
+        )
     }
 
     private fun Throwable.toUiState(fallbackMessage: String) = TripStatisticsUiState.Error(
@@ -68,3 +100,4 @@ private fun com.mapmory.shared.domain.model.TripStatistics.toUiState() =
 private fun Long.toUiCount(): Int = coerceIn(0, Int.MAX_VALUE.toLong()).toInt()
 
 private const val DefaultTravelerName = "여행자"
+private const val StatisticsLogTag = "MapmoryStatistics"

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModel.kt
@@ -16,6 +16,7 @@ class TripStatisticsViewModel(
 ) : ViewModel() {
     private var loadGeneration = 0L
     private val cachedStatistics = tripStatisticsRepository.getCachedStatistics()
+    private var visibleStatisticsRevision: Long? = cachedStatistics?.let { InitialDataRevision }
 
     var uiState by mutableStateOf(
         cachedStatistics
@@ -25,24 +26,21 @@ class TripStatisticsViewModel(
         private set
 
     init {
-        cachedStatistics?.let { statistics ->
-            mapmoryDebugLog(
-                StatisticsLogTag,
-                "cache " +
-                    "visitedCountryCount=${statistics.visitedCountryCount}, " +
-                    "visitedKoreaDistrictCount=${statistics.visitedKoreaDistrictCount}",
-            )
+        if (cachedStatistics != null) {
+            mapmoryDebugLog(StatisticsLogTag, "cache hit")
         }
     }
 
-    suspend fun refresh() {
+    suspend fun refresh(dataRevision: Long = InitialDataRevision) {
         val generation = ++loadGeneration
         val hasVisibleStatistics = uiState is TripStatisticsUiState.Success
+        val canRetainVisibleStatistics =
+            hasVisibleStatistics && visibleStatisticsRevision == dataRevision
         mapmoryDebugLog(
             StatisticsLogTag,
-            "refresh start generation=$generation, hasCachedState=$hasVisibleStatistics",
+            "refresh started generation=$generation, canRetain=$canRetainVisibleStatistics",
         )
-        if (!hasVisibleStatistics) {
+        if (!canRetainVisibleStatistics) {
             uiState = TripStatisticsUiState.Loading
         }
 
@@ -54,29 +52,19 @@ class TripStatisticsViewModel(
         val statistics = result.getOrElse { error ->
             mapmoryDebugLog(
                 StatisticsLogTag,
-                "refresh failed, retainedCache=$hasVisibleStatistics: " +
-                    "${error::class.simpleName}: ${error.message}",
+                "refresh failed, retained=$canRetainVisibleStatistics: ${error::class.simpleName}",
             )
-            if (!hasVisibleStatistics) {
-                uiState = error.toUiState("여행 통계를 불러오지 못했습니다.")
+            if (!canRetainVisibleStatistics) {
+                uiState = TripStatisticsUiState.Error(StatisticsLoadErrorMessage)
             }
             return
         }
 
         val nextState = statistics.toUiState()
         uiState = nextState
-        mapmoryDebugLog(
-            StatisticsLogTag,
-            "ui state " +
-                "worldVisitedCount=${nextState.statistics.worldVisitedCount}, " +
-                "koreaVisitedCount=${nextState.statistics.koreaVisitedCount}, " +
-                "recordCount=${nextState.statistics.recordCount}",
-        )
+        visibleStatisticsRevision = dataRevision
+        mapmoryDebugLog(StatisticsLogTag, "ui state updated")
     }
-
-    private fun Throwable.toUiState(fallbackMessage: String) = TripStatisticsUiState.Error(
-        message = message?.takeIf(String::isNotBlank) ?: fallbackMessage,
-    )
 }
 
 private fun com.mapmory.shared.domain.model.TripStatistics.toUiState() =
@@ -101,3 +89,5 @@ private fun Long.toUiCount(): Int = coerceIn(0, Int.MAX_VALUE.toLong()).toInt()
 
 private const val DefaultTravelerName = "여행자"
 private const val StatisticsLogTag = "MapmoryStatistics"
+private const val StatisticsLoadErrorMessage = "여행 통계를 불러오지 못했습니다."
+private const val InitialDataRevision = 0L

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModel.kt
@@ -1,0 +1,70 @@
+package com.mapmory.shared.presentation.triprecord.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.mapmory.shared.domain.repository.TripStatisticsRepository
+import com.mapmory.shared.presentation.triprecord.state.TopLocationUiModel
+import com.mapmory.shared.presentation.triprecord.state.TripStatisticsUiModel
+import com.mapmory.shared.presentation.triprecord.state.TripStatisticsUiState
+
+/** 전용 여행 통계 API 응답을 화면 상태로 변환한다. */
+class TripStatisticsViewModel(
+    private val tripStatisticsRepository: TripStatisticsRepository,
+) : ViewModel() {
+    private var loadGeneration = 0L
+    private val cachedStatistics = tripStatisticsRepository.getCachedStatistics()
+
+    var uiState by mutableStateOf(
+        cachedStatistics
+            ?.toUiState()
+            ?: TripStatisticsUiState.Loading,
+    )
+        private set
+
+    suspend fun refresh() {
+        val generation = ++loadGeneration
+        val hasVisibleStatistics = uiState is TripStatisticsUiState.Success
+        if (!hasVisibleStatistics) {
+            uiState = TripStatisticsUiState.Loading
+        }
+
+        val result = tripStatisticsRepository.getStatistics()
+        if (generation != loadGeneration) return
+        val statistics = result.getOrElse { error ->
+            if (!hasVisibleStatistics) {
+                uiState = error.toUiState("여행 통계를 불러오지 못했습니다.")
+            }
+            return
+        }
+
+        uiState = statistics.toUiState()
+    }
+
+    private fun Throwable.toUiState(fallbackMessage: String) = TripStatisticsUiState.Error(
+        message = message?.takeIf(String::isNotBlank) ?: fallbackMessage,
+    )
+}
+
+private fun com.mapmory.shared.domain.model.TripStatistics.toUiState() =
+    TripStatisticsUiState.Success(
+        TripStatisticsUiModel(
+            travelerName = DefaultTravelerName,
+            recordCount = recordCount.toUiCount(),
+            photoCount = mediaCount.toUiCount(),
+            worldVisitedCount = visitedCountryCount.toUiCount(),
+            koreaVisitedCount = visitedKoreaDistrictCount.toUiCount(),
+            visitedCountryCodes = visitedCountryCodes.toSet(),
+            topLocations = topRegions.map { region ->
+                TopLocationUiModel(
+                    locationName = region.name,
+                    visitCount = region.recordCount.toUiCount(),
+                )
+            },
+        ),
+    )
+
+private fun Long.toUiCount(): Int = coerceIn(0, Int.MAX_VALUE.toLong()).toInt()
+
+private const val DefaultTravelerName = "여행자"

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/app/AppContainerTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/app/AppContainerTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.runBlocking
 import com.mapmory.shared.presentation.photo.SelectedPhoto
 import com.mapmory.shared.presentation.triprecord.state.TripRecordDetailUiState
 import com.mapmory.shared.presentation.triprecord.state.TripRecordListUiState
+import com.mapmory.shared.presentation.triprecord.state.TripStatisticsUiState
 import com.mapmory.shared.runSuspend
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -203,6 +204,7 @@ class AppContainerTest {
 
         assertIs<TripRecordRemoteRepository>(container.tripRecordRepository)
         assertIs<MapSummaryRemoteRepository>(container.mapSummaryRepository)
+        assertEquals(null, container.tripStatisticsRepository.getCachedStatistics())
         container.close()
     }
 
@@ -240,7 +242,12 @@ class AppContainerTest {
             ),
         )
 
+        val initialStatistics = container.viewModelFactory.createTripStatisticsViewModel()
+        initialStatistics.refresh()
+        assertTrue(container.tripStatisticsRepository.getCachedStatistics() != null)
+
         assertTrue(editor.save())
+        assertEquals(null, container.tripStatisticsRepository.getCachedStatistics())
 
         val list = container.viewModelFactory.createTripRecordListViewModel()
         list.load()
@@ -264,8 +271,19 @@ class AppContainerTest {
             detailState.record.photos.single().previewBytes?.bytesForDecoding(),
         )
 
+        val statistics = container.viewModelFactory.createTripStatisticsViewModel()
+        statistics.refresh()
+        val statisticsState = assertIs<TripStatisticsUiState.Success>(statistics.uiState).statistics
+        assertEquals(1, statisticsState.recordCount)
+        assertEquals(1, statisticsState.photoCount)
+        assertEquals(1, statisticsState.koreaVisitedCount)
+
         assertNotSame(list, container.viewModelFactory.createTripRecordListViewModel())
         assertNotSame(detail, container.viewModelFactory.createTripRecordDetailViewModel())
+        assertNotSame(
+            container.viewModelFactory.createTripStatisticsViewModel(),
+            container.viewModelFactory.createTripStatisticsViewModel(),
+        )
     }
 }
 

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/app/AppContainerTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/app/AppContainerTest.kt
@@ -4,7 +4,6 @@ import com.mapmory.shared.data.local.StaticRegionCatalog
 import com.mapmory.shared.data.auth.AuthTokenStore
 import com.mapmory.shared.data.auth.AuthTokens
 import com.mapmory.shared.data.remote.AccessTokenProvider
-import com.mapmory.shared.data.remote.MapSummaryRemoteRepository
 import com.mapmory.shared.data.remote.TripRecordRemoteRepository
 import com.mapmory.shared.data.remote.configureCommonHttpClient
 import com.mapmory.shared.data.repository.FakeTripRecordRepository
@@ -203,7 +202,7 @@ class AppContainerTest {
         )
 
         assertIs<TripRecordRemoteRepository>(container.tripRecordRepository)
-        assertIs<MapSummaryRemoteRepository>(container.mapSummaryRepository)
+        assertEquals(null, container.mapSummaryRepository.getCachedRootRegions())
         assertEquals(null, container.tripStatisticsRepository.getCachedStatistics())
         container.close()
     }
@@ -218,7 +217,7 @@ class AppContainerTest {
         )
 
         assertSame(repository, container.tripRecordRepository)
-        assertSame(repository, container.mapSummaryRepository)
+        assertEquals(null, container.mapSummaryRepository.getCachedRootRegions())
     }
 
     @Test

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/auth/GuestSessionManagerTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/auth/GuestSessionManagerTest.kt
@@ -52,6 +52,27 @@ class GuestSessionManagerTest {
     }
 
     @Test
+    fun validStoredAccessTokenSkipsRefreshAtAppSessionStart() = runBlocking {
+        val storedTokens = AuthTokens(
+            accessToken = "header.eyJleHAiOjIwMDB9.signature",
+            refreshToken = "stored-refresh",
+        )
+        val gateway = FakeAuthGateway()
+        val store = FakeAuthTokenStore(storedTokens)
+        val session = GuestSessionManager(
+            gateway = gateway,
+            tokenStore = store,
+            nowEpochSeconds = { 1_000L },
+        )
+
+        session.ensureAuthenticated().getOrThrow()
+
+        assertEquals(0, gateway.loginCount)
+        assertEquals(0, gateway.refreshCount)
+        assertEquals(storedTokens.accessToken, session.getAccessToken())
+    }
+
+    @Test
     fun refreshFailureDoesNotCreateAnotherGuestOrDiscardStoredIdentity() = runBlocking {
         val storedTokens = AuthTokens("old-access", "old-refresh")
         val failure = IllegalStateException("refresh failed")

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/TripStatisticsRemoteRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/TripStatisticsRemoteRepositoryTest.kt
@@ -1,0 +1,57 @@
+package com.mapmory.shared.data.remote
+
+import com.mapmory.shared.domain.model.MapRegionType
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TripStatisticsRemoteRepositoryTest {
+    @Test
+    fun `전용_통계_API를_Bearer_토큰으로_조회해_도메인으로_변환한다`() = runBlocking {
+        val client = HttpClient(MockEngine) {
+            configureCommonHttpClient()
+            engine {
+                addHandler { request ->
+                    assertEquals(
+                        "/api/v1/travel-records/statistics",
+                        request.url.encodedPath,
+                    )
+                    assertEquals("Bearer guest-token", request.headers[HttpHeaders.Authorization])
+                    respond(
+                        content = ByteReadChannel(
+                            """{"data":{"recordCount":24,"mediaCount":138,"visitedCountryCount":3,"visitedKoreaDistrictCount":8,"visitedCountryCodes":["JP","KR","US"],"topRegions":[{"regionId":10,"code":"11","regionType":"PROVINCE","name":"서울특별시","recordCount":7},{"regionId":2,"code":"JP","regionType":"COUNTRY","name":"일본","recordCount":4}]}}""",
+                        ),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(
+                            HttpHeaders.ContentType,
+                            ContentType.Application.Json.toString(),
+                        ),
+                    )
+                }
+            }
+        }
+        val repository = TripStatisticsRemoteRepository(
+            client = client,
+            apiBaseUrl = "https://api.example.com/api/v1",
+            accessTokenProvider = AccessTokenProvider { "guest-token" },
+        )
+
+        val statistics = repository.getStatistics().getOrThrow()
+
+        assertEquals(24L, statistics.recordCount)
+        assertEquals(138L, statistics.mediaCount)
+        assertEquals(8L, statistics.visitedKoreaDistrictCount)
+        assertEquals(listOf("JP", "KR", "US"), statistics.visitedCountryCodes)
+        assertEquals(MapRegionType.PROVINCE, statistics.topRegions.first().type)
+        assertEquals("일본", statistics.topRegions.last().name)
+        client.close()
+    }
+}

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/CachedMapSummaryRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/CachedMapSummaryRepositoryTest.kt
@@ -1,0 +1,56 @@
+package com.mapmory.shared.data.repository
+
+import com.mapmory.shared.domain.model.MapRegionLevel
+import com.mapmory.shared.domain.model.MapRegionSummary
+import com.mapmory.shared.domain.model.MapRegionType
+import com.mapmory.shared.domain.repository.MapSummaryRepository
+import com.mapmory.shared.runSuspend
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CachedMapSummaryRepositoryTest {
+    @Test
+    fun `지도_요약을_캐시해_새_화면에서도_즉시_복원하고_무효화한다`() = runSuspend {
+        val korea = summary(1, "KR", MapRegionType.COUNTRY)
+        val seoul = summary(11, "11", MapRegionType.PROVINCE)
+        val cache = MemoryMapSummaryCache()
+        val repository = CachedMapSummaryRepository(
+            delegate = StaticMapSummaryRepository(listOf(korea), mapOf(1L to listOf(seoul))),
+            cache = cache,
+        )
+
+        repository.getRootRegions().getOrThrow()
+        repository.getChildRegions(korea.regionId).getOrThrow()
+
+        val restored = CachedMapSummaryRepository(
+            delegate = StaticMapSummaryRepository(emptyList(), emptyMap()),
+            cache = cache,
+        )
+        assertEquals(listOf(korea), restored.getCachedRootRegions())
+        assertEquals(listOf(seoul), restored.getCachedChildRegions(korea.regionId))
+
+        restored.invalidate()
+
+        assertEquals(null, restored.getCachedRootRegions())
+        assertEquals(null, restored.getCachedChildRegions(korea.regionId))
+    }
+}
+
+private class StaticMapSummaryRepository(
+    private val roots: List<MapRegionSummary>,
+    private val children: Map<Long, List<MapRegionSummary>>,
+) : MapSummaryRepository {
+    override suspend fun getRootRegions(): Result<List<MapRegionSummary>> = Result.success(roots)
+
+    override suspend fun getChildRegions(regionId: Long): Result<List<MapRegionSummary>> =
+        Result.success(children[regionId].orEmpty())
+}
+
+private fun summary(id: Long, code: String, type: MapRegionType) = MapRegionSummary(
+    regionId = id,
+    code = code,
+    type = type,
+    name = code,
+    count = 1,
+    level = MapRegionLevel.LOW,
+)

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/CachedTripStatisticsRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/CachedTripStatisticsRepositoryTest.kt
@@ -1,0 +1,43 @@
+package com.mapmory.shared.data.repository
+
+import com.mapmory.shared.domain.model.TripStatistics
+import com.mapmory.shared.domain.repository.TripStatisticsRepository
+import com.mapmory.shared.runSuspend
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CachedTripStatisticsRepositoryTest {
+    @Test
+    fun `성공한_통계를_캐시하고_기록_변경_시_무효화한다`() = runSuspend {
+        val expected = statistics(recordCount = 3)
+        val repository = CachedTripStatisticsRepository(
+            delegate = StaticTripStatisticsRepository(expected),
+            cache = MemoryTripStatisticsCache(),
+        )
+
+        assertEquals(null, repository.getCachedStatistics())
+
+        repository.getStatistics().getOrThrow()
+
+        assertEquals(expected, repository.getCachedStatistics())
+
+        repository.invalidate()
+
+        assertEquals(null, repository.getCachedStatistics())
+    }
+}
+
+private class StaticTripStatisticsRepository(
+    private val statistics: TripStatistics,
+) : TripStatisticsRepository {
+    override suspend fun getStatistics(): Result<TripStatistics> = Result.success(statistics)
+}
+
+private fun statistics(recordCount: Long) = TripStatistics(
+    recordCount = recordCount,
+    mediaCount = 0,
+    visitedCountryCount = 0,
+    visitedKoreaDistrictCount = 0,
+    visitedCountryCodes = emptyList(),
+    topRegions = emptyList(),
+)

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/viewmodel/MapViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/map/viewmodel/MapViewModelTest.kt
@@ -3,12 +3,33 @@ package com.mapmory.shared.presentation.map.viewmodel
 import com.mapmory.shared.data.local.StaticRegionCatalog
 import com.mapmory.shared.data.repository.FakeTripRecordRepository
 import com.mapmory.shared.domain.model.TripRecordDraft
+import com.mapmory.shared.domain.model.MapRegionLevel
+import com.mapmory.shared.domain.model.MapRegionSummary
+import com.mapmory.shared.domain.model.MapRegionType
+import com.mapmory.shared.domain.repository.MapSummaryRepository
 import com.mapmory.shared.runSuspend
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class MapViewModelTest {
+    @Test
+    fun `캐시된_지도_요약으로_첫_화면을_즉시_구성한다`() {
+        val korea = MapRegionSummary(1, "KR", MapRegionType.COUNTRY, "대한민국", 2, MapRegionLevel.LOW)
+        val seoul = MapRegionSummary(11, "11", MapRegionType.PROVINCE, "서울특별시", 2, MapRegionLevel.LOW)
+        val repository = object : MapSummaryRepository {
+            override fun getCachedRootRegions() = listOf(korea)
+            override fun getCachedChildRegions(regionId: Long) = listOf(seoul)
+            override suspend fun getRootRegions() = Result.success(listOf(korea))
+            override suspend fun getChildRegions(regionId: Long) = Result.success(listOf(seoul))
+        }
+
+        val viewModel = MapViewModel(repository, StaticRegionCatalog())
+
+        assertEquals(setOf("KR"), viewModel.visitedCountryCodes)
+        assertEquals(setOf("KR-11"), viewModel.visitedProvinceCodes)
+    }
+
     @Test
     fun `새로고침은_기록_지역_변경_후_열린_시도를_다시_조회한다`() = runSuspend {
         val catalog = StaticRegionCatalog()

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModelTest.kt
@@ -1,0 +1,120 @@
+package com.mapmory.shared.presentation.triprecord.viewmodel
+
+import com.mapmory.shared.domain.model.MapRegionType
+import com.mapmory.shared.domain.model.TopRegionStatistics
+import com.mapmory.shared.domain.model.TripStatistics
+import com.mapmory.shared.domain.repository.TripStatisticsRepository
+import com.mapmory.shared.presentation.triprecord.state.TripStatisticsUiState
+import com.mapmory.shared.runSuspend
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class TripStatisticsViewModelTest {
+    @Test
+    fun `전용_통계_API_응답을_현재_화면_상태로_변환한다`() = runSuspend {
+        val repository = StubTripStatisticsRepository(
+            responses = mutableListOf(
+                Result.success(statistics(recordCount = 5, mediaCount = 9)),
+            ),
+        )
+        val viewModel = TripStatisticsViewModel(repository)
+
+        viewModel.refresh()
+
+        val statistics = assertIs<TripStatisticsUiState.Success>(viewModel.uiState).statistics
+        assertEquals(5, statistics.recordCount)
+        assertEquals(9, statistics.photoCount)
+        assertEquals(2, statistics.worldVisitedCount)
+        assertEquals(2, statistics.koreaVisitedCount)
+        assertEquals(setOf("JP", "KR"), statistics.visitedCountryCodes)
+        assertEquals(listOf("서울특별시", "일본"), statistics.topLocations.map { it.locationName })
+        assertEquals(listOf(3, 2), statistics.topLocations.map { it.visitCount })
+    }
+
+    @Test
+    fun `다시_조회하면_변경된_서버_통계로_화면_상태를_교체한다`() = runSuspend {
+        val repository = StubTripStatisticsRepository(
+            responses = mutableListOf(
+                Result.success(statistics(recordCount = 1, mediaCount = 2)),
+                Result.success(statistics(recordCount = 2, mediaCount = 5)),
+            ),
+        )
+        val viewModel = TripStatisticsViewModel(repository)
+
+        viewModel.refresh()
+        assertEquals(
+            1,
+            assertIs<TripStatisticsUiState.Success>(viewModel.uiState).statistics.recordCount,
+        )
+
+        viewModel.refresh()
+
+        val updated = assertIs<TripStatisticsUiState.Success>(viewModel.uiState).statistics
+        assertEquals(2, updated.recordCount)
+        assertEquals(5, updated.photoCount)
+        assertEquals(2, repository.requestCount)
+    }
+
+    @Test
+    fun `캐시된_통계는_즉시_표시하고_백그라운드_갱신_실패에도_유지한다`() = runSuspend {
+        val repository = StubTripStatisticsRepository(
+            responses = mutableListOf(Result.failure(IllegalStateException("일시적 오류"))),
+            cached = statistics(recordCount = 4, mediaCount = 7),
+        )
+        val viewModel = TripStatisticsViewModel(repository)
+
+        val cachedState = assertIs<TripStatisticsUiState.Success>(viewModel.uiState).statistics
+        assertEquals(4, cachedState.recordCount)
+        assertEquals(7, cachedState.photoCount)
+
+        viewModel.refresh()
+
+        val retainedState = assertIs<TripStatisticsUiState.Success>(viewModel.uiState).statistics
+        assertEquals(4, retainedState.recordCount)
+        assertEquals(7, retainedState.photoCount)
+    }
+
+    @Test
+    fun `통계_API_조회가_실패하면_오류_상태를_노출한다`() = runSuspend {
+        val viewModel = TripStatisticsViewModel(
+            StubTripStatisticsRepository(
+                mutableListOf(Result.failure(IllegalStateException("서버 연결 실패"))),
+            ),
+        )
+
+        viewModel.refresh()
+
+        assertEquals(
+            TripStatisticsUiState.Error("서버 연결 실패"),
+            viewModel.uiState,
+        )
+    }
+}
+
+private class StubTripStatisticsRepository(
+    private val responses: MutableList<Result<TripStatistics>>,
+    private val cached: TripStatistics? = null,
+) : TripStatisticsRepository {
+    var requestCount: Int = 0
+        private set
+
+    override fun getCachedStatistics(): TripStatistics? = cached
+
+    override suspend fun getStatistics(): Result<TripStatistics> {
+        requestCount += 1
+        return responses.removeAt(0)
+    }
+}
+
+private fun statistics(recordCount: Long, mediaCount: Long) = TripStatistics(
+    recordCount = recordCount,
+    mediaCount = mediaCount,
+    visitedCountryCount = 2,
+    visitedKoreaDistrictCount = 2,
+    visitedCountryCodes = listOf("JP", "KR"),
+    topRegions = listOf(
+        TopRegionStatistics(11, "11", MapRegionType.PROVINCE, "서울특별시", 3),
+        TopRegionStatistics(2, "JP", MapRegionType.COUNTRY, "일본", 2),
+    ),
+)

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripStatisticsViewModelTest.kt
@@ -57,7 +57,7 @@ class TripStatisticsViewModelTest {
     }
 
     @Test
-    fun `캐시된_통계는_즉시_표시하고_백그라운드_갱신_실패에도_유지한다`() = runSuspend {
+    fun `같은_기록_리비전의_캐시된_통계는_백그라운드_갱신_실패에도_유지한다`() = runSuspend {
         val repository = StubTripStatisticsRepository(
             responses = mutableListOf(Result.failure(IllegalStateException("일시적 오류"))),
             cached = statistics(recordCount = 4, mediaCount = 7),
@@ -76,6 +76,25 @@ class TripStatisticsViewModelTest {
     }
 
     @Test
+    fun `기록_변경_후_통계_재조회가_실패하면_이전_통계를_노출하지_않는다`() = runSuspend {
+        val repository = StubTripStatisticsRepository(
+            responses = mutableListOf(
+                Result.success(statistics(recordCount = 4, mediaCount = 7)),
+                Result.failure(IllegalStateException("서버 연결 실패")),
+            ),
+        )
+        val viewModel = TripStatisticsViewModel(repository)
+        viewModel.refresh(dataRevision = 0)
+
+        viewModel.refresh(dataRevision = 1)
+
+        assertEquals(
+            TripStatisticsUiState.Error("여행 통계를 불러오지 못했습니다."),
+            viewModel.uiState,
+        )
+    }
+
+    @Test
     fun `통계_API_조회가_실패하면_오류_상태를_노출한다`() = runSuspend {
         val viewModel = TripStatisticsViewModel(
             StubTripStatisticsRepository(
@@ -86,7 +105,7 @@ class TripStatisticsViewModelTest {
         viewModel.refresh()
 
         assertEquals(
-            TripStatisticsUiState.Error("서버 연결 실패"),
+            TripStatisticsUiState.Error("여행 통계를 불러오지 못했습니다."),
             viewModel.uiState,
         )
     }

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/MainViewController.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/MainViewController.kt
@@ -8,6 +8,8 @@ import com.mapmory.shared.app.createGuestRemoteAppContainer
 import com.mapmory.shared.analytics.MapmoryAnalytics
 import com.mapmory.shared.data.auth.IosAuthTokenStore
 import com.mapmory.shared.data.media.IosPhotoPreviewCache
+import com.mapmory.shared.data.repository.IosTripStatisticsCache
+import com.mapmory.shared.data.repository.IosMapSummaryCache
 
 fun MainViewController(
     onThemeChanged: (Boolean) -> Unit,
@@ -15,6 +17,8 @@ fun MainViewController(
 ) = createGuestRemoteAppContainer(
     tokenStore = IosAuthTokenStore(),
     photoPreviewCache = IosPhotoPreviewCache(),
+    mapSummaryCache = IosMapSummaryCache(),
+    tripStatisticsCache = IosTripStatisticsCache(),
 ).let { container ->
     ComposeUIViewController {
         DisposableEffect(container) {

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/data/repository/IosMapSummaryCache.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/data/repository/IosMapSummaryCache.kt
@@ -1,0 +1,23 @@
+package com.mapmory.shared.data.repository
+
+import kotlinx.serialization.json.Json
+import platform.Foundation.NSUserDefaults
+
+class IosMapSummaryCache : MapSummaryCache {
+    private val preferences = NSUserDefaults.standardUserDefaults
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun read(): MapSummarySnapshot? = preferences.stringForKey(SnapshotKey)
+        ?.let { payload -> runCatching { json.decodeFromString<MapSummarySnapshot>(payload) }.getOrNull() }
+
+    override fun write(snapshot: MapSummarySnapshot) {
+        val payload = runCatching { json.encodeToString(snapshot) }.getOrNull() ?: return
+        preferences.setObject(payload, forKey = SnapshotKey)
+    }
+
+    override fun clear() {
+        preferences.removeObjectForKey(SnapshotKey)
+    }
+}
+
+private const val SnapshotKey = "mapmory_latest_map_summary"

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/data/repository/IosTripStatisticsCache.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/data/repository/IosTripStatisticsCache.kt
@@ -1,0 +1,24 @@
+package com.mapmory.shared.data.repository
+
+import com.mapmory.shared.domain.model.TripStatistics
+import kotlinx.serialization.json.Json
+import platform.Foundation.NSUserDefaults
+
+class IosTripStatisticsCache : TripStatisticsCache {
+    private val preferences = NSUserDefaults.standardUserDefaults
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun read(): TripStatistics? = preferences.stringForKey(StatisticsKey)
+        ?.let { payload -> runCatching { json.decodeFromString<TripStatistics>(payload) }.getOrNull() }
+
+    override fun write(statistics: TripStatistics) {
+        val payload = runCatching { json.encodeToString(statistics) }.getOrNull() ?: return
+        preferences.setObject(payload, forKey = StatisticsKey)
+    }
+
+    override fun clear() {
+        preferences.removeObjectForKey(StatisticsKey)
+    }
+}
+
+private const val StatisticsKey = "mapmory_latest_statistics"

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/logging/MapmoryDebugLog.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/logging/MapmoryDebugLog.ios.kt
@@ -1,0 +1,5 @@
+package com.mapmory.shared.logging
+
+internal actual fun mapmoryDebugLog(tag: String, message: String) {
+    println("D/$tag: $message")
+}

--- a/client/shared/src/jvmMain/kotlin/com/mapmory/shared/logging/MapmoryDebugLog.jvm.kt
+++ b/client/shared/src/jvmMain/kotlin/com/mapmory/shared/logging/MapmoryDebugLog.jvm.kt
@@ -1,0 +1,5 @@
+package com.mapmory.shared.logging
+
+internal actual fun mapmoryDebugLog(tag: String, message: String) {
+    println("D/$tag: $message")
+}


### PR DESCRIPTION
## 요약

- `GET /api/v1/travel-records/statistics` 응답을 프로필 통계 화면에 연결합니다.
- 기록 변경 시 통계와 지도 상태를 갱신하고, 앱 재진입 시 캐시를 먼저 표시하도록 로딩을 개선합니다.
- 통계 API 응답과 화면 전환을 확인할 수 있는 디버그 로그를 추가합니다.

## 배경

통계 화면이 정적 상태를 사용해 실제 기록 수, 방문 국가 수, 국내 도시 수가 반영되지 않았습니다.
또한 앱 종료 후 재진입하거나 화면을 다시 열 때 인증 갱신과 데이터 재조회로 대기 시간이 길어지는 문제가 있었습니다.

## 주요 결정

- API의 `visitedCountryCount`를 국가 수로, `visitedKoreaDistrictCount`를 국내 도시 수로 매핑합니다.
- 통계와 지도 요약을 Android/iOS 로컬 캐시에 저장하고 stale-while-revalidate 방식으로 갱신합니다.
- 유효 기간이 충분한 JWT는 앱 재실행 시 재사용하고, 만료가 임박한 경우에만 갱신합니다.
- `MapmoryStatistics`, `MapmoryNavigation` 태그로 응답 값과 화면 진입을 추적합니다.

## 한계

실제 API 환경이 아직 준비되지 않아 배포 환경의 응답과 화면을 연결한 E2E 확인은 진행하지 못했습니다.
API 환경이 준비되는 대로 실제 응답의 국가 수와 국내 도시 수를 Logcat에서 확인하고 후속 검증할 예정입니다.

## 확인

- [x] `:shared:allTests` 통과
- [x] `:androidApp:assembleDebug` 통과
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 새 환경변수 추가 없음
- [x] DB 스키마 변경 없음
- [x] 실행 방법 및 환경 설정 변경 없음