### PR TITLE
refactor: 출시 알림 이메일을 값 객체로 추출하고 서비스의 DTO 의존 제거

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/waitlist/Email.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/Email.java
@@ -1,0 +1,65 @@
+package com.mapmory.backend.waitlist;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.text.Normalizer;
+import java.util.Locale;
+
+/**
+ * 출시 알림 신청에 쓰는 이메일. 항상 정규화된 형태로만 존재한다.
+ *
+ * <p>정규화가 값 객체 밖에 있으면 같은 주소가 다른 문자열로 저장될 수 있다.
+ * {@code launch_waitlist.email}은 {@code utf8mb4_0900_bin} 대소문자 구분 콜레이션이라
+ * UNIQUE 제약이 {@code A@x.com}과 {@code a@x.com}을 서로 다른 값으로 본다.
+ * 중복 신청을 막는 책임이 애플리케이션에 있으므로 생성 경로에서 강제한다.
+ *
+ * <p>형식 검증(@Email)은 요청 DTO가 담당한다. 여기서는 저장 가능한 형태인지만 본다.
+ */
+@Embeddable
+record Email(
+        @Column(name = "email", nullable = false, length = 254)
+        String value
+) {
+    private static final int MAX_LENGTH = 254;
+
+    Email {
+        validateNotBlank(value);
+        validateLength(value);
+        validateNormalized(value);
+    }
+
+    static Email from(String rawEmail) {
+        validateNotNull(rawEmail);
+
+        return new Email(normalize(rawEmail));
+    }
+
+    private static String normalize(String rawEmail) {
+        return Normalizer.normalize(rawEmail.trim(), Normalizer.Form.NFKC)
+                .toLowerCase(Locale.ROOT);
+    }
+
+    private static void validateNotNull(String rawEmail) {
+        if (rawEmail == null) {
+            throw new IllegalArgumentException("email must not be null");
+        }
+    }
+
+    private static void validateNotBlank(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("email must not be blank");
+        }
+    }
+
+    private static void validateLength(String value) {
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("email must not exceed " + MAX_LENGTH + " characters");
+        }
+    }
+
+    private static void validateNormalized(String value) {
+        if (!value.equals(normalize(value))) {
+            throw new IllegalArgumentException("email must be normalized");
+        }
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/waitlist/Email.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/Email.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.waitlist;
 
+import com.mapmory.backend.common.exception.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.text.Normalizer;
@@ -41,25 +42,29 @@ record Email(
 
     private static void validateNotNull(String rawEmail) {
         if (rawEmail == null) {
-            throw new IllegalArgumentException("email must not be null");
+            throwInvalidEmail();
         }
     }
 
     private static void validateNotBlank(String value) {
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("email must not be blank");
+            throwInvalidEmail();
         }
     }
 
     private static void validateLength(String value) {
         if (value.length() > MAX_LENGTH) {
-            throw new IllegalArgumentException("email must not exceed " + MAX_LENGTH + " characters");
+            throwInvalidEmail();
         }
     }
 
     private static void validateNormalized(String value) {
         if (!value.equals(normalize(value))) {
-            throw new IllegalArgumentException("email must be normalized");
+            throwInvalidEmail();
         }
+    }
+
+    private static void throwInvalidEmail() {
+        throw new BusinessException(LaunchWaitlistErrorCode.INVALID_EMAIL);
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistController.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistController.java
@@ -3,7 +3,6 @@ package com.mapmory.backend.waitlist;
 import com.mapmory.backend.common.dto.ApiResponse;
 import com.mapmory.backend.waitlist.dto.LaunchWaitlistRequest;
 import com.mapmory.backend.waitlist.dto.LaunchWaitlistResponse;
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistStatus;
 import jakarta.validation.Valid;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
@@ -26,8 +25,9 @@ public class LaunchWaitlistController {
     public ResponseEntity<ApiResponse<LaunchWaitlistResponse>> subscribe(
             @Valid @RequestBody LaunchWaitlistRequest request
     ) {
-        LaunchWaitlistResponse response = service.subscribe(request);
-        if (response.status() == LaunchWaitlistStatus.ALREADY_SUBSCRIBED) {
+        LaunchWaitlistStatus status = service.subscribe(request.email());
+        LaunchWaitlistResponse response = LaunchWaitlistResponse.from(status);
+        if (status == LaunchWaitlistStatus.ALREADY_SUBSCRIBED) {
             return ResponseEntity.ok(ApiResponse.from(response));
         }
         return ResponseEntity.created(URI.create("/api/v1/waitlist"))

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistEntry.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistEntry.java
@@ -2,6 +2,7 @@ package com.mapmory.backend.waitlist;
 
 import com.mapmory.backend.common.entity.BaseEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,8 +25,8 @@ public class LaunchWaitlistEntry extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 254)
-    private String email;
+    @Embedded
+    private Email email;
 
     @Column(name = "consented_at", nullable = false, updatable = false)
     private LocalDateTime consentedAt;
@@ -33,13 +34,13 @@ public class LaunchWaitlistEntry extends BaseEntity {
     protected LaunchWaitlistEntry() {
     }
 
-    private LaunchWaitlistEntry(String email, LocalDateTime consentedAt) {
+    private LaunchWaitlistEntry(Email email, LocalDateTime consentedAt) {
         this.email = email;
         this.consentedAt = consentedAt;
     }
 
-    public static LaunchWaitlistEntry of(String normalizedEmail, LocalDateTime consentedAt) {
-        return new LaunchWaitlistEntry(normalizedEmail, consentedAt);
+    public static LaunchWaitlistEntry of(Email email, LocalDateTime consentedAt) {
+        return new LaunchWaitlistEntry(email, consentedAt);
     }
 
     public Long getId() {
@@ -47,7 +48,7 @@ public class LaunchWaitlistEntry extends BaseEntity {
     }
 
     String getEmail() {
-        return email;
+        return email.value();
     }
 
     LocalDateTime getConsentedAt() {

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistErrorCode.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistErrorCode.java
@@ -1,0 +1,46 @@
+package com.mapmory.backend.waitlist;
+
+import com.mapmory.backend.common.exception.ErrorCode;
+import com.mapmory.backend.common.exception.ErrorKind;
+
+public enum LaunchWaitlistErrorCode implements ErrorCode {
+
+    INVALID_EMAIL(
+            ErrorKind.INVALID_INPUT,
+            "VALIDATION_ERROR",
+            "요청 값이 올바르지 않습니다.",
+            "이메일은 비어 있을 수 없으며 254자 이하여야 합니다."
+    );
+
+    private final ErrorKind kind;
+    private final String code;
+    private final String title;
+    private final String detail;
+
+    LaunchWaitlistErrorCode(ErrorKind kind, String code, String title, String detail) {
+        this.kind = kind;
+        this.code = code;
+        this.title = title;
+        this.detail = detail;
+    }
+
+    @Override
+    public ErrorKind kind() {
+        return kind;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String title() {
+        return title;
+    }
+
+    @Override
+    public String detail() {
+        return detail;
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistRepository.java
@@ -1,8 +1,15 @@
 package com.mapmory.backend.waitlist;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LaunchWaitlistRepository extends JpaRepository<LaunchWaitlistEntry, Long> {
 
-    boolean existsByEmail(String email);
+    @Query("""
+            SELECT CASE WHEN COUNT(e) > 0 THEN TRUE ELSE FALSE END
+            FROM LaunchWaitlistEntry e
+            WHERE e.email.value = :email
+            """)
+    boolean existsByEmail(@Param("email") String email);
 }

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistService.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistService.java
@@ -1,11 +1,7 @@
 package com.mapmory.backend.waitlist;
 
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistRequest;
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistResponse;
-import java.text.Normalizer;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Locale;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -28,27 +24,18 @@ public class LaunchWaitlistService {
     }
 
     @Transactional
-    public LaunchWaitlistResponse subscribe(LaunchWaitlistRequest request) {
-        String normalizedEmail = normalizeEmail(request.email());
-        if (repository.existsByEmail(normalizedEmail)) {
-            return LaunchWaitlistResponse.alreadySubscribed();
+    public LaunchWaitlistStatus subscribe(String rawEmail) {
+        Email email = Email.from(rawEmail);
+        if (repository.existsByEmail(email.value())) {
+            return LaunchWaitlistStatus.ALREADY_SUBSCRIBED;
         }
 
-        LaunchWaitlistEntry entry = LaunchWaitlistEntry.of(
-                normalizedEmail,
-                LocalDateTime.now(clock)
-        );
         try {
-            repository.saveAndFlush(entry);
-            return LaunchWaitlistResponse.subscribed();
+            repository.saveAndFlush(LaunchWaitlistEntry.of(email, LocalDateTime.now(clock)));
+            return LaunchWaitlistStatus.SUBSCRIBED;
         } catch (DataIntegrityViolationException exception) {
             // 동시에 같은 주소가 들어온 경우에도 한 번만 저장하고 성공으로 취급한다.
-            return LaunchWaitlistResponse.alreadySubscribed();
+            return LaunchWaitlistStatus.ALREADY_SUBSCRIBED;
         }
-    }
-
-    static String normalizeEmail(String email) {
-        return Normalizer.normalize(email.trim(), Normalizer.Form.NFKC)
-                .toLowerCase(Locale.ROOT);
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistStatus.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistStatus.java
@@ -1,4 +1,4 @@
-package com.mapmory.backend.waitlist.dto;
+package com.mapmory.backend.waitlist;
 
 public enum LaunchWaitlistStatus {
     SUBSCRIBED,

--- a/backend/src/main/java/com/mapmory/backend/waitlist/dto/LaunchWaitlistResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/dto/LaunchWaitlistResponse.java
@@ -1,12 +1,10 @@
 package com.mapmory.backend.waitlist.dto;
 
+import com.mapmory.backend.waitlist.LaunchWaitlistStatus;
+
 public record LaunchWaitlistResponse(LaunchWaitlistStatus status) {
 
-    public static LaunchWaitlistResponse subscribed() {
-        return new LaunchWaitlistResponse(LaunchWaitlistStatus.SUBSCRIBED);
-    }
-
-    public static LaunchWaitlistResponse alreadySubscribed() {
-        return new LaunchWaitlistResponse(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
+    public static LaunchWaitlistResponse from(LaunchWaitlistStatus status) {
+        return new LaunchWaitlistResponse(status);
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/waitlist/EmailTest.java
+++ b/backend/src/test/java/com/mapmory/backend/waitlist/EmailTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.mapmory.backend.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -34,8 +35,7 @@ class EmailTest {
     @NullAndEmptySource
     @ValueSource(strings = {" ", "\t"})
     void 비어_있는_주소를_거부한다(String rawEmail) {
-        assertThatThrownBy(() -> Email.from(rawEmail))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertInvalidEmail(() -> Email.from(rawEmail));
     }
 
     @Test
@@ -49,13 +49,18 @@ class EmailTest {
     void 저장_한계를_넘는_주소를_거부한다() {
         String localPart = "a".repeat(MAX_LENGTH - "@example.com".length() + 1);
 
-        assertThatThrownBy(() -> Email.from(localPart + "@example.com"))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertInvalidEmail(() -> Email.from(localPart + "@example.com"));
     }
 
     @Test
     void 정규화되지_않은_값으로는_만들_수_없다() {
-        assertThatThrownBy(() -> new Email("USER@example.com"))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertInvalidEmail(() -> new Email("USER@example.com"));
+    }
+
+    private void assertInvalidEmail(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo("VALIDATION_ERROR");
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/waitlist/EmailTest.java
+++ b/backend/src/test/java/com/mapmory/backend/waitlist/EmailTest.java
@@ -1,0 +1,61 @@
+package com.mapmory.backend.waitlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EmailTest {
+
+    private static final int MAX_LENGTH = 254;
+
+    @Test
+    void 앞뒤_공백과_대문자를_정규화한다() {
+        assertThat(Email.from("  MapMory.User@Example.COM  ").value())
+                .isEqualTo("mapmory.user@example.com");
+    }
+
+    @Test
+    void 호환_문자를_NFKC로_정규화한다() {
+        assertThat(Email.from("ＵＳＥＲ@example.com").value())
+                .isEqualTo("user@example.com");
+    }
+
+    @Test
+    void 대소문자만_다른_주소는_같은_값이_된다() {
+        assertThat(Email.from("USER@example.com")).isEqualTo(Email.from("user@EXAMPLE.com"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t"})
+    void 비어_있는_주소를_거부한다(String rawEmail) {
+        assertThatThrownBy(() -> Email.from(rawEmail))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 저장_한계_길이는_허용한다() {
+        String localPart = "a".repeat(MAX_LENGTH - "@example.com".length());
+
+        assertThatCode(() -> Email.from(localPart + "@example.com")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 저장_한계를_넘는_주소를_거부한다() {
+        String localPart = "a".repeat(MAX_LENGTH - "@example.com".length() + 1);
+
+        assertThatThrownBy(() -> Email.from(localPart + "@example.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 정규화되지_않은_값으로는_만들_수_없다() {
+        assertThatThrownBy(() -> new Email("USER@example.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/waitlist/LaunchWaitlistControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/waitlist/LaunchWaitlistControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +34,7 @@ class LaunchWaitlistControllerTest {
 
     @Test
     void 출시_알림을_신청하면_201로_응답한다() throws Exception {
-        when(service.subscribe(any())).thenReturn(LaunchWaitlistResponse.subscribed());
+        when(service.subscribe(any())).thenReturn(LaunchWaitlistStatus.SUBSCRIBED);
 
         mockMvc.perform(post("/api/v1/waitlist")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -46,7 +45,7 @@ class LaunchWaitlistControllerTest {
 
     @Test
     void 이미_등록된_이메일은_200으로_응답한다() throws Exception {
-        when(service.subscribe(any())).thenReturn(LaunchWaitlistResponse.alreadySubscribed());
+        when(service.subscribe(any())).thenReturn(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
 
         mockMvc.perform(post("/api/v1/waitlist")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/mapmory/backend/waitlist/LaunchWaitlistServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/waitlist/LaunchWaitlistServiceTest.java
@@ -6,9 +6,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistRequest;
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistResponse;
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistStatus;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -40,11 +37,9 @@ class LaunchWaitlistServiceTest {
 
     @Test
     void 이메일을_정규화해_출시_알림을_신청한다() {
-        LaunchWaitlistRequest request = request("  MapMory.User@Example.COM  ");
+        LaunchWaitlistStatus status = service.subscribe("  MapMory.User@Example.COM  ");
 
-        LaunchWaitlistResponse response = service.subscribe(request);
-
-        assertThat(response.status()).isEqualTo(LaunchWaitlistStatus.SUBSCRIBED);
+        assertThat(status).isEqualTo(LaunchWaitlistStatus.SUBSCRIBED);
         ArgumentCaptor<LaunchWaitlistEntry> captor = ArgumentCaptor.forClass(LaunchWaitlistEntry.class);
         verify(repository).saveAndFlush(captor.capture());
         assertThat(captor.getValue().getEmail()).isEqualTo("mapmory.user@example.com");
@@ -55,9 +50,9 @@ class LaunchWaitlistServiceTest {
     void 이미_등록된_이메일은_다시_저장하지_않는다() {
         when(repository.existsByEmail("user@example.com")).thenReturn(true);
 
-        LaunchWaitlistResponse response = service.subscribe(request("USER@example.com"));
+        LaunchWaitlistStatus status = service.subscribe("USER@example.com");
 
-        assertThat(response.status()).isEqualTo(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
+        assertThat(status).isEqualTo(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
         verify(repository, never()).saveAndFlush(any());
     }
 
@@ -65,12 +60,8 @@ class LaunchWaitlistServiceTest {
     void 동시에_같은_이메일이_저장되어도_중복_신청으로_응답한다() {
         when(repository.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("duplicate"));
 
-        LaunchWaitlistResponse response = service.subscribe(request("user@example.com"));
+        LaunchWaitlistStatus status = service.subscribe("user@example.com");
 
-        assertThat(response.status()).isEqualTo(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
-    }
-
-    private LaunchWaitlistRequest request(String email) {
-        return new LaunchWaitlistRequest(email, true, true);
+        assertThat(status).isEqualTo(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
     }
 }


### PR DESCRIPTION
관련 이슈: #199 (Service 계층의 DTO 반환을 도메인 객체 반환으로 변경)

## 요약

`LaunchWaitlistService`에서 두 가지를 정리합니다. 같은 메서드(`subscribe`)를 건드려 나눌 수 없어 한 PR에 담았습니다.

1. **도메인 규칙을 값 객체로** — 이메일 정규화가 응용 서비스에 있었습니다.
2. **웹 DTO 의존 제거** — `#199`의 대상입니다.

API 응답과 상태 코드는 그대로입니다.

---

## 1. 이메일 정규화를 값 객체로

### 문제

정규화(`trim` + NFKC + 소문자)가 `LaunchWaitlistService`의 `static` 메서드에 있었습니다.

```java
static String normalizeEmail(String email) {
    return Normalizer.normalize(email.trim(), Normalizer.Form.NFKC).toLowerCase(Locale.ROOT);
}
```

`LaunchWaitlistEntry.of(normalizedEmail, ...)`는 이름으로만 "정규화된 값"을 요구할 뿐
실제로는 아무 문자열이나 받습니다. 서비스를 거치지 않으면 정규화가 생략됩니다.

**이게 DB로 새면 실제 중복이 됩니다.**

```sql
email VARCHAR(254) COLLATE utf8mb4_0900_bin NOT NULL,
CONSTRAINT uk_launch_waitlist_email UNIQUE (email)
```

`utf8mb4_0900_bin`은 **대소문자를 구분**합니다. UNIQUE 제약이 `A@x.com`과 `a@x.com`을
서로 다른 값으로 보기 때문에, 중복 신청을 막는 책임이 전적으로 애플리케이션에 있습니다.

### 해결

`TagName`과 같은 방식으로 `Email` 값 객체를 만들어 생성 경로에서 강제합니다.

- 정규화: `trim` + NFKC + 소문자
- 저장 가능 여부: 비어 있지 않음, 254자 이하
- 형식 검증(`@Email`)은 **요청 DTO에 그대로** 둡니다. 값 객체는 저장 가능한 형태인지만 봅니다.

`TagName`처럼 package-private이고, `LaunchWaitlistEntry.getEmail()`은 `String`을 반환해
바깥에서는 타입이 드러나지 않습니다.

리포지토리는 `TagRepository`가 `t.tagName.nameKey` 경로를 쓰는 선례대로
`e.email.value` 명시 쿼리로 바꿨습니다. 메서드 이름과 파라미터 타입은 그대로입니다.

---

## 2. 서비스의 웹 DTO 의존 제거 (#199)

### 입력 — 원시 값으로

`LaunchWaitlistRequest`의 세 필드 중 서비스가 쓰는 것은 `email` 하나뿐입니다.
나머지 둘은 저장하지 않는 **웹 계층 동의 확인**입니다.

| 필드 | 성격 |
| --- | --- |
| `email` | 서비스가 사용 |
| `privacyConsent` | `@AssertTrue` — 저장하지 않음 |
| `ageConfirmed` | `@AssertTrue` — 저장하지 않음 |

커맨드를 만들 이유가 없어 `subscribe(String email)`로 풀었습니다.

### 출력 — 도메인 상태로

`LaunchWaitlistStatus`("새 신청인가, 이미 있는가")는 도메인 개념인데 `dto` 패키지에 있었습니다.
`waitlist` 패키지로 옮기고 서비스가 이를 반환합니다. 응답 조립은 컨트롤러가 맡습니다.
ADR 0016이 채택한 *"Service는 읽기 모델을 반환하고 Controller가 DTO로 변환한다"* 와 같은 규칙입니다.

| 변경 전 | 변경 후 |
| --- | --- |
| `LaunchWaitlistResponse subscribe(LaunchWaitlistRequest)` | `LaunchWaitlistStatus subscribe(String email)` |

---

## API 영향 — 없음

- 응답 레코드의 필드명(`status`)과 열거 상수(`SUBSCRIBED`, `ALREADY_SUBSCRIBED`)가 그대로라
  **JSON이 동일**합니다. `LaunchWaitlistStatus`는 패키지만 옮겼습니다.
- 상태 코드(신규 201 / 중복 200)도 그대로입니다.
- 요청 DTO는 손대지 않았습니다.

## 별도 이슈를 만들지 않은 이유

`AuthService`·`UploadService`·`RegionMapSummaryService`를 확인했는데 **정규화나 형식 검증 로직이
하나도 없습니다.** waitlist가 유일해서 후속 작업이 없고, 두 변경이 같은 메서드를 건드려
나눌 수도 없어 PR 하나로 묶었습니다. `TagName` 선례를 그대로 적용하는 것이라 ADR도 만들지 않았습니다.

---

## 3. 예외를 프로젝트 표준으로

처음엔 `Email`이 `IllegalArgumentException`을 던지게 했는데, 표준에서 벗어나 있었습니다.

도메인 7개(`auth`, `member`, `region`, `travelrecord`, `tag`, `upload`)가
`XxxErrorCode implements ErrorCode` + `BusinessException`을 쓰는데 **`waitlist`만 없었습니다.**

`LaunchWaitlistErrorCode.INVALID_EMAIL`을 추가하고 `BusinessException`을 던지도록 바꿨습니다.
`TagName`이 `TagErrorCode.INVALID_TAG_NAME`을 던지는 것과 같은 구조입니다.

```java
INVALID_EMAIL(
        ErrorKind.INVALID_INPUT,
        "VALIDATION_ERROR",
        "요청 값이 올바르지 않습니다.",
        "이메일은 비어 있을 수 없으며 254자 이하여야 합니다."
)
```

**코드 문자열은 `TagName` 선례대로 `VALIDATION_ERROR`를 재사용합니다.** 새 코드가 아니므로
API 오류 계약이 늘지 않습니다. `ErrorKind.INVALID_INPUT`이라 `BusinessExceptionHandler`가 400으로 매핑합니다.

`ExpiringUrl`과 `LevelPolicy`는 `IllegalArgumentException`을 그대로 뒀습니다.
둘은 사용자 요청이 아니라 **프로그래밍·설정 오류**를 나타내므로 성격이 다릅니다.

## 한계

- `Email`은 형식을 검증하지 않습니다. `@Email`이 요청 DTO에 있고, 이메일 형식 규칙을 두 곳에
  두면 어긋날 여지가 생깁니다.
- 요청 DTO 검증이 먼저 걸러내므로 `INVALID_EMAIL`은 HTTP 경로로는 도달하지 않습니다.
  서비스를 직접 호출하는 경로에 대한 방어입니다.

## 확인

- [x] 로컬에서 실행 확인 — `./gradlew test` 63개 클래스 / 286개 통과 (`Email` 테스트 10건 추가)
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [ ] 새 환경변수를 추가했다면 `.env.example` 갱신 — 해당 없음
- [x] DB 스키마 변경 없음 — `email` 컬럼 매핑 그대로
- [ ] 실행 방법이나 환경 설정이 바뀌었다면 README 갱신 — 해당 없음