### PR TITLE
refactor: TravelRecordService의 웹 계층 DTO 의존 제거

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/travelrecord/MediaView.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/MediaView.java
@@ -1,0 +1,15 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+
+/**
+ * 미디어와 그 조회용 URL의 조합.
+ *
+ * <p>URL을 Object Key 기준 맵으로 넘기면 정렬 순서를 잃는다. 짝지은 목록으로 넘겨
+ * 애그리거트가 정한 sortOrder 순서가 응답까지 그대로 이어지게 한다.
+ */
+public record MediaView(
+        RecordMedia recordMedia,
+        ExpiringUrl viewUrl
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordAssembler.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordAssembler.java
@@ -1,0 +1,85 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.recordmedia.RecordMediaUrlService;
+import com.mapmory.backend.tag.Tag;
+import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+/**
+ * TravelRecord 애그리거트의 읽기 모델을 조립한다.
+ *
+ * <p>ADR 0017 결정 4에 따라 애그리거트당 하나만 둔다. 조회와 URL 발급을 맡으므로
+ * 애그리거트 내부가 아니라 응용 계층에 속한다.
+ */
+@Component
+public class TravelRecordAssembler {
+
+    private final TravelRecordRepository travelRecordRepository;
+    private final TravelRecordTagService travelRecordTagService;
+    private final RecordMediaUrlService recordMediaUrlService;
+
+    public TravelRecordAssembler(
+            TravelRecordRepository travelRecordRepository,
+            TravelRecordTagService travelRecordTagService,
+            RecordMediaUrlService recordMediaUrlService
+    ) {
+        this.travelRecordRepository = travelRecordRepository;
+        this.travelRecordTagService = travelRecordTagService;
+        this.recordMediaUrlService = recordMediaUrlService;
+    }
+
+    public TravelRecordDetail assembleDetail(TravelRecord travelRecord) {
+        return assembleDetail(
+                travelRecord,
+                travelRecordTagService.findByTravelRecordId(travelRecord.getId())
+        );
+    }
+
+    /**
+     * 태그를 이미 알고 있는 수정 경로용. 같은 트랜잭션에서 다시 조회하지 않는다.
+     */
+    public TravelRecordDetail assembleDetail(TravelRecord travelRecord, List<Tag> tags) {
+        return new TravelRecordDetail(travelRecord, tags, toMediaViews(travelRecord));
+    }
+
+    public TravelRecordSummaries assembleSummaries(Page<TravelRecord> travelRecords) {
+        List<Long> travelRecordIds = travelRecords.getContent().stream()
+                .map(TravelRecord::getId)
+                .toList();
+
+        return new TravelRecordSummaries(
+                travelRecords,
+                travelRecordTagService.findByTravelRecordIds(travelRecordIds),
+                createThumbnailUrls(travelRecordIds)
+        );
+    }
+
+    private List<MediaView> toMediaViews(TravelRecord travelRecord) {
+        return travelRecord.getMedia().stream()
+                .map(recordMedia -> new MediaView(
+                        recordMedia,
+                        recordMediaUrlService.createViewUrl(recordMedia.getObjectKey())
+                ))
+                .toList();
+    }
+
+    private Map<Long, ExpiringUrl> createThumbnailUrls(List<Long> travelRecordIds) {
+        if (travelRecordIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, ExpiringUrl> thumbnailUrls = new HashMap<>();
+        for (RecordMedia recordMedia : travelRecordRepository.findMediaByTravelRecordIdIn(travelRecordIds)) {
+            thumbnailUrls.computeIfAbsent(
+                    recordMedia.travelRecordId(),
+                    ignored -> recordMediaUrlService.createViewUrl(recordMedia.getThumbnailObjectKey())
+            );
+        }
+        return Map.copyOf(thumbnailUrls);
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordCommand.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordCommand.java
@@ -1,0 +1,28 @@
+package com.mapmory.backend.travelrecord;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 여행 일지 생성·수정에 필요한 값을 서비스 계층 형태로 담는다.
+ * 웹 요청 스펙(TravelRecordRequest)과 분리해 서비스가 API 계약에 의존하지 않게 한다.
+ *
+ * <p>속성이 9개라 원시 값으로 풀면 순서만 바꿔도 컴파일이 통과하는 시그니처가 된다.
+ * 그래서 Tag와 달리 커맨드를 둔다. (ADR 0017)
+ */
+public record TravelRecordCommand(
+        String countryCode,
+        String provinceCode,
+        String districtCode,
+        String title,
+        String content,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> objectKeys,
+        List<Long> tagIds
+) {
+    public TravelRecordCommand {
+        objectKeys = objectKeys == null ? List.of() : objectKeys;
+        tagIds = tagIds == null ? List.of() : tagIds;
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -38,7 +38,7 @@ public class TravelRecordController {
             @LoginMember Member member,
             @Valid @RequestBody TravelRecordRequest travelRecordRequest
     ) {
-        TravelRecord travelRecord = travelRecordService.create(member, travelRecordRequest);
+        TravelRecord travelRecord = travelRecordService.create(member, travelRecordRequest.toCommand());
         CreateTravelRecordResponse response = CreateTravelRecordResponse.from(travelRecord);
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -55,7 +55,7 @@ public class TravelRecordController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
-        TravelRecordListResponse response = travelRecordService.findAll(
+        TravelRecordSummaries summaries = travelRecordService.findAll(
                 member,
                 countryCode,
                 provinceCode,
@@ -64,6 +64,7 @@ public class TravelRecordController {
                 page,
                 size
         );
+        TravelRecordListResponse response = TravelRecordListResponse.from(summaries);
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }
@@ -73,7 +74,9 @@ public class TravelRecordController {
             @LoginMember Member member,
             @PathVariable @Positive Long travelRecordId
     ) {
-        TravelRecordDetailResponse response = travelRecordService.findById(member, travelRecordId);
+        TravelRecordDetailResponse response = TravelRecordDetailResponse.from(
+                travelRecordService.findById(member, travelRecordId)
+        );
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }
@@ -84,11 +87,12 @@ public class TravelRecordController {
             @PathVariable @Positive Long travelRecordId,
             @Valid @RequestBody TravelRecordRequest travelRecordRequest
     ) {
-        TravelRecordDetailResponse response = travelRecordService.update(
+        TravelRecordDetail detail = travelRecordService.update(
                 member,
                 travelRecordId,
-                travelRecordRequest
+                travelRecordRequest.toCommand()
         );
+        TravelRecordDetailResponse response = TravelRecordDetailResponse.from(detail);
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordDetail.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordDetail.java
@@ -1,0 +1,20 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.tag.Tag;
+import java.util.List;
+
+/**
+ * 여행 일지 상세를 이루는 도메인 조합 결과다.
+ * 표현 형식을 정하지 않으므로 응답 DTO 변환은 웹 계층이 맡는다. (ADR 0016, 0017)
+ */
+public record TravelRecordDetail(
+        TravelRecord travelRecord,
+        List<Tag> tags,
+        List<MediaView> mediaViews
+) {
+    public List<RecordMedia> recordMedia() {
+        return mediaViews.stream()
+                .map(MediaView::recordMedia)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -4,23 +4,15 @@ import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.common.monitoring.MonitoredOperation;
 import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.recordmedia.ExpiringUrl;
-import com.mapmory.backend.recordmedia.RecordMediaUrlService;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -39,7 +31,7 @@ public class TravelRecordService {
     private final TravelRecordTagService travelRecordTagService;
     private final TagService tagService;
     private final OperationTimer operationTimer;
-    private final RecordMediaUrlService recordMediaUrlService;
+    private final TravelRecordAssembler travelRecordAssembler;
     private final Clock clock;
     private final UploadedObjectVerifier uploadedObjectVerifier;
 
@@ -49,7 +41,7 @@ public class TravelRecordService {
             TravelRecordTagService travelRecordTagService,
             TagService tagService,
             OperationTimer operationTimer,
-            RecordMediaUrlService recordMediaUrlService,
+            TravelRecordAssembler travelRecordAssembler,
             Clock clock,
             UploadedObjectVerifier uploadedObjectVerifier
     ) {
@@ -58,74 +50,70 @@ public class TravelRecordService {
         this.travelRecordTagService = travelRecordTagService;
         this.tagService = tagService;
         this.operationTimer = operationTimer;
-        this.recordMediaUrlService = recordMediaUrlService;
+        this.travelRecordAssembler = travelRecordAssembler;
         this.clock = clock;
         this.uploadedObjectVerifier = uploadedObjectVerifier;
     }
 
     @Transactional
-    public TravelRecord create(Member member, TravelRecordRequest request) {
-        validateTravelDates(request.startDate(), request.endDate());
-        validateTravelRecordRegion(request);
-        List<String> objectKeys = objectKeys(request);
+    public TravelRecord create(Member member, TravelRecordCommand command) {
+        validateTravelDates(command.startDate(), command.endDate());
+        validateTravelRecordRegion(command);
+        List<String> objectKeys = command.objectKeys();
         TravelRecord.validateObjectKeys(objectKeys);
         uploadedObjectVerifier.verifyAllUploaded(objectKeys);
-        Region region = resolveRegion(request);
+        Region region = resolveRegion(command);
 
         TravelRecord travelRecord = TravelRecord.of(
                 member,
                 region,
-                request.title(),
-                request.content(),
-                request.startDate(),
-                request.endDate()
+                command.title(),
+                command.content(),
+                command.startDate(),
+                command.endDate()
         );
         travelRecord.synchronizeMedia(objectKeys);
 
         TravelRecord savedTravelRecord = travelRecordRepository.save(travelRecord);
-        travelRecordTagService.replace(member, savedTravelRecord, request.tagIds());
+        travelRecordTagService.replace(member, savedTravelRecord, command.tagIds());
 
         return savedTravelRecord;
     }
 
     @Transactional(readOnly = true)
-    public TravelRecordDetailResponse findById(Member member, Long travelRecordId) {
+    public TravelRecordDetail findById(Member member, Long travelRecordId) {
         TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
-        return createDetailResponse(
-                travelRecord,
-                travelRecord.getMedia(),
-                travelRecordTagService.findByTravelRecordId(travelRecordId)
-        );
+        return travelRecordAssembler.assembleDetail(travelRecord);
     }
 
     @Transactional
-    public TravelRecordDetailResponse update(
+    public TravelRecordDetail update(
             Member member,
             Long travelRecordId,
-            TravelRecordRequest request
+            TravelRecordCommand command
     ) {
-        validateTravelDates(request.startDate(), request.endDate());
-        validateTravelRecordRegion(request);
+        validateTravelDates(command.startDate(), command.endDate());
+        validateTravelRecordRegion(command);
         TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
-        List<String> objectKeys = objectKeys(request);
+        List<String> objectKeys = command.objectKeys();
         TravelRecord.validateObjectKeys(objectKeys);
 
-        Region region = resolveRegion(request);
+        Region region = resolveRegion(command);
         List<String> newObjectKeys = travelRecord.newObjectKeys(objectKeys);
         validateObjectKeysAreAvailable(newObjectKeys);
         uploadedObjectVerifier.verifyAllUploaded(newObjectKeys);
 
         travelRecord.update(
                 region,
-                request.title(),
-                request.content(),
-                request.startDate(),
-                request.endDate()
+                command.title(),
+                command.content(),
+                command.startDate(),
+                command.endDate()
         );
-        List<Tag> tags = travelRecordTagService.replace(member, travelRecord, request.tagIds());
-        List<RecordMedia> updatedMedia = operationTimer.record(
+        List<Tag> tags = travelRecordTagService.replace(member, travelRecord, command.tagIds());
+        operationTimer.record(
                 MonitoredOperation.MEDIA_SYNC,
                 () -> {
                     travelRecord.synchronizeMedia(objectKeys);
@@ -134,7 +122,7 @@ public class TravelRecordService {
                 }
         );
 
-        return createDetailResponse(travelRecord, updatedMedia, tags);
+        return travelRecordAssembler.assembleDetail(travelRecord, tags);
     }
 
     @Transactional
@@ -146,7 +134,7 @@ public class TravelRecordService {
     }
 
     @Transactional(readOnly = true)
-    public TravelRecordListResponse findAll(
+    public TravelRecordSummaries findAll(
             Member member,
             String countryCode,
             String provinceCode,
@@ -194,18 +182,7 @@ public class TravelRecordService {
             }
         }
 
-        List<Long> travelRecordIds = travelRecords.getContent().stream()
-                .map(TravelRecord::getId)
-                .toList();
-        Map<Long, List<Tag>> tagsByTravelRecordId =
-                travelRecordTagService.findByTravelRecordIds(travelRecordIds);
-        Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId =
-                createThumbnailUrls(travelRecordIds);
-        return TravelRecordListResponse.from(
-                travelRecords,
-                tagsByTravelRecordId,
-                thumbnailUrlsByTravelRecordId
-        );
+        return travelRecordAssembler.assembleSummaries(travelRecords);
     }
 
     private void validateRegionFilterHierarchy(
@@ -259,18 +236,18 @@ public class TravelRecordService {
         );
     }
 
-    private Region resolveRegion(TravelRecordRequest request) {
+    private Region resolveRegion(TravelRecordCommand command) {
         return regionResolver.resolve(
-                request.countryCode(),
-                request.provinceCode(),
-                request.districtCode()
+                command.countryCode(),
+                command.provinceCode(),
+                command.districtCode()
         );
     }
 
-    private void validateTravelRecordRegion(TravelRecordRequest request) {
-        String countryCode = request.countryCode();
-        String provinceCode = request.provinceCode();
-        String districtCode = request.districtCode();
+    private void validateTravelRecordRegion(TravelRecordCommand command) {
+        String countryCode = command.countryCode();
+        String provinceCode = command.provinceCode();
+        String districtCode = command.districtCode();
         validateRegionCodeFormat(countryCode, provinceCode, districtCode);
 
         if (KOREA_COUNTRY_CODE.equals(countryCode)) {
@@ -285,45 +262,13 @@ public class TravelRecordService {
         }
     }
 
-    private static List<String> objectKeys(TravelRecordRequest request) {
-        return request.objectKeys() == null ? List.of() : request.objectKeys();
-    }
-
-    private void validateObjectKeysAreAvailable(List<String> newObjectKeys) {
+        private void validateObjectKeysAreAvailable(List<String> newObjectKeys) {
         if (!newObjectKeys.isEmpty()
                 && travelRecordRepository.existsMediaByObjectKeyIn(newObjectKeys)) {
             throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
         }
     }
 
-    private Map<Long, ExpiringUrl> createThumbnailUrls(List<Long> travelRecordIds) {
-        if (travelRecordIds.isEmpty()) {
-            return Map.of();
-        }
 
-        Map<Long, ExpiringUrl> thumbnailUrls = new HashMap<>();
-        for (RecordMedia recordMedia : travelRecordRepository.findMediaByTravelRecordIdIn(travelRecordIds)) {
-            thumbnailUrls.computeIfAbsent(
-                    recordMedia.travelRecordId(),
-                    ignored -> recordMediaUrlService.createViewUrl(recordMedia.getThumbnailObjectKey())
-            );
-        }
-        return Map.copyOf(thumbnailUrls);
-    }
-
-    private TravelRecordDetailResponse createDetailResponse(
-            TravelRecord travelRecord,
-            List<RecordMedia> recordMedia,
-            List<Tag> tags
-    ) {
-        List<TravelRecordMediaResponse> media = recordMedia.stream()
-                .map(item -> TravelRecordMediaResponse.from(
-                        item,
-                        recordMediaUrlService.createViewUrl(item.getObjectKey())
-                ))
-                .toList();
-
-        return TravelRecordDetailResponse.from(travelRecord, recordMedia, tags, media);
-    }
 
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordSummaries.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordSummaries.java
@@ -1,0 +1,24 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.tag.Tag;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
+
+/**
+ * 여행 일지 목록 한 페이지와, 각 일지에 딸린 태그·썸네일을 묶은 도메인 조합 결과다.
+ */
+public record TravelRecordSummaries(
+        Page<TravelRecord> travelRecords,
+        Map<Long, List<Tag>> tagsByTravelRecordId,
+        Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId
+) {
+    public List<Tag> tagsOf(TravelRecord travelRecord) {
+        return tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of());
+    }
+
+    public ExpiringUrl thumbnailUrlOf(TravelRecord travelRecord) {
+        return thumbnailUrlsByTravelRecordId.get(travelRecord.getId());
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
@@ -1,9 +1,9 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.travelrecord.RecordMedia;
-import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.travelrecord.TravelRecordDetail;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,12 +35,9 @@ public record TravelRecordDetailResponse(
         this(id, title, content, region, startDate, endDate, objectKeys, List.of(), List.of(), createdAt, updatedAt);
     }
 
-    public static TravelRecordDetailResponse from(
-            TravelRecord travelRecord,
-            List<RecordMedia> recordMedia,
-            List<Tag> tags,
-            List<TravelRecordMediaResponse> media
-    ) {
+    public static TravelRecordDetailResponse from(TravelRecordDetail detail) {
+        TravelRecord travelRecord = detail.travelRecord();
+
         return new TravelRecordDetailResponse(
                 travelRecord.getId(),
                 travelRecord.getTitle(),
@@ -48,11 +45,13 @@ public record TravelRecordDetailResponse(
                 RegionDetailResponse.from(travelRecord.getRegion()),
                 travelRecord.getStartDate(),
                 travelRecord.getEndDate(),
-                recordMedia.stream()
+                detail.recordMedia().stream()
                         .map(RecordMedia::getObjectKey)
                         .toList(),
-                media,
-                tags.stream().map(TagSummaryResponse::from).toList(),
+                detail.mediaViews().stream()
+                        .map(TravelRecordMediaResponse::from)
+                        .toList(),
+                detail.tags().stream().map(TagSummaryResponse::from).toList(),
                 travelRecord.getCreatedAt(),
                 travelRecord.getUpdatedAt()
         );

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
@@ -1,10 +1,8 @@
 package com.mapmory.backend.travelrecord.dto;
 
-import com.mapmory.backend.recordmedia.ExpiringUrl;
-import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.travelrecord.TravelRecordSummaries;
 import java.util.List;
-import java.util.Map;
 import org.springframework.data.domain.Page;
 
 public record TravelRecordListResponse(
@@ -15,17 +13,15 @@ public record TravelRecordListResponse(
         int totalPages,
         boolean hasNext
 ) {
-    public static TravelRecordListResponse from(
-            Page<TravelRecord> travelRecords,
-            Map<Long, List<Tag>> tagsByTravelRecordId,
-            Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId
-    ) {
+    public static TravelRecordListResponse from(TravelRecordSummaries summaries) {
+        Page<TravelRecord> travelRecords = summaries.travelRecords();
+
         return new TravelRecordListResponse(
                 travelRecords.getContent().stream()
                         .map(travelRecord -> TravelRecordListItemResponse.from(
                                 travelRecord,
-                                tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of()),
-                                thumbnailUrlsByTravelRecordId.get(travelRecord.getId())
+                                summaries.tagsOf(travelRecord),
+                                summaries.thumbnailUrlOf(travelRecord)
                         ))
                         .toList(),
                 travelRecords.getNumber(),

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordMediaResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordMediaResponse.java
@@ -1,6 +1,7 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.travelrecord.MediaView;
 import com.mapmory.backend.travelrecord.RecordMedia;
 
 public record TravelRecordMediaResponse(
@@ -10,6 +11,10 @@ public record TravelRecordMediaResponse(
         long viewUrlExpiresIn,
         int sortOrder
 ) {
+    public static TravelRecordMediaResponse from(MediaView mediaView) {
+        return from(mediaView.recordMedia(), mediaView.viewUrl());
+    }
+
     public static TravelRecordMediaResponse from(
             RecordMedia recordMedia,
             ExpiringUrl viewUrl

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.travelrecord.dto;
 
+import com.mapmory.backend.travelrecord.TravelRecordCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -36,5 +37,19 @@ public record TravelRecordRequest(
             List<String> objectKeys
     ) {
         this(countryCode, provinceCode, districtCode, title, content, startDate, endDate, objectKeys, List.of());
+    }
+
+    public TravelRecordCommand toCommand() {
+        return new TravelRecordCommand(
+                countryCode,
+                provinceCode,
+                districtCode,
+                title,
+                content,
+                startDate,
+                endDate,
+                objectKeys,
+                tagIds
+        );
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -17,19 +17,17 @@ import com.mapmory.backend.auth.security.LoginMember;
 import com.mapmory.backend.common.ProblemDetailFactory;
 import com.mapmory.backend.common.handler.ValidationExceptionHandler;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.travelrecord.dto.CreateTravelRecordResponse;
-import com.mapmory.backend.travelrecord.dto.RegionDetailResponse;
-import com.mapmory.backend.travelrecord.dto.RegionItemResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListItemResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecord.dto.TravelRecordResponse;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,6 +38,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -112,7 +112,7 @@ class TravelRecordControllerTest {
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
 
-        when(travelRecordService.create(MEMBER, request)).thenReturn(travelRecord);
+        when(travelRecordService.create(MEMBER, request.toCommand())).thenReturn(travelRecord);
 
         ResponseEntity<TravelRecordResponse<CreateTravelRecordResponse>> response =
                 travelRecordController.create(MEMBER, request);
@@ -121,7 +121,7 @@ class TravelRecordControllerTest {
         assertThat(response.getBody()).isEqualTo(
                 TravelRecordResponse.of(new CreateTravelRecordResponse(1L))
         );
-        verify(travelRecordService).create(MEMBER, request);
+        verify(travelRecordService).create(MEMBER, request.toCommand());
     }
 
     @ParameterizedTest
@@ -136,7 +136,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -155,7 +155,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -169,7 +169,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @ParameterizedTest
@@ -182,7 +182,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("countryCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -194,7 +194,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("provinceCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -206,7 +206,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("districtCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -220,7 +220,7 @@ class TravelRecordControllerTest {
                 null
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
-        when(travelRecordService.create(eq(MEMBER), any(TravelRecordRequest.class)))
+        when(travelRecordService.create(eq(MEMBER), any(TravelRecordCommand.class)))
                 .thenReturn(travelRecord);
 
         mockMvcWithLoginMember().perform(post("/api/v1/travel-records")
@@ -237,7 +237,7 @@ class TravelRecordControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.id").value(1L));
 
-        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -251,7 +251,7 @@ class TravelRecordControllerTest {
                 null
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
-        when(travelRecordService.create(eq(MEMBER), any(TravelRecordRequest.class)))
+        when(travelRecordService.create(eq(MEMBER), any(TravelRecordCommand.class)))
                 .thenReturn(travelRecord);
 
         mockMvcWithLoginMember().perform(post("/api/v1/travel-records")
@@ -260,12 +260,12 @@ class TravelRecordControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.id").value(1L));
 
-        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
     void 여행_일지_상세_조회를_서비스에_위임한다() {
-        TravelRecordDetailResponse detail = detail("제주 여행", "제주시를 걸었다.",
+        TravelRecordDetail detail = detail("제주 여행", "제주시를 걸었다.",
                 List.of("mapmory/travel-records/a.jpg"));
         when(travelRecordService.findById(MEMBER, 101L)).thenReturn(detail);
 
@@ -273,13 +273,15 @@ class TravelRecordControllerTest {
                 travelRecordController.findById(MEMBER, 101L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isEqualTo(TravelRecordResponse.of(detail));
+        assertThat(response.getBody()).isEqualTo(
+                TravelRecordResponse.of(TravelRecordDetailResponse.from(detail))
+        );
         verify(travelRecordService).findById(MEMBER, 101L);
     }
 
     @Test
     void 여행_일지_상세_HTTP_응답을_반환한다() throws Exception {
-        TravelRecordDetailResponse detail = detail("제주 여행", "제주시를 걸었다.",
+        TravelRecordDetail detail = detail("제주 여행", "제주시를 걸었다.",
                 List.of("mapmory/travel-records/a.jpg"));
         when(travelRecordService.findById(MEMBER, 101L)).thenReturn(detail);
 
@@ -300,25 +302,17 @@ class TravelRecordControllerTest {
 
     @Test
     void 여행_일지_목록에_썸네일_URL을_반환한다() throws Exception {
-        TravelRecordListResponse list = new TravelRecordListResponse(
-                List.of(new TravelRecordListItemResponse(
-                        101L,
-                        "제주 여행",
-                        "제주시",
-                        LocalDate.of(2026, 8, 11),
-                        LocalDate.of(2026, 8, 13),
+        TravelRecord travelRecord = travelRecord("제주 여행", "");
+        TravelRecordSummaries summaries = new TravelRecordSummaries(
+                new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1),
+                Map.of(),
+                Map.of(101L, new ExpiringUrl(
                         "https://download.example/mapmory/travel-records/a.jpg",
-                        300L,
-                        List.of()
-                )),
-                0,
-                20,
-                1,
-                1,
-                false
+                        300L
+                ))
         );
         when(travelRecordService.findAll(MEMBER, null, null, null, null, 0, 20))
-                .thenReturn(list);
+                .thenReturn(summaries);
 
         mockMvcWithLoginMember().perform(get("/api/v1/travel-records"))
                 .andExpect(status().isOk())
@@ -329,12 +323,12 @@ class TravelRecordControllerTest {
 
     @Test
     void 여행_일지를_수정한다() throws Exception {
-        TravelRecordDetailResponse detail = detail("수정된 제주 여행", "수정된 본문",
+        TravelRecordDetail detail = detail("수정된 제주 여행", "수정된 본문",
                 List.of("travel-records/10/b.jpg"));
         when(travelRecordService.update(
                 ArgumentMatchers.eq(MEMBER),
                 ArgumentMatchers.eq(101L),
-                ArgumentMatchers.any(TravelRecordRequest.class)
+                ArgumentMatchers.any(TravelRecordCommand.class)
         )).thenReturn(detail);
 
         mockMvcWithLoginMember().perform(put("/api/v1/travel-records/101")
@@ -369,32 +363,34 @@ class TravelRecordControllerTest {
         verify(travelRecordService).delete(MEMBER, 101L);
     }
 
-    private TravelRecordDetailResponse detail(String title, String content, List<String> objectKeys) {
-        return new TravelRecordDetailResponse(
-                101L,
+    private TravelRecordDetail detail(String title, String content, List<String> objectKeys) {
+        TravelRecord travelRecord = travelRecord(title, content);
+        travelRecord.synchronizeMedia(objectKeys);
+        List<MediaView> mediaViews = travelRecord.getMedia().stream()
+                .map(recordMedia -> new MediaView(recordMedia, new ExpiringUrl(
+                        "https://download.example/" + recordMedia.getObjectKey(),
+                        300L
+                )))
+                .toList();
+
+        return new TravelRecordDetail(travelRecord, List.of(), mediaViews);
+    }
+
+    private TravelRecord travelRecord(String title, String content) {
+        Region country = Region.of(null, null, "KR", "대한민국", RegionType.COUNTRY);
+        Region province = Region.of(country, country, "49", "제주특별자치도", RegionType.PROVINCE);
+        Region district = Region.of(province, country, "50110", "제주시", RegionType.DISTRICT);
+        TravelRecord travelRecord = TravelRecord.of(
+                null,
+                district,
                 title,
                 content,
-                new RegionDetailResponse(
-                        new RegionItemResponse("KR", "대한민국"),
-                        new RegionItemResponse("49", "제주특별자치도"),
-                        new RegionItemResponse("50110", "제주시")
-                ),
                 LocalDate.of(2026, 8, 11),
-                LocalDate.of(2026, 8, 13),
-                objectKeys,
-                IntStream.range(0, objectKeys.size())
-                        .mapToObj(index -> new TravelRecordMediaResponse(
-                                (long) index + 1,
-                                objectKeys.get(index),
-                                "https://download.example/" + objectKeys.get(index),
-                                300L,
-                                index
-                        ))
-                        .toList(),
-                List.of(),
-                null,
-                null
+                LocalDate.of(2026, 8, 13)
         );
+        ReflectionTestUtils.setField(travelRecord, "id", 101L);
+
+        return travelRecord;
     }
 
     private String validCreateRequestBody(String title, String content) {

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -22,10 +22,6 @@ import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -96,7 +92,11 @@ class TravelRecordServiceTest {
                 travelRecordTagService,
                 tagService,
                 operationTimer,
-                recordMediaUrlService,
+                new TravelRecordAssembler(
+                        travelRecordRepository,
+                        travelRecordTagService,
+                        recordMediaUrlService
+                ),
                 FIXED_CLOCK,
                 uploadedObjectVerifier
         );
@@ -105,7 +105,7 @@ class TravelRecordServiceTest {
     @Test
     void 국가_단위_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP", null, null, "일본 여행", "", LocalDate.of(2026, 8, 11), null, List.of(), List.of(1L)
         );
 
@@ -113,7 +113,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result).isNotNull();
         verify(regionResolver).resolve("JP", null, null);
@@ -124,7 +124,7 @@ class TravelRecordServiceTest {
     @Test
     void 본문이_null이면_빈_문자열로_정규화해_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP", null, null, "일본 여행", null, LocalDate.of(2026, 8, 11), null, List.of(), List.of()
         );
 
@@ -132,7 +132,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getContent()).isEmpty();
     }
@@ -140,40 +140,40 @@ class TravelRecordServiceTest {
     @Test
     void 종료일이_시작일보다_빠르면_여행_일지를_생성하지_않는다() {
         LocalDate startDate = TODAY.minusDays(1);
-        TravelRecordRequest request = createRequest(startDate, startDate.minusDays(1));
+        TravelRecordCommand command = createCommand(startDate, startDate.minusDays(1));
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 시작일이_미래이면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest(
+        TravelRecordCommand command = createCommand(
                 TODAY.plusDays(1),
                 null
         );
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 종료일이_미래이면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest(
+        TravelRecordCommand command = createCommand(
                 TODAY,
                 TODAY.plusDays(1)
         );
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 시작일과_종료일이_오늘이면_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = createRequest(TODAY, TODAY);
+        TravelRecordCommand command = createCommand(TODAY, TODAY);
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getStartDate()).isEqualTo(TODAY);
         assertThat(result.getEndDate()).isEqualTo(TODAY);
@@ -181,34 +181,34 @@ class TravelRecordServiceTest {
 
     @Test
     void 대한민국_여행에_시도가_없으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("KR", null, null);
+        TravelRecordCommand command = createCommand("KR", null, null);
 
-        assertInvalidRegion(request, "REGION_REQUIRED");
+        assertInvalidRegion(command, "REGION_REQUIRED");
     }
 
     @Test
     void 대한민국_여행에_시군구가_없으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("KR", "49", null);
+        TravelRecordCommand command = createCommand("KR", "49", null);
 
-        assertInvalidRegion(request, "REGION_REQUIRED");
+        assertInvalidRegion(command, "REGION_REQUIRED");
     }
 
     @Test
     void 해외_여행에_하위_지역이_있으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("JP", "13", null);
+        TravelRecordCommand command = createCommand("JP", "13", null);
 
-        assertInvalidRegion(request, "INVALID_REGION_TYPE");
+        assertInvalidRegion(command, "INVALID_REGION_TYPE");
     }
 
     @Test
     void 대한민국_시군구_단위_여행_일지를_생성한다() {
         Region jejuCity = mock(Region.class);
-        TravelRecordRequest request = createRequest("KR", "49", "50110");
+        TravelRecordCommand command = createCommand("KR", "49", "50110");
         when(regionResolver.resolve("KR", "49", "50110")).thenReturn(jejuCity);
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getRegion()).isEqualTo(jejuCity);
         verify(travelRecordRepository).save(result);
@@ -235,35 +235,38 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        TravelRecordDetailResponse result = travelRecordService.findById(member, 101L);
+        TravelRecordDetail result = travelRecordService.findById(member, 101L);
 
-        assertThat(result.id()).isEqualTo(101L);
-        assertThat(result.content()).isEqualTo("제주시를 걸었다.");
-        assertThat(result.region().country().code()).isEqualTo("KR");
-        assertThat(result.region().province().code()).isEqualTo("49");
-        assertThat(result.region().district().code()).isEqualTo("50110");
-        assertThat(result.objectKeys()).containsExactly(
-                "mapmory/travel-records/a.jpg",
-                "mapmory/travel-records/b.jpg"
-        );
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::viewUrl)
+        Region resolvedRegion = result.travelRecord().getRegion();
+        assertThat(result.travelRecord().getId()).isEqualTo(101L);
+        assertThat(result.travelRecord().getContent()).isEqualTo("제주시를 걸었다.");
+        assertThat(resolvedRegion.getRoot().getRegionCode()).isEqualTo("KR");
+        assertThat(resolvedRegion.getParent().getRegionCode()).isEqualTo("49");
+        assertThat(resolvedRegion.getRegionCode()).isEqualTo("50110");
+        assertThat(result.recordMedia())
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly(
+                        "mapmory/travel-records/a.jpg",
+                        "mapmory/travel-records/b.jpg"
+                );
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.viewUrl().url())
                 .containsExactly(
                         "https://download.example/mapmory/travel-records/a.jpg",
                         "https://download.example/mapmory/travel-records/b.jpg"
                 );
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::viewUrlExpiresIn)
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.viewUrl().expiresIn())
                 .containsOnly(300L);
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::sortOrder)
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.recordMedia().getSortOrder())
                 .containsExactly(0, 1);
         verify(recordMediaUrlService).createViewUrl("mapmory/travel-records/a.jpg");
         verify(recordMediaUrlService).createViewUrl("mapmory/travel-records/b.jpg");
     }
 
-    private TravelRecordRequest createRequest(LocalDate startDate, LocalDate endDate) {
-        return new TravelRecordRequest(
+    private TravelRecordCommand createCommand(LocalDate startDate, LocalDate endDate) {
+        return new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -276,12 +279,12 @@ class TravelRecordServiceTest {
         );
     }
 
-    private TravelRecordRequest createRequest(
+    private TravelRecordCommand createCommand(
             String countryCode,
             String provinceCode,
             String districtCode
     ) {
-        return new TravelRecordRequest(
+        return new TravelRecordCommand(
                 countryCode,
                 provinceCode,
                 districtCode,
@@ -294,16 +297,16 @@ class TravelRecordServiceTest {
         );
     }
 
-    private void assertInvalidTravelDates(TravelRecordRequest request) {
-        assertThatThrownBy(() -> travelRecordService.create(member, request))
+    private void assertInvalidTravelDates(TravelRecordCommand command) {
+        assertThatThrownBy(() -> travelRecordService.create(member, command))
                 .isInstanceOfSatisfying(BusinessException.class, exception ->
                         assertThat(exception.getErrorCode().code())
                                 .isEqualTo("INVALID_TRAVEL_DATE_RANGE"));
         verify(travelRecordRepository, never()).save(any(TravelRecord.class));
     }
 
-    private void assertInvalidRegion(TravelRecordRequest request, String errorCode) {
-        assertThatThrownBy(() -> travelRecordService.create(member, request))
+    private void assertInvalidRegion(TravelRecordCommand command, String errorCode) {
+        assertThatThrownBy(() -> travelRecordService.create(member, command))
                 .isInstanceOfSatisfying(BusinessException.class, exception ->
                         assertThat(exception.getErrorCode().code()).isEqualTo(errorCode));
         verify(travelRecordRepository, never()).save(any(TravelRecord.class));
@@ -324,13 +327,12 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(102L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        TravelRecordDetailResponse result = travelRecordService.findById(member, 102L);
+        TravelRecordDetail result = travelRecordService.findById(member, 102L);
 
-        assertThat(result.region().country().code()).isEqualTo("JP");
-        assertThat(result.region().province()).isNull();
-        assertThat(result.region().district()).isNull();
-        assertThat(result.objectKeys()).isEmpty();
-        assertThat(result.media()).isEmpty();
+        assertThat(result.travelRecord().getRegion().getRegionCode()).isEqualTo("JP");
+        assertThat(result.travelRecord().getRegion().getParent()).isNull();
+        assertThat(result.recordMedia()).isEmpty();
+        assertThat(result.mediaViews()).isEmpty();
         verify(recordMediaUrlService, never()).createViewUrl(anyString());
     }
 
@@ -358,7 +360,7 @@ class TravelRecordServiceTest {
         ReflectionTestUtils.setField(travelRecord, "id", 101L);
         travelRecord.synchronizeMedia(List.of("travel-records/10/a.jpg", "travel-records/10/b.jpg"));
         RecordMedia mediaB = travelRecord.getMedia().getLast();
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "KR",
                 "49",
                 "50110",
@@ -366,23 +368,26 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 11),
                 LocalDate.of(2026, 8, 13),
-                List.of("travel-records/10/b.jpg", "travel-records/10/c.jpg")
-        );
+                List.of("travel-records/10/b.jpg", "travel-records/10/c.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("KR", "49", "50110")).thenReturn(district);
         when(travelRecordRepository.existsMediaByObjectKeyIn(List.of("travel-records/10/c.jpg")))
                 .thenReturn(false);
 
-        TravelRecordDetailResponse result = travelRecordService.update(member, 101L, request);
+        TravelRecordDetail result = travelRecordService.update(member, 101L, command);
 
-        assertThat(result.title()).isEqualTo("수정된 제목");
-        assertThat(result.content()).isEqualTo("수정된 본문");
-        assertThat(result.region().district().code()).isEqualTo("50110");
-        assertThat(result.objectKeys()).containsExactly(
-                "travel-records/10/b.jpg",
-                "travel-records/10/c.jpg"
-        );
+        assertThat(result.travelRecord().getTitle()).isEqualTo("수정된 제목");
+        assertThat(result.travelRecord().getContent()).isEqualTo("수정된 본문");
+        assertThat(result.travelRecord().getRegion().getRegionCode()).isEqualTo("50110");
+        assertThat(result.recordMedia())
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly(
+                        "travel-records/10/b.jpg",
+                        "travel-records/10/c.jpg"
+                );
         assertThat(mediaB.getSortOrder()).isZero();
         assertThat(travelRecord.getMedia())
                 .extracting(RecordMedia::getObjectKey)
@@ -401,7 +406,7 @@ class TravelRecordServiceTest {
                 LocalDate.of(2026, 8, 11),
                 null
         );
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -409,12 +414,13 @@ class TravelRecordServiceTest {
                 "본문",
                 LocalDate.of(2026, 8, 11),
                 null,
-                List.of("travel-records/10/a.jpg", "travel-records/10/a.jpg")
-        );
+                List.of("travel-records/10/a.jpg", "travel-records/10/a.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "INVALID_OBJECT_KEY");
+        assertError(() -> travelRecordService.update(member, 101L, command), "INVALID_OBJECT_KEY");
         verify(regionResolver, never()).resolve("JP", null, null);
     }
 
@@ -429,7 +435,7 @@ class TravelRecordServiceTest {
                 LocalDate.of(2026, 8, 11),
                 null
         );
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -437,15 +443,16 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 12),
                 null,
-                List.of("travel-records/20/used.jpg")
-        );
+                List.of("travel-records/20/used.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
         when(travelRecordRepository.existsMediaByObjectKeyIn(List.of("travel-records/20/used.jpg")))
                 .thenReturn(true);
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "INVALID_OBJECT_KEY");
+        assertError(() -> travelRecordService.update(member, 101L, command), "INVALID_OBJECT_KEY");
         assertThat(travelRecord.getTitle()).isEqualTo("일본 여행");
         assertThat(travelRecord.getMedia()).isEmpty();
     }
@@ -462,7 +469,7 @@ class TravelRecordServiceTest {
                 null
         );
         travelRecord.synchronizeMedia(List.of("travel-records/10/a.jpg"));
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -470,23 +477,24 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 12),
                 null,
-                null
-        );
+                null,
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
 
 
-        TravelRecordDetailResponse result = travelRecordService.update(member, 101L, request);
+        TravelRecordDetail result = travelRecordService.update(member, 101L, command);
 
-        assertThat(result.objectKeys()).isEmpty();
+        assertThat(result.recordMedia()).isEmpty();
         assertThat(travelRecord.getMedia()).isEmpty();
         verify(travelRecordRepository, never()).existsMediaByObjectKeyIn(anyList());
     }
 
     @Test
     void 없거나_다른_회원의_일지_수정을_거부한다() {
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -494,21 +502,20 @@ class TravelRecordServiceTest {
                 "본문",
                 LocalDate.of(2026, 8, 11),
                 null,
+                List.of(),
                 List.of()
-        );
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.empty());
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "TRAVEL_RECORD_NOT_FOUND");
+        assertError(() -> travelRecordService.update(member, 101L, command), "TRAVEL_RECORD_NOT_FOUND");
         verify(regionResolver, never()).resolve("JP", null, null);
     }
 
     @Test
     void 지역_필터_없이_일지_목록을_조회한다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
-        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
@@ -516,12 +523,12 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findMediaByTravelRecordIdIn(List.of(101L)))
                 .thenReturn(List.of(thumbnailMedia));
 
-        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+        TravelRecordSummaries result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result.totalElements()).isEqualTo(1);
-        assertThat(result.items().getFirst().thumbnailUrl())
+        assertThat(result.travelRecords().getTotalElements()).isEqualTo(1);
+        assertThat(result.thumbnailUrlOf(travelRecord).url())
                 .isEqualTo("https://download.example/mapmory/travel-records/a.jpg");
-        assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isEqualTo(300L);
+        assertThat(result.thumbnailUrlOf(travelRecord).expiresIn()).isEqualTo(300L);
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
         verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(null), captor.capture());
         assertThat(captor.getValue().getPageSize()).isEqualTo(20);
@@ -531,9 +538,7 @@ class TravelRecordServiceTest {
     @Test
     void 일지마다_정렬이_가장_앞선_미디어만_썸네일로_쓴다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
-        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
@@ -542,9 +547,9 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findMediaByTravelRecordIdIn(List.of(101L)))
                 .thenReturn(List.of(firstMedia, laterMedia));
 
-        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+        TravelRecordSummaries result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result.items().getFirst().thumbnailUrl())
+        assertThat(result.thumbnailUrlOf(travelRecord).url())
                 .isEqualTo("https://download.example/mapmory/first.jpg");
         verify(recordMediaUrlService).createViewUrl("mapmory/first.jpg");
         verify(recordMediaUrlService, never()).createViewUrl("mapmory/later.jpg");
@@ -553,18 +558,15 @@ class TravelRecordServiceTest {
     @Test
     void 미디어가_없는_일지_목록은_썸네일_정보가_null이다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
-        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
         when(travelRecordRepository.findMediaByTravelRecordIdIn(List.of(101L))).thenReturn(List.of());
 
-        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+        TravelRecordSummaries result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result.items().getFirst().thumbnailUrl()).isNull();
-        assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isNull();
+        assertThat(result.thumbnailUrlOf(travelRecord)).isNull();
         verify(recordMediaUrlService, never()).createViewUrl(anyString());
     }
 
@@ -577,7 +579,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(1L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", null, null, null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", null, null, null, 0, 20).travelRecords()).isEmpty();
         verify(travelRecordRepository, never()).findMediaByTravelRecordIdIn(anyList());
     }
 
@@ -591,7 +593,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(2L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", "49", null, null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", "49", null, null, 0, 20).travelRecords()).isEmpty();
     }
 
     @Test
@@ -605,7 +607,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(3L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", null, 0, 20).travelRecords()).isEmpty();
     }
 
     @Test
@@ -614,11 +616,11 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(7L), any(Pageable.class)))
                 .thenReturn(expected);
 
-        TravelRecordListResponse result = travelRecordService.findAll(
+        TravelRecordSummaries result = travelRecordService.findAll(
                 member, null, null, null, 7L, 0, 20
         );
 
-        assertThat(result.items()).isEmpty();
+        assertThat(result.travelRecords()).isEmpty();
         verify(tagService).getOwnedTag(member, 7L);
         verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(7L), any(Pageable.class));
     }


### PR DESCRIPTION
관련 이슈: #199 (Service 계층의 DTO 반환을 도메인 객체 반환으로 변경)

## 요약

`TravelRecordService`에서 요청·응답 DTO 의존을 제거합니다.
서비스는 커맨드를 받고 도메인 조합 결과를 반환하며, DTO 변환은 컨트롤러가 맡습니다.

**`TravelRecordService`가 329줄 → 274줄이 되고 `dto` import 4개가 사라집니다.**
API 응답 JSON과 상태 코드는 그대로입니다.

## 배경

애그리거트 정리(ADR 0017)는 4단계까지 끝났는데 **이 서비스만 아직 API 응답 타입에 묶여 있었습니다.**
응답 필드가 바뀌면 서비스 시그니처와 서비스 테스트가 함께 흔들리는 상태입니다.

한 번 시도했다가 닫힌 PR #201이 있습니다. 그때는 *"DTO를 걷어내도 서비스가 391줄 그대로"* 라
원인이 DTO 결합이 아니라 애그리거트 부재라는 게 드러나 닫았습니다.
**그 애그리거트 정리가 끝난 지금은 같은 작업이 훨씬 작습니다** — 미디어를 애그리거트가 소유해서
조합할 것이 줄었기 때문입니다.

## 주요 결정

### 입력 — 커맨드

`TravelRecordRequest`는 속성이 9개입니다. 원시 값으로 풀면 **파라미터 순서만 바꿔도 컴파일이
통과하는** 위험한 시그니처가 됩니다. `Tag`(속성 1개)와 달리 커맨드를 뒀습니다.

변환 방향은 `Request → Command`입니다. 웹이 서비스를 아는 것은 정상적인 의존 방향이라
컨트롤러에 매핑 코드를 늘어놓지 않아도 됩니다.

커맨드가 `objectKeys`·`tagIds`의 `null`을 빈 리스트로 정규화해, 서비스에 있던 `objectKeys` 헬퍼를 없앴습니다.

### 출력 — 도메인 조합 결과

| 변경 전 | 변경 후 |
| --- | --- |
| `TravelRecord create(Member, TravelRecordRequest)` | `TravelRecord create(Member, TravelRecordCommand)` |
| `TravelRecordDetailResponse findById(...)` | `TravelRecordDetail findById(...)` |
| `TravelRecordDetailResponse update(...)` | `TravelRecordDetail update(...)` |
| `TravelRecordListResponse findAll(...)` | `TravelRecordSummaries findAll(...)` |

ADR 0016이 이미 채택한 *"Service는 읽기 모델을 반환하고 Controller가 DTO로 변환한다"* 와 같은 규칙입니다.

### 어셈블러 — ADR 0017 결정 4대로

조립은 **애그리거트당 하나**인 `TravelRecordAssembler`가 맡습니다. 조회와 URL 발급을 하므로
애그리거트 내부가 아니라 응용 계층입니다.

진입점을 둘로 나눴습니다.

- `assembleDetail(TravelRecord)` — 태그를 직접 조회 (`findById`)
- `assembleDetail(TravelRecord, List<Tag>)` — **이미 계산한 태그를 재사용** (`update`)

수정 경로는 트랜잭션 안에서 태그를 이미 얻었으므로 재조회하지 않습니다.
덕분에 `TravelRecordService`에서 `RecordMediaUrlService` 의존도 사라졌습니다.

### `MediaView`로 순서 보장

조회 URL을 Object Key 기준 맵으로 넘기면 정렬 순서를 잃습니다.
미디어와 URL을 짝지은 목록으로 넘겨, **애그리거트가 정한 `sortOrder`가 응답까지 그대로 이어지게** 했습니다.

## 테스트

서비스 테스트를 응답 DTO가 아니라 **도메인 기준**으로 다시 썼습니다.

```java
// 변경 전
assertThat(result.region().district().code()).isEqualTo("50110");
// 변경 후
assertThat(result.travelRecord().getRegion().getRegionCode()).isEqualTo("50110");
```

이제 응답 필드가 바뀌어도 서비스 테스트는 흔들리지 않습니다.
어셈블러는 기존 목들로 실제 인스턴스를 만들어 주입해, `createViewUrl` 호출 검증을 그대로 유지했습니다.

목록 테스트에서 **불필요해진 스텁 3개를 제거**했습니다. 서비스가 더 이상 목록 경로에서
`getRegion()`을 부르지 않기 때문입니다(그 호출은 DTO 변환과 함께 컨트롤러로 옮겨갔습니다).
Mockito가 `UnnecessaryStubbingException`으로 정확히 잡아줬습니다.

## API 영향 — 없음

네 개 레코드(`TravelRecordRequest`, `TravelRecordDetailResponse`, `TravelRecordListResponse`,
`TravelRecordMediaResponse`)의 **필드 선언이 모두 동일**함을 확인했습니다. JSON이 같고
엔드포인트·상태 코드도 그대로입니다.

## 한계

- `findAll`의 파라미터 7개(지역 필터 3 + 태그 + 페이지네이션 2)는 그대로 뒀습니다.
  요청 DTO가 아니라 쿼리 파라미터라 이번 범위 밖으로 봤습니다.
- `#199`에는 `UploadService`, `AuthService`, `RegionMapSummaryService`가 남습니다.
  셋 다 애그리거트 문제가 아니라 순수 DTO 결합이라 기계적입니다.

## 확인

- [x] 로컬에서 실행 확인 — `./gradlew cleanTest test` 63개 클래스 / 286개 통과
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [ ] 새 환경변수를 추가했다면 `.env.example` 갱신 — 해당 없음
- [x] DB 스키마 변경 없음
- [ ] 실행 방법이나 환경 설정이 바뀌었다면 README 갱신 — 해당 없음

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fwhim5hLJT6Ysjt7WVwv4o
