### PR TITLE
refactor: 남은 세 서비스의 웹 계층 DTO 의존 제거

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/auth/AuthController.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/AuthController.java
@@ -33,18 +33,18 @@ public class AuthController {
             @Valid @RequestBody KakaoLoginRequest request,
             @AuthenticationPrincipal Long authenticatedMemberId
     ) {
-        return ApiResponse.from(
-                authService.loginWithKakao(request.kakaoAccessToken(), authenticatedMemberId));
+        return ApiResponse.from(LoginResponse.from(
+                authService.loginWithKakao(request.kakaoAccessToken(), authenticatedMemberId)));
     }
 
     @PostMapping("/login/guest")
     public ApiResponse<LoginResponse> loginAsGuest() {
-        return ApiResponse.from(authService.loginAsGuest());
+        return ApiResponse.from(LoginResponse.from(authService.loginAsGuest()));
     }
 
     @PostMapping("/token/refresh")
     public ApiResponse<TokenResponse> refresh(@Valid @RequestBody RefreshRequest request) {
-        return ApiResponse.from(authService.refresh(request.refreshToken()));
+        return ApiResponse.from(TokenResponse.from(authService.refresh(request.refreshToken())));
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/com/mapmory/backend/auth/AuthService.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/AuthService.java
@@ -1,7 +1,5 @@
 package com.mapmory.backend.auth;
 
-import com.mapmory.backend.auth.dto.LoginResponse;
-import com.mapmory.backend.auth.dto.TokenResponse;
 import com.mapmory.backend.auth.exception.AuthErrorCode;
 import com.mapmory.backend.auth.jwt.JwtProvider;
 import com.mapmory.backend.auth.kakao.KakaoApiClient;
@@ -50,7 +48,7 @@ public class AuthService {
      * (ADR 0015)
      */
     @Transactional
-    public LoginResponse loginWithKakao(String kakaoAccessToken, Long authenticatedMemberId) {
+    public LoginResult loginWithKakao(String kakaoAccessToken, Long authenticatedMemberId) {
         KakaoUserResponse kakaoUser = kakaoApiClient.fetchUser(kakaoAccessToken);
         String providerId = String.valueOf(kakaoUser.id());
         Optional<Member> guest = findGuest(authenticatedMemberId);
@@ -87,7 +85,7 @@ public class AuthService {
      * 발급 이후의 토큰 체계는 소셜 로그인과 완전히 동일하다. (ADR 0015)
      */
     @Transactional
-    public LoginResponse loginAsGuest() {
+    public LoginResult loginAsGuest() {
         Member member = memberRepository.save(Member.ofGuest(
                 UUID.randomUUID().toString(),
                 resolveName(null),
@@ -98,12 +96,12 @@ public class AuthService {
 
     // @Transactional을 두지 않는다. validateAndRevoke가 자체 트랜잭션에서 (재사용 시) 토큰 폐기를
     // 커밋한 뒤, 재사용이면 여기서 트랜잭션 밖에서 401을 던져 그 폐기가 롤백되지 않게 한다.
-    public TokenResponse refresh(String refreshToken) {
+    public AuthTokens refresh(String refreshToken) {
         Member member = refreshTokenService.validateAndRevoke(refreshToken)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
         String accessToken = jwtProvider.issueAccessToken(member.getId());
         String newRefreshToken = refreshTokenService.issue(member);
-        return new TokenResponse(accessToken, newRefreshToken);
+        return new AuthTokens(accessToken, newRefreshToken);
     }
 
     @Transactional
@@ -111,10 +109,10 @@ public class AuthService {
         refreshTokenService.revoke(refreshToken);
     }
 
-    private LoginResponse issueTokens(Member member, boolean isNewMember) {
+    private LoginResult issueTokens(Member member, boolean isNewMember) {
         String accessToken = jwtProvider.issueAccessToken(member.getId());
         String refreshToken = refreshTokenService.issue(member);
-        return new LoginResponse(accessToken, refreshToken, isNewMember);
+        return new LoginResult(new AuthTokens(accessToken, refreshToken), isNewMember);
     }
 
     private Member register(String providerId, String nickname) {

--- a/backend/src/main/java/com/mapmory/backend/auth/AuthTokens.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/AuthTokens.java
@@ -1,0 +1,12 @@
+package com.mapmory.backend.auth;
+
+/**
+ * 발급된 access·refresh 토큰 쌍.
+ *
+ * <p>표현 형식을 정하지 않으므로 응답 DTO 변환은 웹 계층이 맡는다. (ADR 0016, 0017)
+ */
+public record AuthTokens(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/auth/LoginResult.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/LoginResult.java
@@ -1,0 +1,13 @@
+package com.mapmory.backend.auth;
+
+/**
+ * 로그인 결과. 토큰 쌍과 신규 가입 여부를 담는다.
+ *
+ * <p>{@code newMember}는 온보딩 분기에 쓰인다. 게스트 승격은 이미 앱을 사용한 상태이므로
+ * 신규로 보지 않는다. (ADR 0015)
+ */
+public record LoginResult(
+        AuthTokens tokens,
+        boolean newMember
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/dto/LoginResponse.java
@@ -1,5 +1,7 @@
 package com.mapmory.backend.auth.dto;
 
+import com.mapmory.backend.auth.LoginResult;
+
 /**
  * 로그인 응답.
  *
@@ -13,4 +15,12 @@ public record LoginResponse(
         String refreshToken,
         boolean isNewMember
 ) {
+
+    public static LoginResponse from(LoginResult result) {
+        return new LoginResponse(
+                result.tokens().accessToken(),
+                result.tokens().refreshToken(),
+                result.newMember()
+        );
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/auth/dto/TokenResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/dto/TokenResponse.java
@@ -1,5 +1,7 @@
 package com.mapmory.backend.auth.dto;
 
+import com.mapmory.backend.auth.AuthTokens;
+
 /**
  * 토큰 재발급 응답. 회전으로 새로 발급된 access/refresh 쌍을 반환한다.
  */
@@ -7,4 +9,8 @@ public record TokenResponse(
         String accessToken,
         String refreshToken
 ) {
+
+    public static TokenResponse from(AuthTokens tokens) {
+        return new TokenResponse(tokens.accessToken(), tokens.refreshToken());
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/RegionMapSummary.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/RegionMapSummary.java
@@ -1,0 +1,20 @@
+package com.mapmory.backend.travelrecord.mapsummary;
+
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
+
+/**
+ * 지도에 칠할 지역 하나의 요약이다.
+ *
+ * <p>리포지토리 프로젝션에 색상 단계 정책을 적용한 결과이며 표현 형식을 정하지 않는다.
+ * 응답 DTO 변환은 웹 계층이 맡는다. (ADR 0016, 0017)
+ */
+public record RegionMapSummary(
+        Long regionId,
+        String regionCode,
+        RegionType regionType,
+        String name,
+        long recordCount,
+        MapColorLevel level
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
@@ -3,6 +3,7 @@ package com.mapmory.backend.travelrecord.mapsummary.controller;
 import com.mapmory.backend.auth.security.LoginMember;
 import com.mapmory.backend.common.dto.ApiResponse;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
 import jakarta.validation.constraints.Positive;
@@ -30,7 +31,7 @@ public class RegionMapSummaryController {
             @LoginMember Member member,
             @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(regionMapSummaryService.getSummaries(member, null, tagId));
+        return ApiResponse.from(toResponses(regionMapSummaryService.getSummaries(member, null, tagId)));
     }
 
     @GetMapping("/{regionId}/children")
@@ -41,6 +42,12 @@ public class RegionMapSummaryController {
             Long regionId,
             @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(regionMapSummaryService.getSummaries(member, regionId, tagId));
+        return ApiResponse.from(toResponses(regionMapSummaryService.getSummaries(member, regionId, tagId)));
+    }
+
+    private List<RegionMapSummaryResponse> toResponses(List<RegionMapSummary> summaries) {
+        return summaries.stream()
+                .map(RegionMapSummaryResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
@@ -3,7 +3,6 @@ package com.mapmory.backend.travelrecord.mapsummary.controller;
 import com.mapmory.backend.auth.security.LoginMember;
 import com.mapmory.backend.common.dto.ApiResponse;
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
 import jakarta.validation.constraints.Positive;
@@ -31,7 +30,9 @@ public class RegionMapSummaryController {
             @LoginMember Member member,
             @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(toResponses(regionMapSummaryService.getSummaries(member, null, tagId)));
+        return ApiResponse.from(RegionMapSummaryResponse.from(
+                regionMapSummaryService.getSummaries(member, null, tagId)
+        ));
     }
 
     @GetMapping("/{regionId}/children")
@@ -42,12 +43,8 @@ public class RegionMapSummaryController {
             Long regionId,
             @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(toResponses(regionMapSummaryService.getSummaries(member, regionId, tagId)));
-    }
-
-    private List<RegionMapSummaryResponse> toResponses(List<RegionMapSummary> summaries) {
-        return summaries.stream()
-                .map(RegionMapSummaryResponse::from)
-                .toList();
+        return ApiResponse.from(RegionMapSummaryResponse.from(
+                regionMapSummaryService.getSummaries(member, regionId, tagId)
+        ));
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/dto/RegionMapSummaryResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/dto/RegionMapSummaryResponse.java
@@ -2,6 +2,7 @@ package com.mapmory.backend.travelrecord.mapsummary.dto;
 
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
+import java.util.List;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
 
 public record RegionMapSummaryResponse(
@@ -12,6 +13,12 @@ public record RegionMapSummaryResponse(
         long count,
         MapColorLevel level
 ) {
+
+    public static List<RegionMapSummaryResponse> from(List<RegionMapSummary> summaries) {
+        return summaries.stream()
+                .map(RegionMapSummaryResponse::from)
+                .toList();
+    }
 
     public static RegionMapSummaryResponse from(RegionMapSummary summary) {
         return new RegionMapSummaryResponse(

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/dto/RegionMapSummaryResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/dto/RegionMapSummaryResponse.java
@@ -1,9 +1,8 @@
 package com.mapmory.backend.travelrecord.mapsummary.dto;
 
 import com.mapmory.backend.region.RegionType;
-import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
-import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryQueryResult;
 
 public record RegionMapSummaryResponse(
         Long regionId,
@@ -14,17 +13,14 @@ public record RegionMapSummaryResponse(
         MapColorLevel level
 ) {
 
-    public static RegionMapSummaryResponse from(
-            RegionMapSummaryQueryResult result,
-            LevelPolicy levelPolicy
-    ) {
+    public static RegionMapSummaryResponse from(RegionMapSummary summary) {
         return new RegionMapSummaryResponse(
-                result.getRegionId(),
-                result.getRegionCode(),
-                RegionType.valueOf(result.getRegionType()),
-                result.getName(),
-                result.getRecordCount(),
-                levelPolicy.levelFor(result.getRecordCount())
+                summary.regionId(),
+                summary.regionCode(),
+                summary.regionType(),
+                summary.name(),
+                summary.recordCount(),
+                summary.level()
         );
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
@@ -7,7 +7,8 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryQueryResult;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryRepository;
@@ -39,7 +40,7 @@ public class RegionMapSummaryService {
     }
 
     @Transactional(readOnly = true)
-    public List<RegionMapSummaryResponse> getSummaries(Member member, Long parentRegionId, Long tagId) {
+    public List<RegionMapSummary> getSummaries(Member member, Long parentRegionId, Long tagId) {
         validateParentRegion(parentRegionId);
         if (tagId != null) {
             tagService.getOwnedTag(member, tagId);
@@ -49,8 +50,19 @@ public class RegionMapSummaryService {
                 () -> regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId, tagId)
         );
         return summaries.stream()
-                .map(result -> RegionMapSummaryResponse.from(result, levelPolicy))
+                .map(this::toSummary)
                 .toList();
+    }
+
+    private RegionMapSummary toSummary(RegionMapSummaryQueryResult result) {
+        return new RegionMapSummary(
+                result.getRegionId(),
+                result.getRegionCode(),
+                RegionType.valueOf(result.getRegionType()),
+                result.getName(),
+                result.getRecordCount(),
+                levelPolicy.levelFor(result.getRecordCount())
+        );
     }
 
     private void validateParentRegion(Long parentRegionId) {

--- a/backend/src/main/java/com/mapmory/backend/upload/PresignedUpload.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/PresignedUpload.java
@@ -1,0 +1,18 @@
+package com.mapmory.backend.upload;
+
+import java.net.URI;
+import java.time.Duration;
+
+/**
+ * 파일 하나에 대해 발급한 presigned 업로드 정보.
+ *
+ * <p>URI와 Duration을 그대로 담는다. 문자열·초 단위 변환은 응답 DTO가 맡는다.
+ */
+public record PresignedUpload(
+        String objectKey,
+        URI presignedUrl,
+        String method,
+        String contentType,
+        Duration expiration
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/upload/UploadFileCommand.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/UploadFileCommand.java
@@ -1,0 +1,12 @@
+package com.mapmory.backend.upload;
+
+/**
+ * presigned 업로드 URL을 받으려는 파일 하나의 정보.
+ * 웹 요청 스펙(UploadFileRequest)과 분리해 서비스가 API 계약에 의존하지 않게 한다.
+ */
+public record UploadFileCommand(
+        String fileName,
+        String contentType,
+        long fileSize
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/upload/controller/UploadController.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/controller/UploadController.java
@@ -27,6 +27,8 @@ public class UploadController {
             @LoginMember Member member,
             @Valid @RequestBody CreatePresignedUrlsRequest request
     ) {
-        return ApiResponse.from(uploadService.createPresignedUrls(member, request));
+        return ApiResponse.from(CreatePresignedUrlsResponse.from(
+                uploadService.createPresignedUrls(member, request.toCommands())
+        ));
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/dto/CreatePresignedUrlsRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/dto/CreatePresignedUrlsRequest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.upload.dto;
 
+import com.mapmory.backend.upload.UploadFileCommand;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
@@ -8,4 +9,10 @@ public record CreatePresignedUrlsRequest(
         @NotEmpty(message = "업로드할 파일은 1개 이상이어야 합니다.")
         List<@Valid UploadFileRequest> files
 ) {
+
+    public List<UploadFileCommand> toCommands() {
+        return files.stream()
+                .map(UploadFileRequest::toCommand)
+                .toList();
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/dto/CreatePresignedUrlsResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/dto/CreatePresignedUrlsResponse.java
@@ -1,8 +1,17 @@
 package com.mapmory.backend.upload.dto;
 
+import com.mapmory.backend.upload.PresignedUpload;
 import java.util.List;
 
 public record CreatePresignedUrlsResponse(
         List<PresignedUploadResponse> uploads
 ) {
+
+    public static CreatePresignedUrlsResponse from(List<PresignedUpload> uploads) {
+        return new CreatePresignedUrlsResponse(
+                uploads.stream()
+                        .map(PresignedUploadResponse::from)
+                        .toList()
+        );
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/dto/PresignedUploadResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/dto/PresignedUploadResponse.java
@@ -1,5 +1,7 @@
 package com.mapmory.backend.upload.dto;
 
+import com.mapmory.backend.upload.PresignedUpload;
+
 public record PresignedUploadResponse(
         String objectKey,
         String presignedUrl,
@@ -7,4 +9,14 @@ public record PresignedUploadResponse(
         String contentType,
         long expiresIn
 ) {
+
+    public static PresignedUploadResponse from(PresignedUpload upload) {
+        return new PresignedUploadResponse(
+                upload.objectKey(),
+                upload.presignedUrl().toString(),
+                upload.method(),
+                upload.contentType(),
+                upload.expiration().toSeconds()
+        );
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/dto/UploadFileRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/dto/UploadFileRequest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.upload.dto;
 
+import com.mapmory.backend.upload.UploadFileCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -15,4 +16,8 @@ public record UploadFileRequest(
         @Positive(message = "파일 크기는 양수여야 합니다.")
         Long fileSize
 ) {
+
+    public UploadFileCommand toCommand() {
+        return new UploadFileCommand(fileName, contentType, fileSize);
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/service/UploadService.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/service/UploadService.java
@@ -1,10 +1,8 @@
 package com.mapmory.backend.upload.service;
 
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.upload.dto.CreatePresignedUrlsRequest;
-import com.mapmory.backend.upload.dto.CreatePresignedUrlsResponse;
-import com.mapmory.backend.upload.dto.PresignedUploadResponse;
-import com.mapmory.backend.upload.dto.UploadFileRequest;
+import com.mapmory.backend.upload.PresignedUpload;
+import com.mapmory.backend.upload.UploadFileCommand;
 import com.mapmory.backend.upload.policy.ObjectKeyGenerator;
 import com.mapmory.backend.upload.policy.UploadFileType;
 import com.mapmory.backend.upload.policy.UploadPolicy;
@@ -37,26 +35,22 @@ public class UploadService {
         this.presignedUrlExpiration = properties.presignedUrlExpiration();
     }
 
-    public CreatePresignedUrlsResponse createPresignedUrls(
-            Member member,
-            CreatePresignedUrlsRequest request
-    ) {
-        uploadPolicy.validateFileCount(request.files().size());
-        List<ValidatedUploadFile> validatedFiles = request.files().stream()
+    public List<PresignedUpload> createPresignedUrls(Member member, List<UploadFileCommand> files) {
+        uploadPolicy.validateFileCount(files.size());
+        List<ValidatedUploadFile> validatedFiles = files.stream()
                 .map(file -> new ValidatedUploadFile(
                         file,
                         uploadPolicy.validateFile(file.fileName(), file.contentType(), file.fileSize())
                 ))
                 .toList();
 
-        List<PresignedUploadResponse> uploads = validatedFiles.stream()
+        return validatedFiles.stream()
                 .map(file -> createPresignedUpload(member.getId(), file))
                 .toList();
-        return new CreatePresignedUrlsResponse(uploads);
     }
 
-    private PresignedUploadResponse createPresignedUpload(Long memberId, ValidatedUploadFile validatedFile) {
-        UploadFileRequest file = validatedFile.file();
+    private PresignedUpload createPresignedUpload(Long memberId, ValidatedUploadFile validatedFile) {
+        UploadFileCommand file = validatedFile.file();
         UploadFileType fileType = validatedFile.fileType();
         String objectKey = objectKeyGenerator.generate(memberId, fileType);
         URI presignedUrl = presignedUrlProvider.createPresignedPutUrl(
@@ -65,17 +59,17 @@ public class UploadService {
                 file.fileSize(),
                 presignedUrlExpiration
         );
-        return new PresignedUploadResponse(
+        return new PresignedUpload(
                 objectKey,
-                presignedUrl.toString(),
+                presignedUrl,
                 UPLOAD_METHOD,
                 fileType.contentType(),
-                presignedUrlExpiration.toSeconds()
+                presignedUrlExpiration
         );
     }
 
     private record ValidatedUploadFile(
-            UploadFileRequest file,
+            UploadFileCommand file,
             UploadFileType fileType
     ) {
     }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
@@ -18,7 +18,7 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.member.MemberRepository;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.region.exception.RegionErrorCode;
-import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
 import java.util.List;
@@ -74,7 +74,7 @@ class RegionMapSummaryControllerTest {
         @DisplayName("회원의 루트 지역별 지도 요약을 의미 기반 단계와 함께 반환한다")
         void returnsRootSummaries() throws Exception {
             when(regionMapSummaryService.getSummaries(any(Member.class), isNull(), isNull())).thenReturn(List.of(
-                    new RegionMapSummaryResponse(
+                    new RegionMapSummary(
                             1L,
                             "KR",
                             RegionType.COUNTRY,
@@ -145,7 +145,7 @@ class RegionMapSummaryControllerTest {
         @DisplayName("선택 지역의 직속 하위 지역별 지도 요약을 반환한다")
         void returnsChildSummaries() throws Exception {
             when(regionMapSummaryService.getSummaries(any(Member.class), eq(1L), isNull())).thenReturn(List.of(
-                    new RegionMapSummaryResponse(
+                    new RegionMapSummary(
                             15L,
                             "49",
                             RegionType.PROVINCE,

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
@@ -14,7 +14,7 @@ import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
 import com.mapmory.backend.tag.TagService;
 import com.mapmory.backend.tag.Tag;
-import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryQueryResult;
@@ -61,9 +61,9 @@ class RegionMapSummaryServiceTest {
             when(regionMapSummaryRepository.findRegionMapSummaries(10L, null, null))
                     .thenReturn(List.of(result(1L, "KR", "대한민국", "COUNTRY", 3L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(member, null, null);
+            List<RegionMapSummary> responses = service.getSummaries(member, null, null);
 
-            assertThat(responses).containsExactly(new RegionMapSummaryResponse(
+            assertThat(responses).containsExactly(new RegionMapSummary(
                     1L,
                     "KR",
                     RegionType.COUNTRY,
@@ -93,9 +93,9 @@ class RegionMapSummaryServiceTest {
             when(regionMapSummaryRepository.findRegionMapSummaries(10L, parentRegionId, null))
                     .thenReturn(List.of(result(childRegionId, regionCode, name, regionType, 1L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(member, parentRegionId, null);
+            List<RegionMapSummary> responses = service.getSummaries(member, parentRegionId, null);
 
-            assertThat(responses).containsExactly(new RegionMapSummaryResponse(
+            assertThat(responses).containsExactly(new RegionMapSummary(
                     childRegionId,
                     regionCode,
                     RegionType.valueOf(regionType),
@@ -127,9 +127,9 @@ class RegionMapSummaryServiceTest {
             when(regionMapSummaryRepository.findRegionMapSummaries(10L, null, 7L))
                     .thenReturn(List.of(result(1L, "KR", "대한민국", "COUNTRY", 1L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(member, null, 7L);
+            List<RegionMapSummary> responses = service.getSummaries(member, null, 7L);
 
-            assertThat(responses).singleElement().extracting(RegionMapSummaryResponse::count).isEqualTo(1L);
+            assertThat(responses).singleElement().extracting(RegionMapSummary::recordCount).isEqualTo(1L);
             verify(tagService).getOwnedTag(member, 7L);
         }
     }

--- a/backend/src/test/java/com/mapmory/backend/upload/service/UploadServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/service/UploadServiceTest.java
@@ -3,9 +3,8 @@ package com.mapmory.backend.upload.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.upload.dto.CreatePresignedUrlsRequest;
-import com.mapmory.backend.upload.dto.CreatePresignedUrlsResponse;
-import com.mapmory.backend.upload.dto.UploadFileRequest;
+import com.mapmory.backend.upload.PresignedUpload;
+import com.mapmory.backend.upload.UploadFileCommand;
 import com.mapmory.backend.upload.policy.ObjectKeyGenerator;
 import com.mapmory.backend.upload.storage.S3StorageProperties;
 import com.mapmory.backend.upload.policy.UploadPolicy;
@@ -32,30 +31,30 @@ class UploadServiceTest {
                 provider,
                 properties
         );
-        CreatePresignedUrlsRequest request = new CreatePresignedUrlsRequest(List.of(
-                new UploadFileRequest("jeju-trip", "IMAGE/JPEG", 3_145_728L),
-                new UploadFileRequest("map.webp", "image/webp", 1024L)
-        ));
+        List<UploadFileCommand> files = List.of(
+                new UploadFileCommand("jeju-trip", "IMAGE/JPEG", 3_145_728L),
+                new UploadFileCommand("map.webp", "image/webp", 1024L)
+        );
 
-        CreatePresignedUrlsResponse response = uploadService.createPresignedUrls(member(), request);
+        List<PresignedUpload> uploads = uploadService.createPresignedUrls(member(), files);
 
-        assertThat(response.uploads()).hasSize(2);
-        assertThat(response.uploads().getFirst().objectKey()).startsWith("travel-records/10/")
+        assertThat(uploads).hasSize(2);
+        assertThat(uploads.getFirst().objectKey()).startsWith("travel-records/10/")
                 .endsWith(".jpg");
-        assertThat(response.uploads().getFirst().presignedUrl())
+        assertThat(uploads.getFirst().presignedUrl().toString())
                 .startsWith("https://upload.example/travel-records/10/");
-        assertThat(response.uploads().getFirst().method()).isEqualTo("PUT");
-        assertThat(response.uploads().getFirst().contentType()).isEqualTo("image/jpeg");
-        assertThat(response.uploads().getFirst().expiresIn()).isEqualTo(300L);
+        assertThat(uploads.getFirst().method()).isEqualTo("PUT");
+        assertThat(uploads.getFirst().contentType()).isEqualTo("image/jpeg");
+        assertThat(uploads.getFirst().expiration()).isEqualTo(java.time.Duration.ofSeconds(300L));
         assertThat(provider.requests).containsExactly(
                 new PresignRequest(
-                        response.uploads().getFirst().objectKey(),
+                        uploads.getFirst().objectKey(),
                         "image/jpeg",
                         3_145_728L,
                         Duration.ofMinutes(5)
                 ),
                 new PresignRequest(
-                        response.uploads().get(1).objectKey(),
+                        uploads.get(1).objectKey(),
                         "image/webp",
                         1024L,
                         Duration.ofMinutes(5)


### PR DESCRIPTION
Closes #199

## 요약

남은 세 서비스(`RegionMapSummaryService`, `AuthService`, `UploadService`)에서
웹 DTO 의존을 제거합니다. **이로써 프로젝트의 모든 서비스에서 `dto` import가 0이 됩니다.**

셋 다 애그리거트 문제가 아니라 순수한 DTO 결합이라 한 PR에 묶었습니다.
API 응답과 상태 코드는 그대로입니다.

## 어셈블러를 만들지 않은 이유

ADR 0017 결정 4의 단서 그대로입니다.

> 애그리거트당 **최대** 하나다. 읽기 모델이 단순한 애그리거트(Tag)는 어셈블러를 만들지 않는다.
> 통일성을 위해 빈 클래스를 두지 않는다.

세 서비스 모두 조회 결과를 그대로 옮기거나 정책 하나를 적용하는 수준이라 **조립할 것이 없습니다.**
`TravelRecordAssembler`가 필요했던 건 상세 응답이 애그리거트 + 다른 애그리거트(태그) + 인프라(presigned URL)
**세 출처**를 모아야 했기 때문입니다. 여기엔 그런 구조가 없습니다.

## 서비스별 변경

### RegionMapSummaryService

```java
List<RegionMapSummaryResponse> getSummaries(...)   →   List<RegionMapSummary> getSummaries(...)
```

리포지토리 프로젝션에 **색상 단계 정책(`LevelPolicy`)을 적용하는 일은 서비스에 남깁니다.**
도메인 정책이라 컨트롤러로 내리면 안 됩니다.

컨트롤러로 넘어간 것은 **필드 이름 매핑**뿐입니다 — `regionCode` → `code`, `recordCount` → `count`.
이 이름 차이는 API 표현상의 선택이지 도메인 개념이 아닙니다.

ADR 0016의 `TravelStatistics`와 같은 모양이 됩니다.

### AuthService

```java
LoginResponse loginWithKakao(...)  →  LoginResult loginWithKakao(...)
LoginResponse loginAsGuest()       →  LoginResult loginAsGuest()
TokenResponse refresh(...)         →  AuthTokens refresh(...)
```

- `AuthTokens(accessToken, refreshToken)` — 토큰 쌍
- `LoginResult(AuthTokens tokens, boolean newMember)` — 토큰 쌍 + 신규 가입 여부

`refresh`는 토큰만 필요하고 로그인은 온보딩 분기용 `newMember`가 더 필요해서, 후자가 전자를 감쌉니다.

### UploadService

```java
CreatePresignedUrlsResponse createPresignedUrls(Member, CreatePresignedUrlsRequest)
                          ↓
List<PresignedUpload> createPresignedUrls(Member, List<UploadFileCommand>)
```

여기는 타입 교체 이상의 이득이 있습니다. **도메인 결과가 `URI`와 `Duration`을 그대로 담습니다.**

```java
public record PresignedUpload(String objectKey, URI presignedUrl, String method,
                              String contentType, Duration expiration) { }
```

`presignedUrl.toString()`과 `expiration.toSeconds()` 같은 **표현 변환이 서비스에서 빠져** 응답 DTO로 갔습니다.
서비스는 실제 타입으로 다루고, 문자열·초 단위는 JSON을 만들 때만 필요한 형태입니다.

요청은 래퍼가 필드 하나(`files`)뿐이라 커맨드 목록을 바로 받습니다.

## API 영향 — 없음

요청·응답 레코드 **7개의 필드 선언이 모두 동일**함을 `origin/backend-develop`과 대조해 확인했습니다.

`RegionMapSummaryResponse`, `LoginResponse`, `TokenResponse`, `CreatePresignedUrlsResponse`,
`PresignedUploadResponse`, `CreatePresignedUrlsRequest`, `UploadFileRequest`

## #199 완료 현황

| 서비스 | PR |
| --- | --- |
| `TagService` | #200 |
| `TravelStatisticsService` | #202 (처음부터 읽기 모델 반환, ADR 0016) |
| `LaunchWaitlistService` | #222 |
| `TravelRecordService` | #223 |
| `RegionMapSummaryService`·`AuthService`·`UploadService` | **이 PR** |

## 확인

- [x] 로컬에서 실행 확인 — `./gradlew cleanTest test` 63개 클래스 / 286개 통과
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [ ] 새 환경변수를 추가했다면 `.env.example` 갱신 — 해당 없음
- [x] DB 스키마 변경 없음
- [ ] 실행 방법이나 환경 설정이 바뀌었다면 README 갱신 — 해당 없음