### PR TITLE
chore: 백엔드 서비스 계층 DTO 정리를 develop에 반영

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/auth/AuthController.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/AuthController.java
@@ -33,18 +33,18 @@ public class AuthController {
             @Valid @RequestBody KakaoLoginRequest request,
             @AuthenticationPrincipal Long authenticatedMemberId
     ) {
-        return ApiResponse.from(
-                authService.loginWithKakao(request.kakaoAccessToken(), authenticatedMemberId));
+        return ApiResponse.from(LoginResponse.from(
+                authService.loginWithKakao(request.kakaoAccessToken(), authenticatedMemberId)));
     }
 
     @PostMapping("/login/guest")
     public ApiResponse<LoginResponse> loginAsGuest() {
-        return ApiResponse.from(authService.loginAsGuest());
+        return ApiResponse.from(LoginResponse.from(authService.loginAsGuest()));
     }
 
     @PostMapping("/token/refresh")
     public ApiResponse<TokenResponse> refresh(@Valid @RequestBody RefreshRequest request) {
-        return ApiResponse.from(authService.refresh(request.refreshToken()));
+        return ApiResponse.from(TokenResponse.from(authService.refresh(request.refreshToken())));
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/com/mapmory/backend/auth/AuthService.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/AuthService.java
@@ -1,7 +1,5 @@
 package com.mapmory.backend.auth;
 
-import com.mapmory.backend.auth.dto.LoginResponse;
-import com.mapmory.backend.auth.dto.TokenResponse;
 import com.mapmory.backend.auth.exception.AuthErrorCode;
 import com.mapmory.backend.auth.jwt.JwtProvider;
 import com.mapmory.backend.auth.kakao.KakaoApiClient;
@@ -50,7 +48,7 @@ public class AuthService {
      * (ADR 0015)
      */
     @Transactional
-    public LoginResponse loginWithKakao(String kakaoAccessToken, Long authenticatedMemberId) {
+    public LoginResult loginWithKakao(String kakaoAccessToken, Long authenticatedMemberId) {
         KakaoUserResponse kakaoUser = kakaoApiClient.fetchUser(kakaoAccessToken);
         String providerId = String.valueOf(kakaoUser.id());
         Optional<Member> guest = findGuest(authenticatedMemberId);
@@ -87,7 +85,7 @@ public class AuthService {
      * 발급 이후의 토큰 체계는 소셜 로그인과 완전히 동일하다. (ADR 0015)
      */
     @Transactional
-    public LoginResponse loginAsGuest() {
+    public LoginResult loginAsGuest() {
         Member member = memberRepository.save(Member.ofGuest(
                 UUID.randomUUID().toString(),
                 resolveName(null),
@@ -98,12 +96,12 @@ public class AuthService {
 
     // @Transactional을 두지 않는다. validateAndRevoke가 자체 트랜잭션에서 (재사용 시) 토큰 폐기를
     // 커밋한 뒤, 재사용이면 여기서 트랜잭션 밖에서 401을 던져 그 폐기가 롤백되지 않게 한다.
-    public TokenResponse refresh(String refreshToken) {
+    public AuthTokens refresh(String refreshToken) {
         Member member = refreshTokenService.validateAndRevoke(refreshToken)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
         String accessToken = jwtProvider.issueAccessToken(member.getId());
         String newRefreshToken = refreshTokenService.issue(member);
-        return new TokenResponse(accessToken, newRefreshToken);
+        return new AuthTokens(accessToken, newRefreshToken);
     }
 
     @Transactional
@@ -111,10 +109,10 @@ public class AuthService {
         refreshTokenService.revoke(refreshToken);
     }
 
-    private LoginResponse issueTokens(Member member, boolean isNewMember) {
+    private LoginResult issueTokens(Member member, boolean isNewMember) {
         String accessToken = jwtProvider.issueAccessToken(member.getId());
         String refreshToken = refreshTokenService.issue(member);
-        return new LoginResponse(accessToken, refreshToken, isNewMember);
+        return new LoginResult(new AuthTokens(accessToken, refreshToken), isNewMember);
     }
 
     private Member register(String providerId, String nickname) {

--- a/backend/src/main/java/com/mapmory/backend/auth/AuthTokens.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/AuthTokens.java
@@ -1,0 +1,12 @@
+package com.mapmory.backend.auth;
+
+/**
+ * 발급된 access·refresh 토큰 쌍.
+ *
+ * <p>표현 형식을 정하지 않으므로 응답 DTO 변환은 웹 계층이 맡는다. (ADR 0016, 0017)
+ */
+public record AuthTokens(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/auth/LoginResult.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/LoginResult.java
@@ -1,0 +1,13 @@
+package com.mapmory.backend.auth;
+
+/**
+ * 로그인 결과. 토큰 쌍과 신규 가입 여부를 담는다.
+ *
+ * <p>{@code newMember}는 온보딩 분기에 쓰인다. 게스트 승격은 이미 앱을 사용한 상태이므로
+ * 신규로 보지 않는다. (ADR 0015)
+ */
+public record LoginResult(
+        AuthTokens tokens,
+        boolean newMember
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/dto/LoginResponse.java
@@ -1,5 +1,7 @@
 package com.mapmory.backend.auth.dto;
 
+import com.mapmory.backend.auth.LoginResult;
+
 /**
  * 로그인 응답.
  *
@@ -13,4 +15,12 @@ public record LoginResponse(
         String refreshToken,
         boolean isNewMember
 ) {
+
+    public static LoginResponse from(LoginResult result) {
+        return new LoginResponse(
+                result.tokens().accessToken(),
+                result.tokens().refreshToken(),
+                result.newMember()
+        );
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/auth/dto/TokenResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/auth/dto/TokenResponse.java
@@ -1,5 +1,7 @@
 package com.mapmory.backend.auth.dto;
 
+import com.mapmory.backend.auth.AuthTokens;
+
 /**
  * 토큰 재발급 응답. 회전으로 새로 발급된 access/refresh 쌍을 반환한다.
  */
@@ -7,4 +9,8 @@ public record TokenResponse(
         String accessToken,
         String refreshToken
 ) {
+
+    public static TokenResponse from(AuthTokens tokens) {
+        return new TokenResponse(tokens.accessToken(), tokens.refreshToken());
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/MediaView.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/MediaView.java
@@ -1,0 +1,15 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+
+/**
+ * 미디어와 그 조회용 URL의 조합.
+ *
+ * <p>URL을 Object Key 기준 맵으로 넘기면 정렬 순서를 잃는다. 짝지은 목록으로 넘겨
+ * 애그리거트가 정한 sortOrder 순서가 응답까지 그대로 이어지게 한다.
+ */
+public record MediaView(
+        RecordMedia recordMedia,
+        ExpiringUrl viewUrl
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordAssembler.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordAssembler.java
@@ -1,0 +1,85 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.recordmedia.RecordMediaUrlService;
+import com.mapmory.backend.tag.Tag;
+import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+/**
+ * TravelRecord 애그리거트의 읽기 모델을 조립한다.
+ *
+ * <p>ADR 0017 결정 4에 따라 애그리거트당 하나만 둔다. 조회와 URL 발급을 맡으므로
+ * 애그리거트 내부가 아니라 응용 계층에 속한다.
+ */
+@Component
+public class TravelRecordAssembler {
+
+    private final TravelRecordRepository travelRecordRepository;
+    private final TravelRecordTagService travelRecordTagService;
+    private final RecordMediaUrlService recordMediaUrlService;
+
+    public TravelRecordAssembler(
+            TravelRecordRepository travelRecordRepository,
+            TravelRecordTagService travelRecordTagService,
+            RecordMediaUrlService recordMediaUrlService
+    ) {
+        this.travelRecordRepository = travelRecordRepository;
+        this.travelRecordTagService = travelRecordTagService;
+        this.recordMediaUrlService = recordMediaUrlService;
+    }
+
+    public TravelRecordDetail assembleDetail(TravelRecord travelRecord) {
+        return assembleDetail(
+                travelRecord,
+                travelRecordTagService.findByTravelRecordId(travelRecord.getId())
+        );
+    }
+
+    /**
+     * 태그를 이미 알고 있는 수정 경로용. 같은 트랜잭션에서 다시 조회하지 않는다.
+     */
+    public TravelRecordDetail assembleDetail(TravelRecord travelRecord, List<Tag> tags) {
+        return new TravelRecordDetail(travelRecord, tags, toMediaViews(travelRecord));
+    }
+
+    public TravelRecordSummaries assembleSummaries(Page<TravelRecord> travelRecords) {
+        List<Long> travelRecordIds = travelRecords.getContent().stream()
+                .map(TravelRecord::getId)
+                .toList();
+
+        return new TravelRecordSummaries(
+                travelRecords,
+                travelRecordTagService.findByTravelRecordIds(travelRecordIds),
+                createThumbnailUrls(travelRecordIds)
+        );
+    }
+
+    private List<MediaView> toMediaViews(TravelRecord travelRecord) {
+        return travelRecord.getMedia().stream()
+                .map(recordMedia -> new MediaView(
+                        recordMedia,
+                        recordMediaUrlService.createViewUrl(recordMedia.getObjectKey())
+                ))
+                .toList();
+    }
+
+    private Map<Long, ExpiringUrl> createThumbnailUrls(List<Long> travelRecordIds) {
+        if (travelRecordIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, ExpiringUrl> thumbnailUrls = new HashMap<>();
+        for (RecordMedia recordMedia : travelRecordRepository.findMediaByTravelRecordIdIn(travelRecordIds)) {
+            thumbnailUrls.computeIfAbsent(
+                    recordMedia.travelRecordId(),
+                    ignored -> recordMediaUrlService.createViewUrl(recordMedia.getThumbnailObjectKey())
+            );
+        }
+        return Map.copyOf(thumbnailUrls);
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordCommand.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordCommand.java
@@ -1,0 +1,28 @@
+package com.mapmory.backend.travelrecord;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 여행 일지 생성·수정에 필요한 값을 서비스 계층 형태로 담는다.
+ * 웹 요청 스펙(TravelRecordRequest)과 분리해 서비스가 API 계약에 의존하지 않게 한다.
+ *
+ * <p>속성이 9개라 원시 값으로 풀면 순서만 바꿔도 컴파일이 통과하는 시그니처가 된다.
+ * 그래서 Tag와 달리 커맨드를 둔다. (ADR 0017)
+ */
+public record TravelRecordCommand(
+        String countryCode,
+        String provinceCode,
+        String districtCode,
+        String title,
+        String content,
+        LocalDate startDate,
+        LocalDate endDate,
+        List<String> objectKeys,
+        List<Long> tagIds
+) {
+    public TravelRecordCommand {
+        objectKeys = objectKeys == null ? List.of() : objectKeys;
+        tagIds = tagIds == null ? List.of() : tagIds;
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordController.java
@@ -38,7 +38,7 @@ public class TravelRecordController {
             @LoginMember Member member,
             @Valid @RequestBody TravelRecordRequest travelRecordRequest
     ) {
-        TravelRecord travelRecord = travelRecordService.create(member, travelRecordRequest);
+        TravelRecord travelRecord = travelRecordService.create(member, travelRecordRequest.toCommand());
         CreateTravelRecordResponse response = CreateTravelRecordResponse.from(travelRecord);
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -55,7 +55,7 @@ public class TravelRecordController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
-        TravelRecordListResponse response = travelRecordService.findAll(
+        TravelRecordSummaries summaries = travelRecordService.findAll(
                 member,
                 countryCode,
                 provinceCode,
@@ -64,6 +64,7 @@ public class TravelRecordController {
                 page,
                 size
         );
+        TravelRecordListResponse response = TravelRecordListResponse.from(summaries);
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }
@@ -73,7 +74,9 @@ public class TravelRecordController {
             @LoginMember Member member,
             @PathVariable @Positive Long travelRecordId
     ) {
-        TravelRecordDetailResponse response = travelRecordService.findById(member, travelRecordId);
+        TravelRecordDetailResponse response = TravelRecordDetailResponse.from(
+                travelRecordService.findById(member, travelRecordId)
+        );
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }
@@ -84,11 +87,12 @@ public class TravelRecordController {
             @PathVariable @Positive Long travelRecordId,
             @Valid @RequestBody TravelRecordRequest travelRecordRequest
     ) {
-        TravelRecordDetailResponse response = travelRecordService.update(
+        TravelRecordDetail detail = travelRecordService.update(
                 member,
                 travelRecordId,
-                travelRecordRequest
+                travelRecordRequest.toCommand()
         );
+        TravelRecordDetailResponse response = TravelRecordDetailResponse.from(detail);
 
         return ResponseEntity.ok(TravelRecordResponse.of(response));
     }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordDetail.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordDetail.java
@@ -1,0 +1,20 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.tag.Tag;
+import java.util.List;
+
+/**
+ * 여행 일지 상세를 이루는 도메인 조합 결과다.
+ * 표현 형식을 정하지 않으므로 응답 DTO 변환은 웹 계층이 맡는다. (ADR 0016, 0017)
+ */
+public record TravelRecordDetail(
+        TravelRecord travelRecord,
+        List<Tag> tags,
+        List<MediaView> mediaViews
+) {
+    public List<RecordMedia> recordMedia() {
+        return mediaViews.stream()
+                .map(MediaView::recordMedia)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordService.java
@@ -4,23 +4,15 @@ import com.mapmory.backend.common.exception.BusinessException;
 import com.mapmory.backend.common.monitoring.MonitoredOperation;
 import com.mapmory.backend.common.monitoring.OperationTimer;
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.recordmedia.ExpiringUrl;
-import com.mapmory.backend.recordmedia.RecordMediaUrlService;
 import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -39,7 +31,7 @@ public class TravelRecordService {
     private final TravelRecordTagService travelRecordTagService;
     private final TagService tagService;
     private final OperationTimer operationTimer;
-    private final RecordMediaUrlService recordMediaUrlService;
+    private final TravelRecordAssembler travelRecordAssembler;
     private final Clock clock;
     private final UploadedObjectVerifier uploadedObjectVerifier;
 
@@ -49,7 +41,7 @@ public class TravelRecordService {
             TravelRecordTagService travelRecordTagService,
             TagService tagService,
             OperationTimer operationTimer,
-            RecordMediaUrlService recordMediaUrlService,
+            TravelRecordAssembler travelRecordAssembler,
             Clock clock,
             UploadedObjectVerifier uploadedObjectVerifier
     ) {
@@ -58,74 +50,70 @@ public class TravelRecordService {
         this.travelRecordTagService = travelRecordTagService;
         this.tagService = tagService;
         this.operationTimer = operationTimer;
-        this.recordMediaUrlService = recordMediaUrlService;
+        this.travelRecordAssembler = travelRecordAssembler;
         this.clock = clock;
         this.uploadedObjectVerifier = uploadedObjectVerifier;
     }
 
     @Transactional
-    public TravelRecord create(Member member, TravelRecordRequest request) {
-        validateTravelDates(request.startDate(), request.endDate());
-        validateTravelRecordRegion(request);
-        List<String> objectKeys = objectKeys(request);
+    public TravelRecord create(Member member, TravelRecordCommand command) {
+        validateTravelDates(command.startDate(), command.endDate());
+        validateTravelRecordRegion(command);
+        List<String> objectKeys = command.objectKeys();
         TravelRecord.validateObjectKeys(objectKeys);
         uploadedObjectVerifier.verifyAllUploaded(objectKeys);
-        Region region = resolveRegion(request);
+        Region region = resolveRegion(command);
 
         TravelRecord travelRecord = TravelRecord.of(
                 member,
                 region,
-                request.title(),
-                request.content(),
-                request.startDate(),
-                request.endDate()
+                command.title(),
+                command.content(),
+                command.startDate(),
+                command.endDate()
         );
         travelRecord.synchronizeMedia(objectKeys);
 
         TravelRecord savedTravelRecord = travelRecordRepository.save(travelRecord);
-        travelRecordTagService.replace(member, savedTravelRecord, request.tagIds());
+        travelRecordTagService.replace(member, savedTravelRecord, command.tagIds());
 
         return savedTravelRecord;
     }
 
     @Transactional(readOnly = true)
-    public TravelRecordDetailResponse findById(Member member, Long travelRecordId) {
+    public TravelRecordDetail findById(Member member, Long travelRecordId) {
         TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
-        return createDetailResponse(
-                travelRecord,
-                travelRecord.getMedia(),
-                travelRecordTagService.findByTravelRecordId(travelRecordId)
-        );
+        return travelRecordAssembler.assembleDetail(travelRecord);
     }
 
     @Transactional
-    public TravelRecordDetailResponse update(
+    public TravelRecordDetail update(
             Member member,
             Long travelRecordId,
-            TravelRecordRequest request
+            TravelRecordCommand command
     ) {
-        validateTravelDates(request.startDate(), request.endDate());
-        validateTravelRecordRegion(request);
+        validateTravelDates(command.startDate(), command.endDate());
+        validateTravelRecordRegion(command);
         TravelRecord travelRecord = travelRecordRepository.findByIdAndMemberId(travelRecordId, member.getId())
                 .orElseThrow(() -> new BusinessException(TravelRecordErrorCode.TRAVEL_RECORD_NOT_FOUND));
-        List<String> objectKeys = objectKeys(request);
+        List<String> objectKeys = command.objectKeys();
         TravelRecord.validateObjectKeys(objectKeys);
 
-        Region region = resolveRegion(request);
+        Region region = resolveRegion(command);
         List<String> newObjectKeys = travelRecord.newObjectKeys(objectKeys);
         validateObjectKeysAreAvailable(newObjectKeys);
         uploadedObjectVerifier.verifyAllUploaded(newObjectKeys);
 
         travelRecord.update(
                 region,
-                request.title(),
-                request.content(),
-                request.startDate(),
-                request.endDate()
+                command.title(),
+                command.content(),
+                command.startDate(),
+                command.endDate()
         );
-        List<Tag> tags = travelRecordTagService.replace(member, travelRecord, request.tagIds());
-        List<RecordMedia> updatedMedia = operationTimer.record(
+        List<Tag> tags = travelRecordTagService.replace(member, travelRecord, command.tagIds());
+        operationTimer.record(
                 MonitoredOperation.MEDIA_SYNC,
                 () -> {
                     travelRecord.synchronizeMedia(objectKeys);
@@ -134,7 +122,7 @@ public class TravelRecordService {
                 }
         );
 
-        return createDetailResponse(travelRecord, updatedMedia, tags);
+        return travelRecordAssembler.assembleDetail(travelRecord, tags);
     }
 
     @Transactional
@@ -146,7 +134,7 @@ public class TravelRecordService {
     }
 
     @Transactional(readOnly = true)
-    public TravelRecordListResponse findAll(
+    public TravelRecordSummaries findAll(
             Member member,
             String countryCode,
             String provinceCode,
@@ -194,18 +182,7 @@ public class TravelRecordService {
             }
         }
 
-        List<Long> travelRecordIds = travelRecords.getContent().stream()
-                .map(TravelRecord::getId)
-                .toList();
-        Map<Long, List<Tag>> tagsByTravelRecordId =
-                travelRecordTagService.findByTravelRecordIds(travelRecordIds);
-        Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId =
-                createThumbnailUrls(travelRecordIds);
-        return TravelRecordListResponse.from(
-                travelRecords,
-                tagsByTravelRecordId,
-                thumbnailUrlsByTravelRecordId
-        );
+        return travelRecordAssembler.assembleSummaries(travelRecords);
     }
 
     private void validateRegionFilterHierarchy(
@@ -259,18 +236,18 @@ public class TravelRecordService {
         );
     }
 
-    private Region resolveRegion(TravelRecordRequest request) {
+    private Region resolveRegion(TravelRecordCommand command) {
         return regionResolver.resolve(
-                request.countryCode(),
-                request.provinceCode(),
-                request.districtCode()
+                command.countryCode(),
+                command.provinceCode(),
+                command.districtCode()
         );
     }
 
-    private void validateTravelRecordRegion(TravelRecordRequest request) {
-        String countryCode = request.countryCode();
-        String provinceCode = request.provinceCode();
-        String districtCode = request.districtCode();
+    private void validateTravelRecordRegion(TravelRecordCommand command) {
+        String countryCode = command.countryCode();
+        String provinceCode = command.provinceCode();
+        String districtCode = command.districtCode();
         validateRegionCodeFormat(countryCode, provinceCode, districtCode);
 
         if (KOREA_COUNTRY_CODE.equals(countryCode)) {
@@ -285,45 +262,13 @@ public class TravelRecordService {
         }
     }
 
-    private static List<String> objectKeys(TravelRecordRequest request) {
-        return request.objectKeys() == null ? List.of() : request.objectKeys();
-    }
-
-    private void validateObjectKeysAreAvailable(List<String> newObjectKeys) {
+        private void validateObjectKeysAreAvailable(List<String> newObjectKeys) {
         if (!newObjectKeys.isEmpty()
                 && travelRecordRepository.existsMediaByObjectKeyIn(newObjectKeys)) {
             throw new BusinessException(TravelRecordErrorCode.INVALID_OBJECT_KEY);
         }
     }
 
-    private Map<Long, ExpiringUrl> createThumbnailUrls(List<Long> travelRecordIds) {
-        if (travelRecordIds.isEmpty()) {
-            return Map.of();
-        }
 
-        Map<Long, ExpiringUrl> thumbnailUrls = new HashMap<>();
-        for (RecordMedia recordMedia : travelRecordRepository.findMediaByTravelRecordIdIn(travelRecordIds)) {
-            thumbnailUrls.computeIfAbsent(
-                    recordMedia.travelRecordId(),
-                    ignored -> recordMediaUrlService.createViewUrl(recordMedia.getThumbnailObjectKey())
-            );
-        }
-        return Map.copyOf(thumbnailUrls);
-    }
-
-    private TravelRecordDetailResponse createDetailResponse(
-            TravelRecord travelRecord,
-            List<RecordMedia> recordMedia,
-            List<Tag> tags
-    ) {
-        List<TravelRecordMediaResponse> media = recordMedia.stream()
-                .map(item -> TravelRecordMediaResponse.from(
-                        item,
-                        recordMediaUrlService.createViewUrl(item.getObjectKey())
-                ))
-                .toList();
-
-        return TravelRecordDetailResponse.from(travelRecord, recordMedia, tags, media);
-    }
 
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordSummaries.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordSummaries.java
@@ -1,0 +1,24 @@
+package com.mapmory.backend.travelrecord;
+
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.tag.Tag;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
+
+/**
+ * 여행 일지 목록 한 페이지와, 각 일지에 딸린 태그·썸네일을 묶은 도메인 조합 결과다.
+ */
+public record TravelRecordSummaries(
+        Page<TravelRecord> travelRecords,
+        Map<Long, List<Tag>> tagsByTravelRecordId,
+        Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId
+) {
+    public List<Tag> tagsOf(TravelRecord travelRecord) {
+        return tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of());
+    }
+
+    public ExpiringUrl thumbnailUrlOf(TravelRecord travelRecord) {
+        return thumbnailUrlsByTravelRecordId.get(travelRecord.getId());
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordDetailResponse.java
@@ -1,9 +1,9 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.travelrecord.RecordMedia;
-import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.tag.dto.TagSummaryResponse;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.travelrecord.TravelRecordDetail;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,12 +35,9 @@ public record TravelRecordDetailResponse(
         this(id, title, content, region, startDate, endDate, objectKeys, List.of(), List.of(), createdAt, updatedAt);
     }
 
-    public static TravelRecordDetailResponse from(
-            TravelRecord travelRecord,
-            List<RecordMedia> recordMedia,
-            List<Tag> tags,
-            List<TravelRecordMediaResponse> media
-    ) {
+    public static TravelRecordDetailResponse from(TravelRecordDetail detail) {
+        TravelRecord travelRecord = detail.travelRecord();
+
         return new TravelRecordDetailResponse(
                 travelRecord.getId(),
                 travelRecord.getTitle(),
@@ -48,11 +45,13 @@ public record TravelRecordDetailResponse(
                 RegionDetailResponse.from(travelRecord.getRegion()),
                 travelRecord.getStartDate(),
                 travelRecord.getEndDate(),
-                recordMedia.stream()
+                detail.recordMedia().stream()
                         .map(RecordMedia::getObjectKey)
                         .toList(),
-                media,
-                tags.stream().map(TagSummaryResponse::from).toList(),
+                detail.mediaViews().stream()
+                        .map(TravelRecordMediaResponse::from)
+                        .toList(),
+                detail.tags().stream().map(TagSummaryResponse::from).toList(),
                 travelRecord.getCreatedAt(),
                 travelRecord.getUpdatedAt()
         );

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordListResponse.java
@@ -1,10 +1,8 @@
 package com.mapmory.backend.travelrecord.dto;
 
-import com.mapmory.backend.recordmedia.ExpiringUrl;
-import com.mapmory.backend.tag.Tag;
 import com.mapmory.backend.travelrecord.TravelRecord;
+import com.mapmory.backend.travelrecord.TravelRecordSummaries;
 import java.util.List;
-import java.util.Map;
 import org.springframework.data.domain.Page;
 
 public record TravelRecordListResponse(
@@ -15,17 +13,15 @@ public record TravelRecordListResponse(
         int totalPages,
         boolean hasNext
 ) {
-    public static TravelRecordListResponse from(
-            Page<TravelRecord> travelRecords,
-            Map<Long, List<Tag>> tagsByTravelRecordId,
-            Map<Long, ExpiringUrl> thumbnailUrlsByTravelRecordId
-    ) {
+    public static TravelRecordListResponse from(TravelRecordSummaries summaries) {
+        Page<TravelRecord> travelRecords = summaries.travelRecords();
+
         return new TravelRecordListResponse(
                 travelRecords.getContent().stream()
                         .map(travelRecord -> TravelRecordListItemResponse.from(
                                 travelRecord,
-                                tagsByTravelRecordId.getOrDefault(travelRecord.getId(), List.of()),
-                                thumbnailUrlsByTravelRecordId.get(travelRecord.getId())
+                                summaries.tagsOf(travelRecord),
+                                summaries.thumbnailUrlOf(travelRecord)
                         ))
                         .toList(),
                 travelRecords.getNumber(),

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordMediaResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordMediaResponse.java
@@ -1,6 +1,7 @@
 package com.mapmory.backend.travelrecord.dto;
 
 import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.travelrecord.MediaView;
 import com.mapmory.backend.travelrecord.RecordMedia;
 
 public record TravelRecordMediaResponse(
@@ -10,6 +11,10 @@ public record TravelRecordMediaResponse(
         long viewUrlExpiresIn,
         int sortOrder
 ) {
+    public static TravelRecordMediaResponse from(MediaView mediaView) {
+        return from(mediaView.recordMedia(), mediaView.viewUrl());
+    }
+
     public static TravelRecordMediaResponse from(
             RecordMedia recordMedia,
             ExpiringUrl viewUrl

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/dto/TravelRecordRequest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.travelrecord.dto;
 
+import com.mapmory.backend.travelrecord.TravelRecordCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -36,5 +37,19 @@ public record TravelRecordRequest(
             List<String> objectKeys
     ) {
         this(countryCode, provinceCode, districtCode, title, content, startDate, endDate, objectKeys, List.of());
+    }
+
+    public TravelRecordCommand toCommand() {
+        return new TravelRecordCommand(
+                countryCode,
+                provinceCode,
+                districtCode,
+                title,
+                content,
+                startDate,
+                endDate,
+                objectKeys,
+                tagIds
+        );
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/RegionMapSummary.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/RegionMapSummary.java
@@ -1,0 +1,20 @@
+package com.mapmory.backend.travelrecord.mapsummary;
+
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
+
+/**
+ * 지도에 칠할 지역 하나의 요약이다.
+ *
+ * <p>리포지토리 프로젝션에 색상 단계 정책을 적용한 결과이며 표현 형식을 정하지 않는다.
+ * 응답 DTO 변환은 웹 계층이 맡는다. (ADR 0016, 0017)
+ */
+public record RegionMapSummary(
+        Long regionId,
+        String regionCode,
+        RegionType regionType,
+        String name,
+        long recordCount,
+        MapColorLevel level
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
@@ -3,6 +3,7 @@ package com.mapmory.backend.travelrecord.mapsummary.controller;
 import com.mapmory.backend.auth.security.LoginMember;
 import com.mapmory.backend.common.dto.ApiResponse;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
 import jakarta.validation.constraints.Positive;
@@ -30,7 +31,7 @@ public class RegionMapSummaryController {
             @LoginMember Member member,
             @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(regionMapSummaryService.getSummaries(member, null, tagId));
+        return ApiResponse.from(toResponses(regionMapSummaryService.getSummaries(member, null, tagId)));
     }
 
     @GetMapping("/{regionId}/children")
@@ -41,6 +42,12 @@ public class RegionMapSummaryController {
             Long regionId,
             @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(regionMapSummaryService.getSummaries(member, regionId, tagId));
+        return ApiResponse.from(toResponses(regionMapSummaryService.getSummaries(member, regionId, tagId)));
+    }
+
+    private List<RegionMapSummaryResponse> toResponses(List<RegionMapSummary> summaries) {
+        return summaries.stream()
+                .map(RegionMapSummaryResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryController.java
@@ -3,7 +3,6 @@ package com.mapmory.backend.travelrecord.mapsummary.controller;
 import com.mapmory.backend.auth.security.LoginMember;
 import com.mapmory.backend.common.dto.ApiResponse;
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
 import jakarta.validation.constraints.Positive;
@@ -31,7 +30,9 @@ public class RegionMapSummaryController {
             @LoginMember Member member,
             @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(toResponses(regionMapSummaryService.getSummaries(member, null, tagId)));
+        return ApiResponse.from(RegionMapSummaryResponse.from(
+                regionMapSummaryService.getSummaries(member, null, tagId)
+        ));
     }
 
     @GetMapping("/{regionId}/children")
@@ -42,12 +43,8 @@ public class RegionMapSummaryController {
             Long regionId,
             @RequestParam(required = false) @Positive Long tagId
     ) {
-        return ApiResponse.from(toResponses(regionMapSummaryService.getSummaries(member, regionId, tagId)));
-    }
-
-    private List<RegionMapSummaryResponse> toResponses(List<RegionMapSummary> summaries) {
-        return summaries.stream()
-                .map(RegionMapSummaryResponse::from)
-                .toList();
+        return ApiResponse.from(RegionMapSummaryResponse.from(
+                regionMapSummaryService.getSummaries(member, regionId, tagId)
+        ));
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/dto/RegionMapSummaryResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/dto/RegionMapSummaryResponse.java
@@ -2,6 +2,7 @@ package com.mapmory.backend.travelrecord.mapsummary.dto;
 
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
+import java.util.List;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
 
 public record RegionMapSummaryResponse(
@@ -12,6 +13,12 @@ public record RegionMapSummaryResponse(
         long count,
         MapColorLevel level
 ) {
+
+    public static List<RegionMapSummaryResponse> from(List<RegionMapSummary> summaries) {
+        return summaries.stream()
+                .map(RegionMapSummaryResponse::from)
+                .toList();
+    }
 
     public static RegionMapSummaryResponse from(RegionMapSummary summary) {
         return new RegionMapSummaryResponse(

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/dto/RegionMapSummaryResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/dto/RegionMapSummaryResponse.java
@@ -1,9 +1,8 @@
 package com.mapmory.backend.travelrecord.mapsummary.dto;
 
 import com.mapmory.backend.region.RegionType;
-import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
-import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryQueryResult;
 
 public record RegionMapSummaryResponse(
         Long regionId,
@@ -14,17 +13,14 @@ public record RegionMapSummaryResponse(
         MapColorLevel level
 ) {
 
-    public static RegionMapSummaryResponse from(
-            RegionMapSummaryQueryResult result,
-            LevelPolicy levelPolicy
-    ) {
+    public static RegionMapSummaryResponse from(RegionMapSummary summary) {
         return new RegionMapSummaryResponse(
-                result.getRegionId(),
-                result.getRegionCode(),
-                RegionType.valueOf(result.getRegionType()),
-                result.getName(),
-                result.getRecordCount(),
-                levelPolicy.levelFor(result.getRecordCount())
+                summary.regionId(),
+                summary.regionCode(),
+                summary.regionType(),
+                summary.name(),
+                summary.recordCount(),
+                summary.level()
         );
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryService.java
@@ -7,7 +7,8 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
+import com.mapmory.backend.region.RegionType;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryQueryResult;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryRepository;
@@ -39,7 +40,7 @@ public class RegionMapSummaryService {
     }
 
     @Transactional(readOnly = true)
-    public List<RegionMapSummaryResponse> getSummaries(Member member, Long parentRegionId, Long tagId) {
+    public List<RegionMapSummary> getSummaries(Member member, Long parentRegionId, Long tagId) {
         validateParentRegion(parentRegionId);
         if (tagId != null) {
             tagService.getOwnedTag(member, tagId);
@@ -49,8 +50,19 @@ public class RegionMapSummaryService {
                 () -> regionMapSummaryRepository.findRegionMapSummaries(member.getId(), parentRegionId, tagId)
         );
         return summaries.stream()
-                .map(result -> RegionMapSummaryResponse.from(result, levelPolicy))
+                .map(this::toSummary)
                 .toList();
+    }
+
+    private RegionMapSummary toSummary(RegionMapSummaryQueryResult result) {
+        return new RegionMapSummary(
+                result.getRegionId(),
+                result.getRegionCode(),
+                RegionType.valueOf(result.getRegionType()),
+                result.getName(),
+                result.getRecordCount(),
+                levelPolicy.levelFor(result.getRecordCount())
+        );
     }
 
     private void validateParentRegion(Long parentRegionId) {

--- a/backend/src/main/java/com/mapmory/backend/upload/PresignedUpload.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/PresignedUpload.java
@@ -1,0 +1,18 @@
+package com.mapmory.backend.upload;
+
+import java.net.URI;
+import java.time.Duration;
+
+/**
+ * 파일 하나에 대해 발급한 presigned 업로드 정보.
+ *
+ * <p>URI와 Duration을 그대로 담는다. 문자열·초 단위 변환은 응답 DTO가 맡는다.
+ */
+public record PresignedUpload(
+        String objectKey,
+        URI presignedUrl,
+        String method,
+        String contentType,
+        Duration expiration
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/upload/UploadFileCommand.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/UploadFileCommand.java
@@ -1,0 +1,12 @@
+package com.mapmory.backend.upload;
+
+/**
+ * presigned 업로드 URL을 받으려는 파일 하나의 정보.
+ * 웹 요청 스펙(UploadFileRequest)과 분리해 서비스가 API 계약에 의존하지 않게 한다.
+ */
+public record UploadFileCommand(
+        String fileName,
+        String contentType,
+        long fileSize
+) {
+}

--- a/backend/src/main/java/com/mapmory/backend/upload/controller/UploadController.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/controller/UploadController.java
@@ -27,6 +27,8 @@ public class UploadController {
             @LoginMember Member member,
             @Valid @RequestBody CreatePresignedUrlsRequest request
     ) {
-        return ApiResponse.from(uploadService.createPresignedUrls(member, request));
+        return ApiResponse.from(CreatePresignedUrlsResponse.from(
+                uploadService.createPresignedUrls(member, request.toCommands())
+        ));
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/dto/CreatePresignedUrlsRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/dto/CreatePresignedUrlsRequest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.upload.dto;
 
+import com.mapmory.backend.upload.UploadFileCommand;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
@@ -8,4 +9,10 @@ public record CreatePresignedUrlsRequest(
         @NotEmpty(message = "업로드할 파일은 1개 이상이어야 합니다.")
         List<@Valid UploadFileRequest> files
 ) {
+
+    public List<UploadFileCommand> toCommands() {
+        return files.stream()
+                .map(UploadFileRequest::toCommand)
+                .toList();
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/dto/CreatePresignedUrlsResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/dto/CreatePresignedUrlsResponse.java
@@ -1,8 +1,17 @@
 package com.mapmory.backend.upload.dto;
 
+import com.mapmory.backend.upload.PresignedUpload;
 import java.util.List;
 
 public record CreatePresignedUrlsResponse(
         List<PresignedUploadResponse> uploads
 ) {
+
+    public static CreatePresignedUrlsResponse from(List<PresignedUpload> uploads) {
+        return new CreatePresignedUrlsResponse(
+                uploads.stream()
+                        .map(PresignedUploadResponse::from)
+                        .toList()
+        );
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/dto/PresignedUploadResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/dto/PresignedUploadResponse.java
@@ -1,5 +1,7 @@
 package com.mapmory.backend.upload.dto;
 
+import com.mapmory.backend.upload.PresignedUpload;
+
 public record PresignedUploadResponse(
         String objectKey,
         String presignedUrl,
@@ -7,4 +9,14 @@ public record PresignedUploadResponse(
         String contentType,
         long expiresIn
 ) {
+
+    public static PresignedUploadResponse from(PresignedUpload upload) {
+        return new PresignedUploadResponse(
+                upload.objectKey(),
+                upload.presignedUrl().toString(),
+                upload.method(),
+                upload.contentType(),
+                upload.expiration().toSeconds()
+        );
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/dto/UploadFileRequest.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/dto/UploadFileRequest.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.upload.dto;
 
+import com.mapmory.backend.upload.UploadFileCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -15,4 +16,8 @@ public record UploadFileRequest(
         @Positive(message = "파일 크기는 양수여야 합니다.")
         Long fileSize
 ) {
+
+    public UploadFileCommand toCommand() {
+        return new UploadFileCommand(fileName, contentType, fileSize);
+    }
 }

--- a/backend/src/main/java/com/mapmory/backend/upload/service/UploadService.java
+++ b/backend/src/main/java/com/mapmory/backend/upload/service/UploadService.java
@@ -1,10 +1,8 @@
 package com.mapmory.backend.upload.service;
 
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.upload.dto.CreatePresignedUrlsRequest;
-import com.mapmory.backend.upload.dto.CreatePresignedUrlsResponse;
-import com.mapmory.backend.upload.dto.PresignedUploadResponse;
-import com.mapmory.backend.upload.dto.UploadFileRequest;
+import com.mapmory.backend.upload.PresignedUpload;
+import com.mapmory.backend.upload.UploadFileCommand;
 import com.mapmory.backend.upload.policy.ObjectKeyGenerator;
 import com.mapmory.backend.upload.policy.UploadFileType;
 import com.mapmory.backend.upload.policy.UploadPolicy;
@@ -37,26 +35,22 @@ public class UploadService {
         this.presignedUrlExpiration = properties.presignedUrlExpiration();
     }
 
-    public CreatePresignedUrlsResponse createPresignedUrls(
-            Member member,
-            CreatePresignedUrlsRequest request
-    ) {
-        uploadPolicy.validateFileCount(request.files().size());
-        List<ValidatedUploadFile> validatedFiles = request.files().stream()
+    public List<PresignedUpload> createPresignedUrls(Member member, List<UploadFileCommand> files) {
+        uploadPolicy.validateFileCount(files.size());
+        List<ValidatedUploadFile> validatedFiles = files.stream()
                 .map(file -> new ValidatedUploadFile(
                         file,
                         uploadPolicy.validateFile(file.fileName(), file.contentType(), file.fileSize())
                 ))
                 .toList();
 
-        List<PresignedUploadResponse> uploads = validatedFiles.stream()
+        return validatedFiles.stream()
                 .map(file -> createPresignedUpload(member.getId(), file))
                 .toList();
-        return new CreatePresignedUrlsResponse(uploads);
     }
 
-    private PresignedUploadResponse createPresignedUpload(Long memberId, ValidatedUploadFile validatedFile) {
-        UploadFileRequest file = validatedFile.file();
+    private PresignedUpload createPresignedUpload(Long memberId, ValidatedUploadFile validatedFile) {
+        UploadFileCommand file = validatedFile.file();
         UploadFileType fileType = validatedFile.fileType();
         String objectKey = objectKeyGenerator.generate(memberId, fileType);
         URI presignedUrl = presignedUrlProvider.createPresignedPutUrl(
@@ -65,17 +59,17 @@ public class UploadService {
                 file.fileSize(),
                 presignedUrlExpiration
         );
-        return new PresignedUploadResponse(
+        return new PresignedUpload(
                 objectKey,
-                presignedUrl.toString(),
+                presignedUrl,
                 UPLOAD_METHOD,
                 fileType.contentType(),
-                presignedUrlExpiration.toSeconds()
+                presignedUrlExpiration
         );
     }
 
     private record ValidatedUploadFile(
-            UploadFileRequest file,
+            UploadFileCommand file,
             UploadFileType fileType
     ) {
     }

--- a/backend/src/main/java/com/mapmory/backend/waitlist/Email.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/Email.java
@@ -1,0 +1,65 @@
+package com.mapmory.backend.waitlist;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.text.Normalizer;
+import java.util.Locale;
+
+/**
+ * 출시 알림 신청에 쓰는 이메일. 항상 정규화된 형태로만 존재한다.
+ *
+ * <p>정규화가 값 객체 밖에 있으면 같은 주소가 다른 문자열로 저장될 수 있다.
+ * {@code launch_waitlist.email}은 {@code utf8mb4_0900_bin} 대소문자 구분 콜레이션이라
+ * UNIQUE 제약이 {@code A@x.com}과 {@code a@x.com}을 서로 다른 값으로 본다.
+ * 중복 신청을 막는 책임이 애플리케이션에 있으므로 생성 경로에서 강제한다.
+ *
+ * <p>형식 검증(@Email)은 요청 DTO가 담당한다. 여기서는 저장 가능한 형태인지만 본다.
+ */
+@Embeddable
+record Email(
+        @Column(name = "email", nullable = false, length = 254)
+        String value
+) {
+    private static final int MAX_LENGTH = 254;
+
+    Email {
+        validateNotBlank(value);
+        validateLength(value);
+        validateNormalized(value);
+    }
+
+    static Email from(String rawEmail) {
+        validateNotNull(rawEmail);
+
+        return new Email(normalize(rawEmail));
+    }
+
+    private static String normalize(String rawEmail) {
+        return Normalizer.normalize(rawEmail.trim(), Normalizer.Form.NFKC)
+                .toLowerCase(Locale.ROOT);
+    }
+
+    private static void validateNotNull(String rawEmail) {
+        if (rawEmail == null) {
+            throw new IllegalArgumentException("email must not be null");
+        }
+    }
+
+    private static void validateNotBlank(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("email must not be blank");
+        }
+    }
+
+    private static void validateLength(String value) {
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("email must not exceed " + MAX_LENGTH + " characters");
+        }
+    }
+
+    private static void validateNormalized(String value) {
+        if (!value.equals(normalize(value))) {
+            throw new IllegalArgumentException("email must be normalized");
+        }
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/waitlist/Email.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/Email.java
@@ -1,5 +1,6 @@
 package com.mapmory.backend.waitlist;
 
+import com.mapmory.backend.common.exception.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.text.Normalizer;
@@ -41,25 +42,29 @@ record Email(
 
     private static void validateNotNull(String rawEmail) {
         if (rawEmail == null) {
-            throw new IllegalArgumentException("email must not be null");
+            throwInvalidEmail();
         }
     }
 
     private static void validateNotBlank(String value) {
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("email must not be blank");
+            throwInvalidEmail();
         }
     }
 
     private static void validateLength(String value) {
         if (value.length() > MAX_LENGTH) {
-            throw new IllegalArgumentException("email must not exceed " + MAX_LENGTH + " characters");
+            throwInvalidEmail();
         }
     }
 
     private static void validateNormalized(String value) {
         if (!value.equals(normalize(value))) {
-            throw new IllegalArgumentException("email must be normalized");
+            throwInvalidEmail();
         }
+    }
+
+    private static void throwInvalidEmail() {
+        throw new BusinessException(LaunchWaitlistErrorCode.INVALID_EMAIL);
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistController.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistController.java
@@ -3,7 +3,6 @@ package com.mapmory.backend.waitlist;
 import com.mapmory.backend.common.dto.ApiResponse;
 import com.mapmory.backend.waitlist.dto.LaunchWaitlistRequest;
 import com.mapmory.backend.waitlist.dto.LaunchWaitlistResponse;
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistStatus;
 import jakarta.validation.Valid;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
@@ -26,8 +25,9 @@ public class LaunchWaitlistController {
     public ResponseEntity<ApiResponse<LaunchWaitlistResponse>> subscribe(
             @Valid @RequestBody LaunchWaitlistRequest request
     ) {
-        LaunchWaitlistResponse response = service.subscribe(request);
-        if (response.status() == LaunchWaitlistStatus.ALREADY_SUBSCRIBED) {
+        LaunchWaitlistStatus status = service.subscribe(request.email());
+        LaunchWaitlistResponse response = LaunchWaitlistResponse.from(status);
+        if (status == LaunchWaitlistStatus.ALREADY_SUBSCRIBED) {
             return ResponseEntity.ok(ApiResponse.from(response));
         }
         return ResponseEntity.created(URI.create("/api/v1/waitlist"))

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistEntry.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistEntry.java
@@ -2,6 +2,7 @@ package com.mapmory.backend.waitlist;
 
 import com.mapmory.backend.common.entity.BaseEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,8 +25,8 @@ public class LaunchWaitlistEntry extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 254)
-    private String email;
+    @Embedded
+    private Email email;
 
     @Column(name = "consented_at", nullable = false, updatable = false)
     private LocalDateTime consentedAt;
@@ -33,13 +34,13 @@ public class LaunchWaitlistEntry extends BaseEntity {
     protected LaunchWaitlistEntry() {
     }
 
-    private LaunchWaitlistEntry(String email, LocalDateTime consentedAt) {
+    private LaunchWaitlistEntry(Email email, LocalDateTime consentedAt) {
         this.email = email;
         this.consentedAt = consentedAt;
     }
 
-    public static LaunchWaitlistEntry of(String normalizedEmail, LocalDateTime consentedAt) {
-        return new LaunchWaitlistEntry(normalizedEmail, consentedAt);
+    public static LaunchWaitlistEntry of(Email email, LocalDateTime consentedAt) {
+        return new LaunchWaitlistEntry(email, consentedAt);
     }
 
     public Long getId() {
@@ -47,7 +48,7 @@ public class LaunchWaitlistEntry extends BaseEntity {
     }
 
     String getEmail() {
-        return email;
+        return email.value();
     }
 
     LocalDateTime getConsentedAt() {

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistErrorCode.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistErrorCode.java
@@ -1,0 +1,46 @@
+package com.mapmory.backend.waitlist;
+
+import com.mapmory.backend.common.exception.ErrorCode;
+import com.mapmory.backend.common.exception.ErrorKind;
+
+public enum LaunchWaitlistErrorCode implements ErrorCode {
+
+    INVALID_EMAIL(
+            ErrorKind.INVALID_INPUT,
+            "VALIDATION_ERROR",
+            "요청 값이 올바르지 않습니다.",
+            "이메일은 비어 있을 수 없으며 254자 이하여야 합니다."
+    );
+
+    private final ErrorKind kind;
+    private final String code;
+    private final String title;
+    private final String detail;
+
+    LaunchWaitlistErrorCode(ErrorKind kind, String code, String title, String detail) {
+        this.kind = kind;
+        this.code = code;
+        this.title = title;
+        this.detail = detail;
+    }
+
+    @Override
+    public ErrorKind kind() {
+        return kind;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String title() {
+        return title;
+    }
+
+    @Override
+    public String detail() {
+        return detail;
+    }
+}

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistRepository.java
@@ -1,8 +1,15 @@
 package com.mapmory.backend.waitlist;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LaunchWaitlistRepository extends JpaRepository<LaunchWaitlistEntry, Long> {
 
-    boolean existsByEmail(String email);
+    @Query("""
+            SELECT CASE WHEN COUNT(e) > 0 THEN TRUE ELSE FALSE END
+            FROM LaunchWaitlistEntry e
+            WHERE e.email.value = :email
+            """)
+    boolean existsByEmail(@Param("email") String email);
 }

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistService.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistService.java
@@ -1,11 +1,7 @@
 package com.mapmory.backend.waitlist;
 
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistRequest;
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistResponse;
-import java.text.Normalizer;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Locale;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -28,27 +24,18 @@ public class LaunchWaitlistService {
     }
 
     @Transactional
-    public LaunchWaitlistResponse subscribe(LaunchWaitlistRequest request) {
-        String normalizedEmail = normalizeEmail(request.email());
-        if (repository.existsByEmail(normalizedEmail)) {
-            return LaunchWaitlistResponse.alreadySubscribed();
+    public LaunchWaitlistStatus subscribe(String rawEmail) {
+        Email email = Email.from(rawEmail);
+        if (repository.existsByEmail(email.value())) {
+            return LaunchWaitlistStatus.ALREADY_SUBSCRIBED;
         }
 
-        LaunchWaitlistEntry entry = LaunchWaitlistEntry.of(
-                normalizedEmail,
-                LocalDateTime.now(clock)
-        );
         try {
-            repository.saveAndFlush(entry);
-            return LaunchWaitlistResponse.subscribed();
+            repository.saveAndFlush(LaunchWaitlistEntry.of(email, LocalDateTime.now(clock)));
+            return LaunchWaitlistStatus.SUBSCRIBED;
         } catch (DataIntegrityViolationException exception) {
             // 동시에 같은 주소가 들어온 경우에도 한 번만 저장하고 성공으로 취급한다.
-            return LaunchWaitlistResponse.alreadySubscribed();
+            return LaunchWaitlistStatus.ALREADY_SUBSCRIBED;
         }
-    }
-
-    static String normalizeEmail(String email) {
-        return Normalizer.normalize(email.trim(), Normalizer.Form.NFKC)
-                .toLowerCase(Locale.ROOT);
     }
 }

--- a/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistStatus.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/LaunchWaitlistStatus.java
@@ -1,4 +1,4 @@
-package com.mapmory.backend.waitlist.dto;
+package com.mapmory.backend.waitlist;
 
 public enum LaunchWaitlistStatus {
     SUBSCRIBED,

--- a/backend/src/main/java/com/mapmory/backend/waitlist/dto/LaunchWaitlistResponse.java
+++ b/backend/src/main/java/com/mapmory/backend/waitlist/dto/LaunchWaitlistResponse.java
@@ -1,12 +1,10 @@
 package com.mapmory.backend.waitlist.dto;
 
+import com.mapmory.backend.waitlist.LaunchWaitlistStatus;
+
 public record LaunchWaitlistResponse(LaunchWaitlistStatus status) {
 
-    public static LaunchWaitlistResponse subscribed() {
-        return new LaunchWaitlistResponse(LaunchWaitlistStatus.SUBSCRIBED);
-    }
-
-    public static LaunchWaitlistResponse alreadySubscribed() {
-        return new LaunchWaitlistResponse(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
+    public static LaunchWaitlistResponse from(LaunchWaitlistStatus status) {
+        return new LaunchWaitlistResponse(status);
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordControllerTest.java
@@ -17,19 +17,17 @@ import com.mapmory.backend.auth.security.LoginMember;
 import com.mapmory.backend.common.ProblemDetailFactory;
 import com.mapmory.backend.common.handler.ValidationExceptionHandler;
 import com.mapmory.backend.member.Member;
+import com.mapmory.backend.recordmedia.ExpiringUrl;
+import com.mapmory.backend.region.Region;
+import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.travelrecord.dto.CreateTravelRecordResponse;
-import com.mapmory.backend.travelrecord.dto.RegionDetailResponse;
-import com.mapmory.backend.travelrecord.dto.RegionItemResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListItemResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
 import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecord.dto.TravelRecordResponse;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,6 +38,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -112,7 +112,7 @@ class TravelRecordControllerTest {
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
 
-        when(travelRecordService.create(MEMBER, request)).thenReturn(travelRecord);
+        when(travelRecordService.create(MEMBER, request.toCommand())).thenReturn(travelRecord);
 
         ResponseEntity<TravelRecordResponse<CreateTravelRecordResponse>> response =
                 travelRecordController.create(MEMBER, request);
@@ -121,7 +121,7 @@ class TravelRecordControllerTest {
         assertThat(response.getBody()).isEqualTo(
                 TravelRecordResponse.of(new CreateTravelRecordResponse(1L))
         );
-        verify(travelRecordService).create(MEMBER, request);
+        verify(travelRecordService).create(MEMBER, request.toCommand());
     }
 
     @ParameterizedTest
@@ -136,7 +136,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -155,7 +155,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -169,7 +169,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("title"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @ParameterizedTest
@@ -182,7 +182,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("countryCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -194,7 +194,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("provinceCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -206,7 +206,7 @@ class TravelRecordControllerTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.errors[0].field").value("districtCode"));
 
-        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService, never()).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -220,7 +220,7 @@ class TravelRecordControllerTest {
                 null
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
-        when(travelRecordService.create(eq(MEMBER), any(TravelRecordRequest.class)))
+        when(travelRecordService.create(eq(MEMBER), any(TravelRecordCommand.class)))
                 .thenReturn(travelRecord);
 
         mockMvcWithLoginMember().perform(post("/api/v1/travel-records")
@@ -237,7 +237,7 @@ class TravelRecordControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.id").value(1L));
 
-        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
@@ -251,7 +251,7 @@ class TravelRecordControllerTest {
                 null
         );
         ReflectionTestUtils.setField(travelRecord, "id", 1L);
-        when(travelRecordService.create(eq(MEMBER), any(TravelRecordRequest.class)))
+        when(travelRecordService.create(eq(MEMBER), any(TravelRecordCommand.class)))
                 .thenReturn(travelRecord);
 
         mockMvcWithLoginMember().perform(post("/api/v1/travel-records")
@@ -260,12 +260,12 @@ class TravelRecordControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.id").value(1L));
 
-        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordRequest.class));
+        verify(travelRecordService).create(eq(MEMBER), any(TravelRecordCommand.class));
     }
 
     @Test
     void 여행_일지_상세_조회를_서비스에_위임한다() {
-        TravelRecordDetailResponse detail = detail("제주 여행", "제주시를 걸었다.",
+        TravelRecordDetail detail = detail("제주 여행", "제주시를 걸었다.",
                 List.of("mapmory/travel-records/a.jpg"));
         when(travelRecordService.findById(MEMBER, 101L)).thenReturn(detail);
 
@@ -273,13 +273,15 @@ class TravelRecordControllerTest {
                 travelRecordController.findById(MEMBER, 101L);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isEqualTo(TravelRecordResponse.of(detail));
+        assertThat(response.getBody()).isEqualTo(
+                TravelRecordResponse.of(TravelRecordDetailResponse.from(detail))
+        );
         verify(travelRecordService).findById(MEMBER, 101L);
     }
 
     @Test
     void 여행_일지_상세_HTTP_응답을_반환한다() throws Exception {
-        TravelRecordDetailResponse detail = detail("제주 여행", "제주시를 걸었다.",
+        TravelRecordDetail detail = detail("제주 여행", "제주시를 걸었다.",
                 List.of("mapmory/travel-records/a.jpg"));
         when(travelRecordService.findById(MEMBER, 101L)).thenReturn(detail);
 
@@ -300,25 +302,17 @@ class TravelRecordControllerTest {
 
     @Test
     void 여행_일지_목록에_썸네일_URL을_반환한다() throws Exception {
-        TravelRecordListResponse list = new TravelRecordListResponse(
-                List.of(new TravelRecordListItemResponse(
-                        101L,
-                        "제주 여행",
-                        "제주시",
-                        LocalDate.of(2026, 8, 11),
-                        LocalDate.of(2026, 8, 13),
+        TravelRecord travelRecord = travelRecord("제주 여행", "");
+        TravelRecordSummaries summaries = new TravelRecordSummaries(
+                new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1),
+                Map.of(),
+                Map.of(101L, new ExpiringUrl(
                         "https://download.example/mapmory/travel-records/a.jpg",
-                        300L,
-                        List.of()
-                )),
-                0,
-                20,
-                1,
-                1,
-                false
+                        300L
+                ))
         );
         when(travelRecordService.findAll(MEMBER, null, null, null, null, 0, 20))
-                .thenReturn(list);
+                .thenReturn(summaries);
 
         mockMvcWithLoginMember().perform(get("/api/v1/travel-records"))
                 .andExpect(status().isOk())
@@ -329,12 +323,12 @@ class TravelRecordControllerTest {
 
     @Test
     void 여행_일지를_수정한다() throws Exception {
-        TravelRecordDetailResponse detail = detail("수정된 제주 여행", "수정된 본문",
+        TravelRecordDetail detail = detail("수정된 제주 여행", "수정된 본문",
                 List.of("travel-records/10/b.jpg"));
         when(travelRecordService.update(
                 ArgumentMatchers.eq(MEMBER),
                 ArgumentMatchers.eq(101L),
-                ArgumentMatchers.any(TravelRecordRequest.class)
+                ArgumentMatchers.any(TravelRecordCommand.class)
         )).thenReturn(detail);
 
         mockMvcWithLoginMember().perform(put("/api/v1/travel-records/101")
@@ -369,32 +363,34 @@ class TravelRecordControllerTest {
         verify(travelRecordService).delete(MEMBER, 101L);
     }
 
-    private TravelRecordDetailResponse detail(String title, String content, List<String> objectKeys) {
-        return new TravelRecordDetailResponse(
-                101L,
+    private TravelRecordDetail detail(String title, String content, List<String> objectKeys) {
+        TravelRecord travelRecord = travelRecord(title, content);
+        travelRecord.synchronizeMedia(objectKeys);
+        List<MediaView> mediaViews = travelRecord.getMedia().stream()
+                .map(recordMedia -> new MediaView(recordMedia, new ExpiringUrl(
+                        "https://download.example/" + recordMedia.getObjectKey(),
+                        300L
+                )))
+                .toList();
+
+        return new TravelRecordDetail(travelRecord, List.of(), mediaViews);
+    }
+
+    private TravelRecord travelRecord(String title, String content) {
+        Region country = Region.of(null, null, "KR", "대한민국", RegionType.COUNTRY);
+        Region province = Region.of(country, country, "49", "제주특별자치도", RegionType.PROVINCE);
+        Region district = Region.of(province, country, "50110", "제주시", RegionType.DISTRICT);
+        TravelRecord travelRecord = TravelRecord.of(
+                null,
+                district,
                 title,
                 content,
-                new RegionDetailResponse(
-                        new RegionItemResponse("KR", "대한민국"),
-                        new RegionItemResponse("49", "제주특별자치도"),
-                        new RegionItemResponse("50110", "제주시")
-                ),
                 LocalDate.of(2026, 8, 11),
-                LocalDate.of(2026, 8, 13),
-                objectKeys,
-                IntStream.range(0, objectKeys.size())
-                        .mapToObj(index -> new TravelRecordMediaResponse(
-                                (long) index + 1,
-                                objectKeys.get(index),
-                                "https://download.example/" + objectKeys.get(index),
-                                300L,
-                                index
-                        ))
-                        .toList(),
-                List.of(),
-                null,
-                null
+                LocalDate.of(2026, 8, 13)
         );
+        ReflectionTestUtils.setField(travelRecord, "id", 101L);
+
+        return travelRecord;
     }
 
     private String validCreateRequestBody(String title, String content) {

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordServiceTest.java
@@ -22,10 +22,6 @@ import com.mapmory.backend.region.Region;
 import com.mapmory.backend.region.RegionResolver;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.tag.TagService;
-import com.mapmory.backend.travelrecord.dto.TravelRecordDetailResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordListResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordMediaResponse;
-import com.mapmory.backend.travelrecord.dto.TravelRecordRequest;
 import com.mapmory.backend.travelrecordtag.TravelRecordTagService;
 import com.mapmory.backend.upload.service.UploadedObjectVerifier;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -96,7 +92,11 @@ class TravelRecordServiceTest {
                 travelRecordTagService,
                 tagService,
                 operationTimer,
-                recordMediaUrlService,
+                new TravelRecordAssembler(
+                        travelRecordRepository,
+                        travelRecordTagService,
+                        recordMediaUrlService
+                ),
                 FIXED_CLOCK,
                 uploadedObjectVerifier
         );
@@ -105,7 +105,7 @@ class TravelRecordServiceTest {
     @Test
     void 국가_단위_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP", null, null, "일본 여행", "", LocalDate.of(2026, 8, 11), null, List.of(), List.of(1L)
         );
 
@@ -113,7 +113,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result).isNotNull();
         verify(regionResolver).resolve("JP", null, null);
@@ -124,7 +124,7 @@ class TravelRecordServiceTest {
     @Test
     void 본문이_null이면_빈_문자열로_정규화해_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP", null, null, "일본 여행", null, LocalDate.of(2026, 8, 11), null, List.of(), List.of()
         );
 
@@ -132,7 +132,7 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getContent()).isEmpty();
     }
@@ -140,40 +140,40 @@ class TravelRecordServiceTest {
     @Test
     void 종료일이_시작일보다_빠르면_여행_일지를_생성하지_않는다() {
         LocalDate startDate = TODAY.minusDays(1);
-        TravelRecordRequest request = createRequest(startDate, startDate.minusDays(1));
+        TravelRecordCommand command = createCommand(startDate, startDate.minusDays(1));
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 시작일이_미래이면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest(
+        TravelRecordCommand command = createCommand(
                 TODAY.plusDays(1),
                 null
         );
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 종료일이_미래이면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest(
+        TravelRecordCommand command = createCommand(
                 TODAY,
                 TODAY.plusDays(1)
         );
 
-        assertInvalidTravelDates(request);
+        assertInvalidTravelDates(command);
     }
 
     @Test
     void 시작일과_종료일이_오늘이면_여행_일지를_생성한다() {
         Region japan = mock(Region.class);
-        TravelRecordRequest request = createRequest(TODAY, TODAY);
+        TravelRecordCommand command = createCommand(TODAY, TODAY);
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getStartDate()).isEqualTo(TODAY);
         assertThat(result.getEndDate()).isEqualTo(TODAY);
@@ -181,34 +181,34 @@ class TravelRecordServiceTest {
 
     @Test
     void 대한민국_여행에_시도가_없으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("KR", null, null);
+        TravelRecordCommand command = createCommand("KR", null, null);
 
-        assertInvalidRegion(request, "REGION_REQUIRED");
+        assertInvalidRegion(command, "REGION_REQUIRED");
     }
 
     @Test
     void 대한민국_여행에_시군구가_없으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("KR", "49", null);
+        TravelRecordCommand command = createCommand("KR", "49", null);
 
-        assertInvalidRegion(request, "REGION_REQUIRED");
+        assertInvalidRegion(command, "REGION_REQUIRED");
     }
 
     @Test
     void 해외_여행에_하위_지역이_있으면_여행_일지를_생성하지_않는다() {
-        TravelRecordRequest request = createRequest("JP", "13", null);
+        TravelRecordCommand command = createCommand("JP", "13", null);
 
-        assertInvalidRegion(request, "INVALID_REGION_TYPE");
+        assertInvalidRegion(command, "INVALID_REGION_TYPE");
     }
 
     @Test
     void 대한민국_시군구_단위_여행_일지를_생성한다() {
         Region jejuCity = mock(Region.class);
-        TravelRecordRequest request = createRequest("KR", "49", "50110");
+        TravelRecordCommand command = createCommand("KR", "49", "50110");
         when(regionResolver.resolve("KR", "49", "50110")).thenReturn(jejuCity);
         when(travelRecordRepository.save(any(TravelRecord.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        TravelRecord result = travelRecordService.create(member, request);
+        TravelRecord result = travelRecordService.create(member, command);
 
         assertThat(result.getRegion()).isEqualTo(jejuCity);
         verify(travelRecordRepository).save(result);
@@ -235,35 +235,38 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        TravelRecordDetailResponse result = travelRecordService.findById(member, 101L);
+        TravelRecordDetail result = travelRecordService.findById(member, 101L);
 
-        assertThat(result.id()).isEqualTo(101L);
-        assertThat(result.content()).isEqualTo("제주시를 걸었다.");
-        assertThat(result.region().country().code()).isEqualTo("KR");
-        assertThat(result.region().province().code()).isEqualTo("49");
-        assertThat(result.region().district().code()).isEqualTo("50110");
-        assertThat(result.objectKeys()).containsExactly(
-                "mapmory/travel-records/a.jpg",
-                "mapmory/travel-records/b.jpg"
-        );
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::viewUrl)
+        Region resolvedRegion = result.travelRecord().getRegion();
+        assertThat(result.travelRecord().getId()).isEqualTo(101L);
+        assertThat(result.travelRecord().getContent()).isEqualTo("제주시를 걸었다.");
+        assertThat(resolvedRegion.getRoot().getRegionCode()).isEqualTo("KR");
+        assertThat(resolvedRegion.getParent().getRegionCode()).isEqualTo("49");
+        assertThat(resolvedRegion.getRegionCode()).isEqualTo("50110");
+        assertThat(result.recordMedia())
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly(
+                        "mapmory/travel-records/a.jpg",
+                        "mapmory/travel-records/b.jpg"
+                );
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.viewUrl().url())
                 .containsExactly(
                         "https://download.example/mapmory/travel-records/a.jpg",
                         "https://download.example/mapmory/travel-records/b.jpg"
                 );
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::viewUrlExpiresIn)
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.viewUrl().expiresIn())
                 .containsOnly(300L);
-        assertThat(result.media())
-                .extracting(TravelRecordMediaResponse::sortOrder)
+        assertThat(result.mediaViews())
+                .extracting(mediaView -> mediaView.recordMedia().getSortOrder())
                 .containsExactly(0, 1);
         verify(recordMediaUrlService).createViewUrl("mapmory/travel-records/a.jpg");
         verify(recordMediaUrlService).createViewUrl("mapmory/travel-records/b.jpg");
     }
 
-    private TravelRecordRequest createRequest(LocalDate startDate, LocalDate endDate) {
-        return new TravelRecordRequest(
+    private TravelRecordCommand createCommand(LocalDate startDate, LocalDate endDate) {
+        return new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -276,12 +279,12 @@ class TravelRecordServiceTest {
         );
     }
 
-    private TravelRecordRequest createRequest(
+    private TravelRecordCommand createCommand(
             String countryCode,
             String provinceCode,
             String districtCode
     ) {
-        return new TravelRecordRequest(
+        return new TravelRecordCommand(
                 countryCode,
                 provinceCode,
                 districtCode,
@@ -294,16 +297,16 @@ class TravelRecordServiceTest {
         );
     }
 
-    private void assertInvalidTravelDates(TravelRecordRequest request) {
-        assertThatThrownBy(() -> travelRecordService.create(member, request))
+    private void assertInvalidTravelDates(TravelRecordCommand command) {
+        assertThatThrownBy(() -> travelRecordService.create(member, command))
                 .isInstanceOfSatisfying(BusinessException.class, exception ->
                         assertThat(exception.getErrorCode().code())
                                 .isEqualTo("INVALID_TRAVEL_DATE_RANGE"));
         verify(travelRecordRepository, never()).save(any(TravelRecord.class));
     }
 
-    private void assertInvalidRegion(TravelRecordRequest request, String errorCode) {
-        assertThatThrownBy(() -> travelRecordService.create(member, request))
+    private void assertInvalidRegion(TravelRecordCommand command, String errorCode) {
+        assertThatThrownBy(() -> travelRecordService.create(member, command))
                 .isInstanceOfSatisfying(BusinessException.class, exception ->
                         assertThat(exception.getErrorCode().code()).isEqualTo(errorCode));
         verify(travelRecordRepository, never()).save(any(TravelRecord.class));
@@ -324,13 +327,12 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByIdAndMemberId(102L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        TravelRecordDetailResponse result = travelRecordService.findById(member, 102L);
+        TravelRecordDetail result = travelRecordService.findById(member, 102L);
 
-        assertThat(result.region().country().code()).isEqualTo("JP");
-        assertThat(result.region().province()).isNull();
-        assertThat(result.region().district()).isNull();
-        assertThat(result.objectKeys()).isEmpty();
-        assertThat(result.media()).isEmpty();
+        assertThat(result.travelRecord().getRegion().getRegionCode()).isEqualTo("JP");
+        assertThat(result.travelRecord().getRegion().getParent()).isNull();
+        assertThat(result.recordMedia()).isEmpty();
+        assertThat(result.mediaViews()).isEmpty();
         verify(recordMediaUrlService, never()).createViewUrl(anyString());
     }
 
@@ -358,7 +360,7 @@ class TravelRecordServiceTest {
         ReflectionTestUtils.setField(travelRecord, "id", 101L);
         travelRecord.synchronizeMedia(List.of("travel-records/10/a.jpg", "travel-records/10/b.jpg"));
         RecordMedia mediaB = travelRecord.getMedia().getLast();
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "KR",
                 "49",
                 "50110",
@@ -366,23 +368,26 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 11),
                 LocalDate.of(2026, 8, 13),
-                List.of("travel-records/10/b.jpg", "travel-records/10/c.jpg")
-        );
+                List.of("travel-records/10/b.jpg", "travel-records/10/c.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("KR", "49", "50110")).thenReturn(district);
         when(travelRecordRepository.existsMediaByObjectKeyIn(List.of("travel-records/10/c.jpg")))
                 .thenReturn(false);
 
-        TravelRecordDetailResponse result = travelRecordService.update(member, 101L, request);
+        TravelRecordDetail result = travelRecordService.update(member, 101L, command);
 
-        assertThat(result.title()).isEqualTo("수정된 제목");
-        assertThat(result.content()).isEqualTo("수정된 본문");
-        assertThat(result.region().district().code()).isEqualTo("50110");
-        assertThat(result.objectKeys()).containsExactly(
-                "travel-records/10/b.jpg",
-                "travel-records/10/c.jpg"
-        );
+        assertThat(result.travelRecord().getTitle()).isEqualTo("수정된 제목");
+        assertThat(result.travelRecord().getContent()).isEqualTo("수정된 본문");
+        assertThat(result.travelRecord().getRegion().getRegionCode()).isEqualTo("50110");
+        assertThat(result.recordMedia())
+                .extracting(RecordMedia::getObjectKey)
+                .containsExactly(
+                        "travel-records/10/b.jpg",
+                        "travel-records/10/c.jpg"
+                );
         assertThat(mediaB.getSortOrder()).isZero();
         assertThat(travelRecord.getMedia())
                 .extracting(RecordMedia::getObjectKey)
@@ -401,7 +406,7 @@ class TravelRecordServiceTest {
                 LocalDate.of(2026, 8, 11),
                 null
         );
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -409,12 +414,13 @@ class TravelRecordServiceTest {
                 "본문",
                 LocalDate.of(2026, 8, 11),
                 null,
-                List.of("travel-records/10/a.jpg", "travel-records/10/a.jpg")
-        );
+                List.of("travel-records/10/a.jpg", "travel-records/10/a.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "INVALID_OBJECT_KEY");
+        assertError(() -> travelRecordService.update(member, 101L, command), "INVALID_OBJECT_KEY");
         verify(regionResolver, never()).resolve("JP", null, null);
     }
 
@@ -429,7 +435,7 @@ class TravelRecordServiceTest {
                 LocalDate.of(2026, 8, 11),
                 null
         );
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -437,15 +443,16 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 12),
                 null,
-                List.of("travel-records/20/used.jpg")
-        );
+                List.of("travel-records/20/used.jpg"),
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
         when(travelRecordRepository.existsMediaByObjectKeyIn(List.of("travel-records/20/used.jpg")))
                 .thenReturn(true);
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "INVALID_OBJECT_KEY");
+        assertError(() -> travelRecordService.update(member, 101L, command), "INVALID_OBJECT_KEY");
         assertThat(travelRecord.getTitle()).isEqualTo("일본 여행");
         assertThat(travelRecord.getMedia()).isEmpty();
     }
@@ -462,7 +469,7 @@ class TravelRecordServiceTest {
                 null
         );
         travelRecord.synchronizeMedia(List.of("travel-records/10/a.jpg"));
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -470,23 +477,24 @@ class TravelRecordServiceTest {
                 "수정된 본문",
                 LocalDate.of(2026, 8, 12),
                 null,
-                null
-        );
+                null,
+                List.of()
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.of(travelRecord));
         when(regionResolver.resolve("JP", null, null)).thenReturn(japan);
 
 
-        TravelRecordDetailResponse result = travelRecordService.update(member, 101L, request);
+        TravelRecordDetail result = travelRecordService.update(member, 101L, command);
 
-        assertThat(result.objectKeys()).isEmpty();
+        assertThat(result.recordMedia()).isEmpty();
         assertThat(travelRecord.getMedia()).isEmpty();
         verify(travelRecordRepository, never()).existsMediaByObjectKeyIn(anyList());
     }
 
     @Test
     void 없거나_다른_회원의_일지_수정을_거부한다() {
-        TravelRecordRequest request = new TravelRecordRequest(
+        TravelRecordCommand command = new TravelRecordCommand(
                 "JP",
                 null,
                 null,
@@ -494,21 +502,20 @@ class TravelRecordServiceTest {
                 "본문",
                 LocalDate.of(2026, 8, 11),
                 null,
+                List.of(),
                 List.of()
-        );
+            );
         when(travelRecordRepository.findByIdAndMemberId(101L, 10L))
                 .thenReturn(Optional.empty());
 
-        assertError(() -> travelRecordService.update(member, 101L, request), "TRAVEL_RECORD_NOT_FOUND");
+        assertError(() -> travelRecordService.update(member, 101L, command), "TRAVEL_RECORD_NOT_FOUND");
         verify(regionResolver, never()).resolve("JP", null, null);
     }
 
     @Test
     void 지역_필터_없이_일지_목록을_조회한다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
-        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
@@ -516,12 +523,12 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findMediaByTravelRecordIdIn(List.of(101L)))
                 .thenReturn(List.of(thumbnailMedia));
 
-        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+        TravelRecordSummaries result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result.totalElements()).isEqualTo(1);
-        assertThat(result.items().getFirst().thumbnailUrl())
+        assertThat(result.travelRecords().getTotalElements()).isEqualTo(1);
+        assertThat(result.thumbnailUrlOf(travelRecord).url())
                 .isEqualTo("https://download.example/mapmory/travel-records/a.jpg");
-        assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isEqualTo(300L);
+        assertThat(result.thumbnailUrlOf(travelRecord).expiresIn()).isEqualTo(300L);
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
         verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(null), captor.capture());
         assertThat(captor.getValue().getPageSize()).isEqualTo(20);
@@ -531,9 +538,7 @@ class TravelRecordServiceTest {
     @Test
     void 일지마다_정렬이_가장_앞선_미디어만_썸네일로_쓴다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
-        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
@@ -542,9 +547,9 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findMediaByTravelRecordIdIn(List.of(101L)))
                 .thenReturn(List.of(firstMedia, laterMedia));
 
-        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+        TravelRecordSummaries result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result.items().getFirst().thumbnailUrl())
+        assertThat(result.thumbnailUrlOf(travelRecord).url())
                 .isEqualTo("https://download.example/mapmory/first.jpg");
         verify(recordMediaUrlService).createViewUrl("mapmory/first.jpg");
         verify(recordMediaUrlService, never()).createViewUrl("mapmory/later.jpg");
@@ -553,18 +558,15 @@ class TravelRecordServiceTest {
     @Test
     void 미디어가_없는_일지_목록은_썸네일_정보가_null이다() {
         TravelRecord travelRecord = mock(TravelRecord.class);
-        Region region = mock(Region.class);
         when(travelRecord.getId()).thenReturn(101L);
-        when(travelRecord.getRegion()).thenReturn(region);
         Page<TravelRecord> expected = new PageImpl<>(List.of(travelRecord), PageRequest.of(0, 20), 1);
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
         when(travelRecordRepository.findMediaByTravelRecordIdIn(List.of(101L))).thenReturn(List.of());
 
-        TravelRecordListResponse result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
+        TravelRecordSummaries result = travelRecordService.findAll(member, null, null, null, null, 0, 20);
 
-        assertThat(result.items().getFirst().thumbnailUrl()).isNull();
-        assertThat(result.items().getFirst().thumbnailUrlExpiresIn()).isNull();
+        assertThat(result.thumbnailUrlOf(travelRecord)).isNull();
         verify(recordMediaUrlService, never()).createViewUrl(anyString());
     }
 
@@ -577,7 +579,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(1L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", null, null, null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", null, null, null, 0, 20).travelRecords()).isEmpty();
         verify(travelRecordRepository, never()).findMediaByTravelRecordIdIn(anyList());
     }
 
@@ -591,7 +593,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(2L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", "49", null, null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", "49", null, null, 0, 20).travelRecords()).isEmpty();
     }
 
     @Test
@@ -605,7 +607,7 @@ class TravelRecordServiceTest {
                 eq(10L), eq(3L), eq(null), any(Pageable.class)))
                 .thenReturn(expected);
 
-        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", null, 0, 20).items()).isEmpty();
+        assertThat(travelRecordService.findAll(member, "KR", "49", "50110", null, 0, 20).travelRecords()).isEmpty();
     }
 
     @Test
@@ -614,11 +616,11 @@ class TravelRecordServiceTest {
         when(travelRecordRepository.findByMemberIdAndOptionalTagId(eq(10L), eq(7L), any(Pageable.class)))
                 .thenReturn(expected);
 
-        TravelRecordListResponse result = travelRecordService.findAll(
+        TravelRecordSummaries result = travelRecordService.findAll(
                 member, null, null, null, 7L, 0, 20
         );
 
-        assertThat(result.items()).isEmpty();
+        assertThat(result.travelRecords()).isEmpty();
         verify(tagService).getOwnedTag(member, 7L);
         verify(travelRecordRepository).findByMemberIdAndOptionalTagId(eq(10L), eq(7L), any(Pageable.class));
     }

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/controller/RegionMapSummaryControllerTest.java
@@ -18,7 +18,7 @@ import com.mapmory.backend.member.Member;
 import com.mapmory.backend.member.MemberRepository;
 import com.mapmory.backend.region.RegionType;
 import com.mapmory.backend.region.exception.RegionErrorCode;
-import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
 import com.mapmory.backend.travelrecord.mapsummary.service.RegionMapSummaryService;
 import java.util.List;
@@ -74,7 +74,7 @@ class RegionMapSummaryControllerTest {
         @DisplayName("회원의 루트 지역별 지도 요약을 의미 기반 단계와 함께 반환한다")
         void returnsRootSummaries() throws Exception {
             when(regionMapSummaryService.getSummaries(any(Member.class), isNull(), isNull())).thenReturn(List.of(
-                    new RegionMapSummaryResponse(
+                    new RegionMapSummary(
                             1L,
                             "KR",
                             RegionType.COUNTRY,
@@ -145,7 +145,7 @@ class RegionMapSummaryControllerTest {
         @DisplayName("선택 지역의 직속 하위 지역별 지도 요약을 반환한다")
         void returnsChildSummaries() throws Exception {
             when(regionMapSummaryService.getSummaries(any(Member.class), eq(1L), isNull())).thenReturn(List.of(
-                    new RegionMapSummaryResponse(
+                    new RegionMapSummary(
                             15L,
                             "49",
                             RegionType.PROVINCE,

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/mapsummary/service/RegionMapSummaryServiceTest.java
@@ -14,7 +14,7 @@ import com.mapmory.backend.region.exception.RegionErrorCode;
 import com.mapmory.backend.region.RegionRepository;
 import com.mapmory.backend.tag.TagService;
 import com.mapmory.backend.tag.Tag;
-import com.mapmory.backend.travelrecord.mapsummary.dto.RegionMapSummaryResponse;
+import com.mapmory.backend.travelrecord.mapsummary.RegionMapSummary;
 import com.mapmory.backend.travelrecord.mapsummary.policy.LevelPolicy;
 import com.mapmory.backend.travelrecord.mapsummary.policy.MapColorLevel;
 import com.mapmory.backend.travelrecord.mapsummary.repository.RegionMapSummaryQueryResult;
@@ -61,9 +61,9 @@ class RegionMapSummaryServiceTest {
             when(regionMapSummaryRepository.findRegionMapSummaries(10L, null, null))
                     .thenReturn(List.of(result(1L, "KR", "대한민국", "COUNTRY", 3L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(member, null, null);
+            List<RegionMapSummary> responses = service.getSummaries(member, null, null);
 
-            assertThat(responses).containsExactly(new RegionMapSummaryResponse(
+            assertThat(responses).containsExactly(new RegionMapSummary(
                     1L,
                     "KR",
                     RegionType.COUNTRY,
@@ -93,9 +93,9 @@ class RegionMapSummaryServiceTest {
             when(regionMapSummaryRepository.findRegionMapSummaries(10L, parentRegionId, null))
                     .thenReturn(List.of(result(childRegionId, regionCode, name, regionType, 1L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(member, parentRegionId, null);
+            List<RegionMapSummary> responses = service.getSummaries(member, parentRegionId, null);
 
-            assertThat(responses).containsExactly(new RegionMapSummaryResponse(
+            assertThat(responses).containsExactly(new RegionMapSummary(
                     childRegionId,
                     regionCode,
                     RegionType.valueOf(regionType),
@@ -127,9 +127,9 @@ class RegionMapSummaryServiceTest {
             when(regionMapSummaryRepository.findRegionMapSummaries(10L, null, 7L))
                     .thenReturn(List.of(result(1L, "KR", "대한민국", "COUNTRY", 1L)));
 
-            List<RegionMapSummaryResponse> responses = service.getSummaries(member, null, 7L);
+            List<RegionMapSummary> responses = service.getSummaries(member, null, 7L);
 
-            assertThat(responses).singleElement().extracting(RegionMapSummaryResponse::count).isEqualTo(1L);
+            assertThat(responses).singleElement().extracting(RegionMapSummary::recordCount).isEqualTo(1L);
             verify(tagService).getOwnedTag(member, 7L);
         }
     }

--- a/backend/src/test/java/com/mapmory/backend/upload/service/UploadServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/upload/service/UploadServiceTest.java
@@ -3,9 +3,8 @@ package com.mapmory.backend.upload.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mapmory.backend.member.Member;
-import com.mapmory.backend.upload.dto.CreatePresignedUrlsRequest;
-import com.mapmory.backend.upload.dto.CreatePresignedUrlsResponse;
-import com.mapmory.backend.upload.dto.UploadFileRequest;
+import com.mapmory.backend.upload.PresignedUpload;
+import com.mapmory.backend.upload.UploadFileCommand;
 import com.mapmory.backend.upload.policy.ObjectKeyGenerator;
 import com.mapmory.backend.upload.storage.S3StorageProperties;
 import com.mapmory.backend.upload.policy.UploadPolicy;
@@ -32,30 +31,30 @@ class UploadServiceTest {
                 provider,
                 properties
         );
-        CreatePresignedUrlsRequest request = new CreatePresignedUrlsRequest(List.of(
-                new UploadFileRequest("jeju-trip", "IMAGE/JPEG", 3_145_728L),
-                new UploadFileRequest("map.webp", "image/webp", 1024L)
-        ));
+        List<UploadFileCommand> files = List.of(
+                new UploadFileCommand("jeju-trip", "IMAGE/JPEG", 3_145_728L),
+                new UploadFileCommand("map.webp", "image/webp", 1024L)
+        );
 
-        CreatePresignedUrlsResponse response = uploadService.createPresignedUrls(member(), request);
+        List<PresignedUpload> uploads = uploadService.createPresignedUrls(member(), files);
 
-        assertThat(response.uploads()).hasSize(2);
-        assertThat(response.uploads().getFirst().objectKey()).startsWith("travel-records/10/")
+        assertThat(uploads).hasSize(2);
+        assertThat(uploads.getFirst().objectKey()).startsWith("travel-records/10/")
                 .endsWith(".jpg");
-        assertThat(response.uploads().getFirst().presignedUrl())
+        assertThat(uploads.getFirst().presignedUrl().toString())
                 .startsWith("https://upload.example/travel-records/10/");
-        assertThat(response.uploads().getFirst().method()).isEqualTo("PUT");
-        assertThat(response.uploads().getFirst().contentType()).isEqualTo("image/jpeg");
-        assertThat(response.uploads().getFirst().expiresIn()).isEqualTo(300L);
+        assertThat(uploads.getFirst().method()).isEqualTo("PUT");
+        assertThat(uploads.getFirst().contentType()).isEqualTo("image/jpeg");
+        assertThat(uploads.getFirst().expiration()).isEqualTo(java.time.Duration.ofSeconds(300L));
         assertThat(provider.requests).containsExactly(
                 new PresignRequest(
-                        response.uploads().getFirst().objectKey(),
+                        uploads.getFirst().objectKey(),
                         "image/jpeg",
                         3_145_728L,
                         Duration.ofMinutes(5)
                 ),
                 new PresignRequest(
-                        response.uploads().get(1).objectKey(),
+                        uploads.get(1).objectKey(),
                         "image/webp",
                         1024L,
                         Duration.ofMinutes(5)

--- a/backend/src/test/java/com/mapmory/backend/waitlist/EmailTest.java
+++ b/backend/src/test/java/com/mapmory/backend/waitlist/EmailTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.mapmory.backend.common.exception.BusinessException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -34,8 +35,7 @@ class EmailTest {
     @NullAndEmptySource
     @ValueSource(strings = {" ", "\t"})
     void 비어_있는_주소를_거부한다(String rawEmail) {
-        assertThatThrownBy(() -> Email.from(rawEmail))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertInvalidEmail(() -> Email.from(rawEmail));
     }
 
     @Test
@@ -49,13 +49,18 @@ class EmailTest {
     void 저장_한계를_넘는_주소를_거부한다() {
         String localPart = "a".repeat(MAX_LENGTH - "@example.com".length() + 1);
 
-        assertThatThrownBy(() -> Email.from(localPart + "@example.com"))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertInvalidEmail(() -> Email.from(localPart + "@example.com"));
     }
 
     @Test
     void 정규화되지_않은_값으로는_만들_수_없다() {
-        assertThatThrownBy(() -> new Email("USER@example.com"))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertInvalidEmail(() -> new Email("USER@example.com"));
+    }
+
+    private void assertInvalidEmail(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOf(BusinessException.class)
+                .extracting(exception -> ((BusinessException) exception).getErrorCode().code())
+                .isEqualTo("VALIDATION_ERROR");
     }
 }

--- a/backend/src/test/java/com/mapmory/backend/waitlist/EmailTest.java
+++ b/backend/src/test/java/com/mapmory/backend/waitlist/EmailTest.java
@@ -1,0 +1,61 @@
+package com.mapmory.backend.waitlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EmailTest {
+
+    private static final int MAX_LENGTH = 254;
+
+    @Test
+    void 앞뒤_공백과_대문자를_정규화한다() {
+        assertThat(Email.from("  MapMory.User@Example.COM  ").value())
+                .isEqualTo("mapmory.user@example.com");
+    }
+
+    @Test
+    void 호환_문자를_NFKC로_정규화한다() {
+        assertThat(Email.from("ＵＳＥＲ@example.com").value())
+                .isEqualTo("user@example.com");
+    }
+
+    @Test
+    void 대소문자만_다른_주소는_같은_값이_된다() {
+        assertThat(Email.from("USER@example.com")).isEqualTo(Email.from("user@EXAMPLE.com"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t"})
+    void 비어_있는_주소를_거부한다(String rawEmail) {
+        assertThatThrownBy(() -> Email.from(rawEmail))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 저장_한계_길이는_허용한다() {
+        String localPart = "a".repeat(MAX_LENGTH - "@example.com".length());
+
+        assertThatCode(() -> Email.from(localPart + "@example.com")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 저장_한계를_넘는_주소를_거부한다() {
+        String localPart = "a".repeat(MAX_LENGTH - "@example.com".length() + 1);
+
+        assertThatThrownBy(() -> Email.from(localPart + "@example.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 정규화되지_않은_값으로는_만들_수_없다() {
+        assertThatThrownBy(() -> new Email("USER@example.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/src/test/java/com/mapmory/backend/waitlist/LaunchWaitlistControllerTest.java
+++ b/backend/src/test/java/com/mapmory/backend/waitlist/LaunchWaitlistControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +34,7 @@ class LaunchWaitlistControllerTest {
 
     @Test
     void 출시_알림을_신청하면_201로_응답한다() throws Exception {
-        when(service.subscribe(any())).thenReturn(LaunchWaitlistResponse.subscribed());
+        when(service.subscribe(any())).thenReturn(LaunchWaitlistStatus.SUBSCRIBED);
 
         mockMvc.perform(post("/api/v1/waitlist")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -46,7 +45,7 @@ class LaunchWaitlistControllerTest {
 
     @Test
     void 이미_등록된_이메일은_200으로_응답한다() throws Exception {
-        when(service.subscribe(any())).thenReturn(LaunchWaitlistResponse.alreadySubscribed());
+        when(service.subscribe(any())).thenReturn(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
 
         mockMvc.perform(post("/api/v1/waitlist")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/mapmory/backend/waitlist/LaunchWaitlistServiceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/waitlist/LaunchWaitlistServiceTest.java
@@ -6,9 +6,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistRequest;
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistResponse;
-import com.mapmory.backend.waitlist.dto.LaunchWaitlistStatus;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -40,11 +37,9 @@ class LaunchWaitlistServiceTest {
 
     @Test
     void 이메일을_정규화해_출시_알림을_신청한다() {
-        LaunchWaitlistRequest request = request("  MapMory.User@Example.COM  ");
+        LaunchWaitlistStatus status = service.subscribe("  MapMory.User@Example.COM  ");
 
-        LaunchWaitlistResponse response = service.subscribe(request);
-
-        assertThat(response.status()).isEqualTo(LaunchWaitlistStatus.SUBSCRIBED);
+        assertThat(status).isEqualTo(LaunchWaitlistStatus.SUBSCRIBED);
         ArgumentCaptor<LaunchWaitlistEntry> captor = ArgumentCaptor.forClass(LaunchWaitlistEntry.class);
         verify(repository).saveAndFlush(captor.capture());
         assertThat(captor.getValue().getEmail()).isEqualTo("mapmory.user@example.com");
@@ -55,9 +50,9 @@ class LaunchWaitlistServiceTest {
     void 이미_등록된_이메일은_다시_저장하지_않는다() {
         when(repository.existsByEmail("user@example.com")).thenReturn(true);
 
-        LaunchWaitlistResponse response = service.subscribe(request("USER@example.com"));
+        LaunchWaitlistStatus status = service.subscribe("USER@example.com");
 
-        assertThat(response.status()).isEqualTo(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
+        assertThat(status).isEqualTo(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
         verify(repository, never()).saveAndFlush(any());
     }
 
@@ -65,12 +60,8 @@ class LaunchWaitlistServiceTest {
     void 동시에_같은_이메일이_저장되어도_중복_신청으로_응답한다() {
         when(repository.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("duplicate"));
 
-        LaunchWaitlistResponse response = service.subscribe(request("user@example.com"));
+        LaunchWaitlistStatus status = service.subscribe("user@example.com");
 
-        assertThat(response.status()).isEqualTo(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
-    }
-
-    private LaunchWaitlistRequest request(String email) {
-        return new LaunchWaitlistRequest(email, true, true);
+        assertThat(status).isEqualTo(LaunchWaitlistStatus.ALREADY_SUBSCRIBED);
     }
 }


### PR DESCRIPTION
## 요약

백엔드 작업을 `backend-develop`에서 `develop`으로 올립니다. **`backend/` 45개 파일만 바뀝니다.**

`#199`(Service 계층의 DTO 반환을 도메인 객체 반환으로 변경)를 닫은 작업들입니다.

## 충돌 없음

지난번 #219는 같은 백엔드 작업이 두 브랜치에 서로 다른 SHA로 중복 병합돼 있어 충돌 6건이 났습니다.
그 PR로 계보가 합쳐진 덕분에 **이번에는 충돌이 없습니다.**

`client/`·`landing/` 변경은 0개입니다.

## 들어가는 작업 (PR 3건)

### #222 — 출시 알림 이메일을 값 객체로

이메일 정규화(`trim` + NFKC + 소문자)가 `LaunchWaitlistService`의 `static` 메서드에 있었습니다.

`launch_waitlist.email`은 `utf8mb4_0900_bin` **대소문자 구분** 콜레이션이라 UNIQUE 제약이
`A@x.com`과 `a@x.com`을 다른 값으로 봅니다. 중복 차단이 애플리케이션 책임인데 서비스를 우회하면
정규화가 생략되는 구조였습니다. `Email` 값 객체가 그 경로를 닫습니다.

검증 실패는 `LaunchWaitlistErrorCode.INVALID_EMAIL` + `BusinessException`으로 프로젝트 표준을 따릅니다.
코드 문자열은 `VALIDATION_ERROR`를 재사용해 오류 계약이 늘지 않습니다.

### #223 — TravelRecordService의 DTO 의존 제거

`TravelRecordCommand`(속성 9개) 입력, `TravelRecordDetail`·`TravelRecordSummaries` 출력.
조립은 ADR 0017 결정 4대로 애그리거트당 하나인 `TravelRecordAssembler`가 맡습니다.

서비스가 329줄 → 274줄이 되고 `RecordMediaUrlService` 의존이 사라집니다.

### #224 — 남은 세 서비스

`RegionMapSummaryService`, `AuthService`, `UploadService`.
읽기 모델이 단순해 **어셈블러는 만들지 않았습니다**(ADR 0017 결정 4의 단서).

`UploadService`는 결과가 `URI`·`Duration`을 그대로 담게 되어, 문자열·초 단위 변환이 응답 DTO로 갔습니다.

## API 영향 — 없음

세 PR 모두 요청·응답 레코드의 **필드 선언이 변경 전과 동일**함을 대조해 확인했습니다.
엔드포인트·상태 코드·JSON이 그대로라 `api.md`를 고치지 않았습니다.

동작 변경도 없습니다. (#222의 빈 이메일 거부는 요청 DTO의 `@Email`·`@NotBlank`가 먼저 걸러내므로
HTTP 경로로는 도달하지 않습니다.)

## 확인

- [x] 로컬에서 실행 확인 — 병합 대상 커밋에서 `./gradlew cleanTest test` 63개 클래스 / 286개 통과
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [ ] 새 환경변수를 추가했다면 `.env.example` 갱신 — 해당 없음
- [x] DB 스키마 변경 없음
- [ ] 실행 방법이나 환경 설정이 바뀌었다면 README 갱신 — 해당 없음