### PR TITLE
fix: 기록 편집 오류 처리와 사진 UX 개선

### DIFF
--- a/client/androidApp/src/androidTest/java/com/mapmory/android/MapmoryAppNavigationTest.kt
+++ b/client/androidApp/src/androidTest/java/com/mapmory/android/MapmoryAppNavigationTest.kt
@@ -73,6 +73,11 @@ class MapmoryAppNavigationTest {
 
         composeRule.onNodeWithText("아직 작성한 여행 기록이 없어요.").assertIsDisplayed()
 
+        composeRule.onNodeWithContentDescription("새 기록 작성").assertIsDisplayed().performClick()
+        composeRule.onNodeWithText("기록 남기기").assertIsDisplayed()
+        composeRule.onNodeWithText("←").performClick()
+        composeRule.onNodeWithText("아직 작성한 여행 기록이 없어요.").assertIsDisplayed()
+
         composeRule.onNodeWithText("지도").performClick()
         composeRule.onNodeWithContentDescription("새 기록 작성").performClick()
         composeRule.onNodeWithText("기록 남기기").assertIsDisplayed()

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/auth/AuthSession.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/auth/AuthSession.kt
@@ -9,10 +9,10 @@ data class AuthTokens(
     val refreshToken: String,
 ) {
     init {
-        require(accessToken.isNotBlank()) { "액세스 토큰은 비어 있을 수 없습니다." }
-        require(refreshToken.isNotBlank()) { "리프레시 토큰은 비어 있을 수 없습니다." }
+        require(accessToken.isNotBlank()) { "로그인 정보를 확인하지 못했습니다. 다시 로그인해 주세요." }
+        require(refreshToken.isNotBlank()) { "로그인 정보를 확인하지 못했습니다. 다시 로그인해 주세요." }
         require('\n' !in accessToken && '\n' !in refreshToken) {
-            "토큰에는 줄바꿈을 포함할 수 없습니다."
+            "로그인 정보를 확인하지 못했습니다. 다시 로그인해 주세요."
         }
     }
 }
@@ -83,7 +83,7 @@ internal class GuestSessionManager(
         authenticationMutex.withLock {
             val currentTokens = tokens
                 ?: return@withLock Result.failure(
-                    IllegalStateException("갱신할 인증 토큰이 없습니다."),
+                    IllegalStateException("로그인 정보가 만료되었습니다. 다시 로그인해 주세요."),
                 )
 
             if (currentTokens.accessToken != failedAccessToken) {

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/media/PhotoPreviewCache.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/media/PhotoPreviewCache.kt
@@ -44,7 +44,7 @@ class MemoryPhotoPreviewCache(
 }
 
 internal fun objectKeyCacheFileName(objectKey: String): String {
-    require(objectKey.isNotBlank()) { "사진 Object Key는 비어 있을 수 없습니다." }
+    require(objectKey.isNotBlank()) { "사진 정보를 확인하지 못했습니다." }
     // v1에는 Android 원격 사진의 EXIF 방향이 적용되지 않았으므로 기존 파일을 재사용하지 않는다.
     val bytes = "$PreviewCacheSchemaVersion:$objectKey".encodeToByteArray()
     val forward = bytes.fold(FnvOffsetBasis) { hash, byte ->

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/ApiCall.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/ApiCall.kt
@@ -17,6 +17,10 @@ internal class MapmoryConnectionException(
     cause: Throwable,
 ) : IllegalStateException(message, cause)
 
+internal class MapmoryRemoteRequestException(
+    cause: Throwable,
+) : IllegalStateException(RemoteRequestFailureMessage, cause)
+
 internal fun Throwable.toUserFriendlyRemoteFailure(): Throwable {
     if (this is MapmoryApiException || this is MapmoryConnectionException) return this
 
@@ -41,10 +45,18 @@ internal fun Throwable.toUserFriendlyRemoteFailure(): Throwable {
         error::class.simpleName in ConnectionExceptionNames ||
             error.message.containsAny(ConnectionMessageFragments)
     }
+    val isResponseParsingFailure = generateSequence(this) { error -> error.cause }.any { error ->
+        val name = error::class.simpleName.orEmpty()
+        name in ResponseParsingExceptionNames || name.endsWith("SerializationException")
+    }
     return if (isConnectionFailure) {
         MapmoryConnectionException(ServerConnectionFailureMessage, this)
-    } else {
+    } else if (isResponseParsingFailure) {
+        MapmoryRemoteRequestException(this)
+    } else if (this is IllegalArgumentException || this is MissingAccessTokenException) {
         this
+    } else {
+        MapmoryRemoteRequestException(this)
     }
 }
 
@@ -60,6 +72,11 @@ private val TimeoutExceptionNames = setOf(
     "SocketTimeoutException",
 )
 private val ConnectionExceptionNames = setOf("ConnectException", "ConnectionRefusedException")
+private val ResponseParsingExceptionNames = setOf(
+    "JsonConvertException",
+    "JsonDecodingException",
+    "NoTransformationFoundException",
+)
 private val NameResolutionMessageFragments = setOf(
     "unable to resolve host",
     "no address associated with hostname",
@@ -77,3 +94,5 @@ private const val ServerConnectionFailureMessage =
     "서버에 연결할 수 없습니다. 인터넷 연결을 확인한 뒤 잠시 후 다시 시도해 주세요."
 private const val ServerTimeoutMessage =
     "서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해 주세요."
+private const val RemoteRequestFailureMessage =
+    "요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요."

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/ApiCall.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/ApiCall.kt
@@ -9,5 +9,71 @@ internal suspend inline fun <T> apiCall(
 } catch (error: CancellationException) {
     throw error
 } catch (error: Exception) {
-    Result.failure(error)
+    Result.failure(error.toUserFriendlyRemoteFailure())
 }
+
+internal class MapmoryConnectionException(
+    message: String,
+    cause: Throwable,
+) : IllegalStateException(message, cause)
+
+internal fun Throwable.toUserFriendlyRemoteFailure(): Throwable {
+    if (this is MapmoryApiException || this is MapmoryConnectionException) return this
+
+    val causes = generateSequence(this) { error -> error.cause }
+    val isNameResolutionFailure = causes.any { error ->
+        error::class.simpleName in NameResolutionExceptionNames ||
+            error.message.containsAny(NameResolutionMessageFragments)
+    }
+    if (isNameResolutionFailure) {
+        return MapmoryConnectionException(ServerConnectionFailureMessage, this)
+    }
+
+    val isTimeout = generateSequence(this) { error -> error.cause }.any { error ->
+        error::class.simpleName in TimeoutExceptionNames ||
+            error.message.containsAny(TimeoutMessageFragments)
+    }
+    if (isTimeout) {
+        return MapmoryConnectionException(ServerTimeoutMessage, this)
+    }
+
+    val isConnectionFailure = generateSequence(this) { error -> error.cause }.any { error ->
+        error::class.simpleName in ConnectionExceptionNames ||
+            error.message.containsAny(ConnectionMessageFragments)
+    }
+    return if (isConnectionFailure) {
+        MapmoryConnectionException(ServerConnectionFailureMessage, this)
+    } else {
+        this
+    }
+}
+
+private fun String?.containsAny(fragments: Set<String>): Boolean {
+    val normalized = this?.lowercase() ?: return false
+    return fragments.any(normalized::contains)
+}
+
+private val NameResolutionExceptionNames = setOf("UnknownHostException", "UnresolvedAddressException")
+private val TimeoutExceptionNames = setOf(
+    "HttpRequestTimeoutException",
+    "ConnectTimeoutException",
+    "SocketTimeoutException",
+)
+private val ConnectionExceptionNames = setOf("ConnectException", "ConnectionRefusedException")
+private val NameResolutionMessageFragments = setOf(
+    "unable to resolve host",
+    "no address associated with hostname",
+    "could not resolve host",
+    "nodename nor servname provided",
+)
+private val TimeoutMessageFragments = setOf("timed out", "timeout")
+private val ConnectionMessageFragments = setOf(
+    "failed to connect",
+    "connection refused",
+    "network is unreachable",
+)
+
+private const val ServerConnectionFailureMessage =
+    "서버에 연결할 수 없습니다. 인터넷 연결을 확인한 뒤 잠시 후 다시 시도해 주세요."
+private const val ServerTimeoutMessage =
+    "서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해 주세요."

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/ApiResponseHandling.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/ApiResponseHandling.kt
@@ -26,4 +26,21 @@ class MapmoryApiException(
     val detail: String?,
     val instance: String?,
     val errors: List<ProblemFieldErrorDto>,
-) : IllegalStateException(detail ?: title ?: "API 요청에 실패했습니다.")
+) : IllegalStateException(userFacingApiMessage(code, title, detail))
+
+private fun userFacingApiMessage(
+    code: String,
+    title: String?,
+    detail: String?,
+): String = when (code) {
+    "INVALID_OBJECT_KEY" ->
+        "사진을 저장하지 못했습니다. 문제가 있는 사진을 삭제한 뒤 다시 추가해 주세요."
+
+    "INVALID_ACCESS_TOKEN",
+    "EXPIRED_ACCESS_TOKEN",
+    "INVALID_REFRESH_TOKEN",
+    "EXPIRED_REFRESH_TOKEN" -> "로그인 정보가 만료되었습니다. 다시 로그인해 주세요."
+
+    "INVALID_KAKAO_TOKEN" -> "카카오 로그인 정보를 확인하지 못했습니다. 다시 로그인해 주세요."
+    else -> detail ?: title ?: "요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요."
+}

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/ApiResponseHandling.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/ApiResponseHandling.kt
@@ -34,7 +34,7 @@ private fun userFacingApiMessage(
     detail: String?,
 ): String = when (code) {
     "INVALID_OBJECT_KEY" ->
-        "사진을 저장하지 못했습니다. 문제가 있는 사진을 삭제한 뒤 다시 추가해 주세요."
+        "사진을 저장하지 못했습니다. 잠시 후 다시 저장해 주세요."
 
     "INVALID_ACCESS_TOKEN",
     "EXPIRED_ACCESS_TOKEN",

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/MapSummaryRemoteRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/MapSummaryRemoteRepository.kt
@@ -18,7 +18,7 @@ class MapSummaryRemoteRepository(
     private val summaryUrl = "${apiBaseUrl.trimEnd('/')}/travel-records/map-summary/regions"
 
     override suspend fun getRootRegions(tagId: Long?): Result<List<MapRegionSummary>> = apiCall {
-        require(tagId == null || tagId > 0) { "태그 ID는 양수여야 합니다." }
+        require(tagId == null || tagId > 0) { "선택한 태그 정보를 확인하지 못했습니다." }
         client.get("$summaryUrl/roots") {
             authorizeWith(accessTokenProvider)
             tagId?.let { parameter("tagId", it) }
@@ -29,8 +29,8 @@ class MapSummaryRemoteRepository(
     }
 
     override suspend fun getChildRegions(regionId: Long, tagId: Long?): Result<List<MapRegionSummary>> = apiCall {
-        require(regionId > 0) { "지역 ID는 양수여야 합니다." }
-        require(tagId == null || tagId > 0) { "태그 ID는 양수여야 합니다." }
+        require(regionId > 0) { "선택한 지역 정보를 확인하지 못했습니다." }
+        require(tagId == null || tagId > 0) { "선택한 태그 정보를 확인하지 못했습니다." }
         client.get("$summaryUrl/$regionId/children") {
             authorizeWith(accessTokenProvider)
             tagId?.let { parameter("tagId", it) }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/PhotoRemoteSource.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/PhotoRemoteSource.kt
@@ -10,7 +10,9 @@ internal class PresignedPhotoRemoteSource(
     private val client: HttpClient,
 ) : PhotoRemoteSource {
     override suspend fun download(url: String): Result<ByteArray> = apiCall {
-        require(url.startsWith(HttpsPrefix)) { "사진 조회 URL은 HTTPS여야 합니다." }
+        require(url.startsWith(HttpsPrefix)) {
+            "사진을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요."
+        }
         client.get(url).requireSuccess().body()
     }
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/PhotoUploadRemoteRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/PhotoUploadRemoteRepository.kt
@@ -48,7 +48,7 @@ internal class PhotoUploadRemoteRepository(
             sources.forEach { source ->
                 require(source.fileName.isNotBlank()) { "사진 파일 이름은 비어 있을 수 없습니다." }
                 require(source.contentType in SupportedImageContentTypes) {
-                    "JPEG, PNG, WEBP, HEIC 사진만 업로드할 수 있습니다: ${source.contentType}"
+                    "지원하지 않는 사진 형식입니다. JPEG, PNG, WEBP 또는 HEIC 사진을 선택해 주세요."
                 }
                 require(source.bytes.isNotEmpty()) { "빈 사진은 업로드할 수 없습니다." }
             }
@@ -73,18 +73,19 @@ internal class PhotoUploadRemoteRepository(
                 .uploads
 
             require(uploads.size == sources.size) {
-                "발급된 업로드 URL 개수가 요청한 사진 개수와 다릅니다."
+                PhotoUploadPreparationFailureMessage
             }
 
             coroutineScope {
                 sources.zip(uploads).map { (source, upload) ->
                     async {
                         require(upload.method.equals(ExpectedUploadMethod, ignoreCase = true)) {
-                            "지원하지 않는 업로드 방식입니다: ${upload.method}"
+                            PhotoUploadPreparationFailureMessage
                         }
-                        val contentType = ContentType.parse(upload.contentType)
+                        val contentType = runCatching { ContentType.parse(upload.contentType) }
+                            .getOrElse { throw IllegalArgumentException(PhotoUploadPreparationFailureMessage) }
                         require(contentType.contentType == "image") {
-                            "서버가 이미지가 아닌 MIME 타입을 반환했습니다: ${upload.contentType}"
+                            PhotoUploadPreparationFailureMessage
                         }
                         client.put(upload.presignedUrl) {
                             setBody(ByteArrayContent(source.bytes, contentType))
@@ -97,6 +98,8 @@ internal class PhotoUploadRemoteRepository(
 }
 
 private const val ExpectedUploadMethod = "PUT"
+private const val PhotoUploadPreparationFailureMessage =
+    "사진 업로드를 준비하지 못했습니다. 잠시 후 다시 시도해 주세요."
 private val SupportedImageContentTypes = setOf(
     "image/jpeg",
     "image/png",

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/TripRecordRemoteRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/TripRecordRemoteRepository.kt
@@ -35,9 +35,11 @@ class TripRecordRemoteRepository(
 
     override suspend fun getTripRecords(query: TripRecordQuery): Result<TripRecordPage> =
         apiCall {
-            require(query.page >= 0) { "페이지 번호는 0 이상이어야 합니다." }
-            require(query.size in 1..MaxPageSize) { "페이지 크기는 1 이상 100 이하여야 합니다." }
-            require(query.tagId == null || query.tagId > 0) { "태그 ID는 양수여야 합니다." }
+            require(query.page >= 0) { "여행 기록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요." }
+            require(query.size in 1..MaxPageSize) {
+                "여행 기록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요."
+            }
+            require(query.tagId == null || query.tagId > 0) { "선택한 태그 정보를 확인하지 못했습니다." }
             val region = query.toRegionQuery(regionCatalog)
             val response = client.get(recordsUrl) {
                 authorizeWith(accessTokenProvider)
@@ -99,7 +101,7 @@ class TripRecordRemoteRepository(
         }
 
     private fun requireValidRecordId(id: Long) {
-        require(id > 0) { "여행 기록 ID는 양수여야 합니다." }
+        require(id > 0) { "여행 기록을 찾을 수 없습니다." }
     }
 }
 

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/model/ApiDtoMappers.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/remote/model/ApiDtoMappers.kt
@@ -40,8 +40,7 @@ fun TripRecordDetailDto.toDomain(regionCatalog: RegionCatalog): TripRecordData {
         else -> regionCatalog.findByCode(region.country.code)
     }
     requireNotNull(location) {
-        "서버 지역 코드를 로컬 지역 데이터에서 찾을 수 없습니다: ${region.country.code}/" +
-            "${region.province?.code.orEmpty()}/${region.district?.code.orEmpty()}"
+        "여행 장소 정보를 확인하지 못했습니다. 잠시 후 다시 시도해 주세요."
     }
 
     return TripRecordData(
@@ -85,7 +84,7 @@ internal data class RegionQuery(
 internal fun TripRecordQuery.toRegionQuery(regionCatalog: RegionCatalog): RegionQuery? =
     locationId?.let { id ->
         val location = requireNotNull(regionCatalog.findById(id)) {
-            "선택한 지역을 찾을 수 없습니다: $id"
+            "선택한 지역 정보를 확인하지 못했습니다. 여행 장소를 다시 선택해 주세요."
         }
         location.toRegionQuery(regionCatalog, allowKoreanProvince = true)
     }
@@ -94,11 +93,11 @@ internal fun TripRecordDraft.toRequestDto(regionCatalog: RegionCatalog): TripRec
     require(title.length <= MaxTitleLength) { "제목은 200자 이하여야 합니다." }
     dateValidationError()?.let { error -> throw IllegalArgumentException(error) }
     require(mediaObjectKeys.distinct().size == mediaObjectKeys.size) {
-        "사진 Object Key는 중복될 수 없습니다."
+        "같은 사진을 중복해서 추가할 수 없습니다."
     }
     TagRules.validateRecordTagIds(tagIds)
     val location = requireNotNull(regionCatalog.findById(locationId)) {
-        "선택한 지역을 찾을 수 없습니다: $locationId"
+        "선택한 지역 정보를 확인하지 못했습니다. 여행 장소를 다시 선택해 주세요."
     }
     val region = location.toRegionQuery(regionCatalog, allowKoreanProvince = false)
     return TripRecordRequestDto(
@@ -120,10 +119,10 @@ private fun Location.toRegionQuery(
 ): RegionQuery = when {
     type == LocationType.DISTRICT -> {
         val province = requireNotNull(parentId?.let(regionCatalog::findById)) {
-            "시·군·구의 상위 시·도를 찾을 수 없습니다: $regionCode"
+            "선택한 지역 정보를 확인하지 못했습니다. 여행 장소를 다시 선택해 주세요."
         }
         require(province.regionCode.startsWith(KoreanProvincePrefix)) {
-            "대한민국 시·군·구만 기록할 수 있습니다: $regionCode"
+            "국내 여행은 시·군·구 단위로 선택해 주세요."
         }
         RegionQuery(
             countryCode = KoreaCountryCode,
@@ -141,7 +140,7 @@ private fun Location.toRegionQuery(
     }
 
     regionCode.length == CountryCodeLength -> RegionQuery(countryCode = regionCode)
-    else -> error("지원하지 않는 지역 단계입니다: $regionCode")
+    else -> error("선택한 지역 정보를 확인하지 못했습니다. 여행 장소를 다시 선택해 주세요.")
 }
 
 fun PageDto<TripRecordListItemDto>.toDomain(): TripRecordPage = TripRecordPage(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/FakeTripRecordRepository.kt
@@ -33,7 +33,9 @@ class FakeTripRecordRepository(
 
     override suspend fun getTripRecords(query: TripRecordQuery): Result<TripRecordPage> {
         if (query.page < 0 || query.size !in 1..MaxPageSize) {
-            return Result.failure(IllegalArgumentException("페이지 번호와 크기를 확인해 주세요."))
+            return Result.failure(
+                IllegalArgumentException("여행 기록을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요."),
+            )
         }
 
         val filteredRecords = records.filter { record ->

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepository.kt
@@ -73,7 +73,7 @@ internal class UploadingTripRecordRepository(
         val pendingSources = mutableListOf<PhotoUploadSource>()
 
         draft.mediaObjectKeys.forEachIndexed { index, key ->
-            if (key.isServerObjectKey()) return@forEachIndexed
+            if (key in draft.uploadedMediaObjectKeys) return@forEachIndexed
             val media = mediaByLocalId[key]
                 ?: return Result.failure(
                     IllegalStateException("업로드할 사진 데이터를 찾을 수 없습니다: $key"),
@@ -110,6 +110,9 @@ internal class UploadingTripRecordRepository(
                 mediaObjectKeys = draft.mediaObjectKeys.map { key ->
                     objectKeyByLocalId[key] ?: key
                 },
+                uploadedMediaObjectKeys = draft.mediaObjectKeys
+                    .map { key -> objectKeyByLocalId[key] ?: key }
+                    .toSet(),
                 localMedia = draft.localMedia.map { media ->
                     objectKeyByLocalId[media.objectKey]
                         ?.let { objectKey -> media.copy(objectKey = objectKey) }
@@ -177,8 +180,6 @@ private fun List<TripRecordMedia>.toListMedia(): List<TripRecordMedia> =
         )
     }
 
-private fun String.isServerObjectKey(): Boolean = startsWith(ServerObjectKeyPrefix)
-
 private fun normalizedFileName(
     fileName: String?,
     contentType: String,
@@ -240,5 +241,4 @@ private fun ByteArray.hasAsciiAt(offset: Int, expected: String): Boolean =
 private fun ByteArray.hasAnyAsciiAt(offset: Int, vararg expected: String): Boolean =
     expected.any { value -> hasAsciiAt(offset, value) }
 
-private const val ServerObjectKeyPrefix = "travel-records/"
 private const val DefaultMaxCachedPreviewBytes = 32L * 1024L * 1024L

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepository.kt
@@ -1,5 +1,6 @@
 package com.mapmory.shared.data.repository
 
+import com.mapmory.shared.data.remote.MapmoryApiException
 import com.mapmory.shared.data.remote.PhotoUploadSource
 import com.mapmory.shared.data.remote.PhotoUploader
 import com.mapmory.shared.domain.model.TripRecordData
@@ -65,7 +66,13 @@ internal class UploadingTripRecordRepository(
         save: suspend (TripRecordDraft) -> Result<TripRecordData>,
     ): Result<TripRecordData> {
         val prepared = prepareDraft(draft).getOrElse { error -> return Result.failure(error) }
-        return save(prepared).withCachedMedia(prepared.localMedia)
+        val firstResult = save(prepared)
+        if (firstResult.isSuccess || !draft.canRetryWithFreshObjectKeys(firstResult.exceptionOrNull())) {
+            return firstResult.withCachedMedia(prepared.localMedia)
+        }
+
+        val retried = prepareDraft(draft).getOrElse { error -> return Result.failure(error) }
+        return save(retried).withCachedMedia(retried.localMedia)
     }
 
     private suspend fun prepareDraft(draft: TripRecordDraft): Result<TripRecordDraft> {
@@ -77,19 +84,19 @@ internal class UploadingTripRecordRepository(
             val media = mediaByLocalId[key]
                 ?: return Result.failure(
                     IllegalStateException(
-                        "사진 정보를 확인하지 못했습니다. 사진을 삭제한 뒤 다시 추가해 주세요.",
+                        "사진 정보를 확인하지 못했습니다. 잠시 후 다시 저장해 주세요.",
                     ),
                 )
             val bytes = media.originalBytes
                 ?: return Result.failure(
                     IllegalStateException(
-                        "사진 원본을 불러오지 못했습니다. 사진을 삭제한 뒤 다시 추가해 주세요.",
+                        "사진 원본을 불러오지 못했습니다. 잠시 후 다시 저장해 주세요.",
                     ),
                 )
             val contentType = detectImageContentType(media.fileName, bytes)
                 ?: return Result.failure(
                     IllegalArgumentException(
-                        "JPEG, PNG, WEBP, HEIC 사진만 업로드할 수 있습니다: ${media.fileName ?: key}",
+                        "지원하지 않는 사진 형식입니다. JPEG, PNG, WEBP 또는 HEIC 사진을 선택해 주세요.",
                     ),
                 )
             pendingSources += PhotoUploadSource(
@@ -176,6 +183,11 @@ internal class UploadingTripRecordRepository(
     }
 }
 
+private fun TripRecordDraft.canRetryWithFreshObjectKeys(error: Throwable?): Boolean =
+    mediaObjectKeys.any { key -> key !in uploadedMediaObjectKeys } &&
+        error is MapmoryApiException &&
+        error.code == InvalidObjectKeyCode
+
 private fun List<TripRecordMedia>.toListMedia(): List<TripRecordMedia> =
     sortedBy(TripRecordMedia::sortOrder).mapIndexed { index, media ->
         media.copy(
@@ -246,3 +258,4 @@ private fun ByteArray.hasAnyAsciiAt(offset: Int, vararg expected: String): Boole
     expected.any { value -> hasAsciiAt(offset, value) }
 
 private const val DefaultMaxCachedPreviewBytes = 32L * 1024L * 1024L
+private const val InvalidObjectKeyCode = "INVALID_OBJECT_KEY"

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepository.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepository.kt
@@ -76,11 +76,15 @@ internal class UploadingTripRecordRepository(
             if (key in draft.uploadedMediaObjectKeys) return@forEachIndexed
             val media = mediaByLocalId[key]
                 ?: return Result.failure(
-                    IllegalStateException("업로드할 사진 데이터를 찾을 수 없습니다: $key"),
+                    IllegalStateException(
+                        "사진 정보를 확인하지 못했습니다. 사진을 삭제한 뒤 다시 추가해 주세요.",
+                    ),
                 )
             val bytes = media.originalBytes
                 ?: return Result.failure(
-                    IllegalStateException("사진 원본을 읽지 못했습니다: ${media.fileName ?: key}"),
+                    IllegalStateException(
+                        "사진 원본을 불러오지 못했습니다. 사진을 삭제한 뒤 다시 추가해 주세요.",
+                    ),
                 )
             val contentType = detectImageContentType(media.fileName, bytes)
                 ?: return Result.failure(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/Tag.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/Tag.kt
@@ -15,7 +15,7 @@ object TagRules {
     const val MaxTagsPerMember = 10
     const val MaxTagsPerRecord = 5
 
-    const val InvalidIdMessage = "태그 ID는 양수여야 합니다."
+    const val InvalidIdMessage = "선택한 태그 정보를 확인하지 못했습니다."
     const val EmptyNameMessage = "태그 이름을 입력해 주세요."
     const val HashNotAllowedMessage = "#은 빼고 태그 이름만 입력해 주세요."
     const val NameTooLongMessage = "태그 이름은 30자 이하여야 합니다."
@@ -23,7 +23,7 @@ object TagRules {
     const val MemberLimitMessage = "태그는 최대 10개까지 만들 수 있습니다."
     const val DuplicateNameMessage = "같은 이름의 태그가 있습니다."
     const val RecordLimitMessage = "태그는 기록당 최대 5개까지 선택할 수 있습니다."
-    const val DuplicateIdMessage = "태그 ID는 중복될 수 없습니다."
+    const val DuplicateIdMessage = "같은 태그를 중복해서 선택할 수 없습니다."
 
     fun normalizeName(value: String): String = value.trim().replace(Regex("\\s+"), " ")
 

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/TripRecordData.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/TripRecordData.kt
@@ -47,6 +47,14 @@ data class TripRecordDraft(
     val tagIds: List<Long> = emptyList(),
 )
 
+object TripRecordPhotoRules {
+    const val MaxPhotosPerRecord = 10
+    const val LimitMessage = "사진은 기록당 최대 10장까지 추가할 수 있습니다."
+
+    fun remainingSlots(currentPhotoCount: Int): Int =
+        (MaxPhotosPerRecord - currentPhotoCount).coerceAtLeast(0)
+}
+
 fun TripRecordDraft.dateValidationError(): String? = when {
     startDate == null -> "시작일을 입력해 주세요."
     !startDate.isValidIsoDate() -> "올바른 시작일을 입력해 주세요."

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/TripRecordData.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/model/TripRecordData.kt
@@ -40,6 +40,8 @@ data class TripRecordDraft(
     val startDate: String?,
     val endDate: String?,
     val mediaObjectKeys: List<String>,
+    /** 이미 업로드된 미디어는 키 형식을 해석하지 않고 원본 바이트 없이 그대로 저장한다. */
+    val uploadedMediaObjectKeys: Set<String> = emptySet(),
     // API 요청에는 object key만 사용하고, 로컬 저장소에서는 선택한 사진 표시 데이터를 보존한다.
     val localMedia: List<TripRecordMediaDraft> = emptyList(),
     val tagIds: List<Long> = emptyList(),

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/region/RegionCatalog.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/domain/region/RegionCatalog.kt
@@ -15,5 +15,5 @@ interface RegionCatalog {
     ): Location?
 
     fun requireByCode(code: String): Location =
-        requireNotNull(findByCode(code)) { "지역 코드를 찾을 수 없습니다: $code" }
+        requireNotNull(findByCode(code)) { "선택한 지역 정보를 확인하지 못했습니다." }
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/data/GeneratedKoreaDistrictMapData.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/map/data/GeneratedKoreaDistrictMapData.kt
@@ -19,7 +19,7 @@ internal object GeneratedKoreaDistrictMapData {
 
     suspend fun forProvince(provinceCode: String): List<ProvincePolygon> {
         val suffix = provinceCode.removePrefix("KR-")
-        require(suffix in supportedProvinceCodes) { "지원하지 않는 시·도 코드입니다: $provinceCode" }
+        require(suffix in supportedProvinceCodes) { "선택한 지역의 지도를 불러오지 못했습니다." }
 
         val file = Res.readBytes("files/korea-districts-$suffix.json")
             .decodeToString()

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationPaging.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationPaging.kt
@@ -1,12 +1,19 @@
 package com.mapmory.shared.presentation.photo
 
+import com.mapmory.shared.domain.model.TripRecordPhotoRules
+
 internal data class PhotoRecommendationPagingState(
     val generation: Int? = null,
     val photos: List<SelectedPhoto> = emptyList(),
     val selectedIds: Set<String> = emptySet(),
     val pageIndex: Int = 0,
     val hasMore: Boolean = false,
-)
+    val maxSelectionCount: Int = TripRecordPhotoRules.MaxPhotosPerRecord,
+) {
+    init {
+        require(maxSelectionCount >= 0)
+    }
+}
 
 internal data class RecommendationLoadKey(
     val generation: Int,
@@ -31,14 +38,16 @@ internal fun PhotoRecommendationPagingState.accept(
     }
 
     val nextPhotos = if (isFirstPage) incoming else photos + incoming
+    val selectedFromIncoming = incoming
+        .asSequence()
+        .map(SelectedPhoto::id)
+        .filterNot(selectedIds::contains)
+        .take((maxSelectionCount - selectedIds.size).coerceAtLeast(0))
+        .toSet()
     return copy(
         generation = page.generation,
         photos = nextPhotos,
-        selectedIds = if (isFirstPage) {
-            incoming.mapTo(mutableSetOf(), SelectedPhoto::id)
-        } else {
-            selectedIds + incoming.map(SelectedPhoto::id)
-        },
+        selectedIds = selectedIds + selectedFromIncoming,
         pageIndex = if (isFirstPage) 0 else pageIndex + 1,
         hasMore = page.hasMore,
     )
@@ -51,6 +60,7 @@ internal fun PhotoRecommendationPagingState.toggleSelection(
     val nextSelectedIds = if (photoId in selectedIds) {
         selectedIds - photoId
     } else {
+        if (selectedIds.size >= maxSelectionCount) return this
         selectedIds + photoId
     }
     return copy(selectedIds = nextSelectedIds)

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripMapScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripMapScreen.kt
@@ -1,6 +1,5 @@
 package com.mapmory.shared.presentation.triprecord.screen
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -17,25 +16,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mapmory.shared.domain.model.Tag
-import com.mapmory.shared.analytics.LocalMapmoryAnalytics
-import com.mapmory.shared.analytics.MapmoryAnalyticsEvent
 import com.mapmory.shared.presentation.map.data.GeneratedKoreaMapData
 import com.mapmory.shared.presentation.map.domain.MapScope
 import com.mapmory.shared.presentation.map.ui.KoreaMapArtwork
@@ -62,11 +54,9 @@ fun TripMapScreen(
     onProfileClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    val palette = TripRecordPalette.current
-    val analytics = LocalMapmoryAnalytics.current
     TripRecordBackground(
         modifier = modifier,
-        backgroundColor = palette.pageBackground,
+        backgroundColor = TripRecordPalette.current.pageBackground,
     ) {
         Column(
             modifier = Modifier
@@ -98,43 +88,11 @@ fun TripMapScreen(
                     content = mapContent,
                 )
 
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(end = 28.dp, bottom = 33.dp)
-                        .size(44.dp)
-                        .clip(CircleShape)
-                        .background(palette.primary)
-                        .clickable {
-                            analytics.logEvent(
-                                MapmoryAnalyticsEvent.RECORD_CREATE_STARTED,
-                                mapOf("source" to "map_fab"),
-                            )
-                            onCreateClick()
-                        }
-                        .semantics { contentDescription = "새 기록 작성" },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Canvas(Modifier.size(24.dp)) {
-                        val strokeWidth = 2.dp.toPx()
-                        val center = Offset(size.width / 2f, size.height / 2f)
-                        val armLength = size.minDimension * 0.32f
-                        drawLine(
-                            color = palette.onPrimary,
-                            start = Offset(center.x - armLength, center.y),
-                            end = Offset(center.x + armLength, center.y),
-                            strokeWidth = strokeWidth,
-                            cap = StrokeCap.Round,
-                        )
-                        drawLine(
-                            color = palette.onPrimary,
-                            start = Offset(center.x, center.y - armLength),
-                            end = Offset(center.x, center.y + armLength),
-                            strokeWidth = strokeWidth,
-                            cap = StrokeCap.Round,
-                        )
-                    }
-                }
+                TripRecordCreateButton(
+                    source = "map_fab",
+                    onClick = onCreateClick,
+                    modifier = Modifier.align(Alignment.BottomEnd),
+                )
             }
 
             TripBottomBar(
@@ -202,13 +160,14 @@ private fun MapHeaderOverlay(
             onMapDetailBackClick = onMapDetailBackClick,
             modifier = Modifier.padding(horizontal = 12.dp),
         )
-        Spacer(Modifier.height(14.dp))
+        Spacer(Modifier.height(8.dp))
         MapTagFilter(
             tags = tags,
             selectedTagId = selectedTagId,
             onTagSelected = onTagSelected,
             modifier = Modifier.padding(horizontal = 18.dp),
         )
+        Spacer(Modifier.height(6.dp))
     }
 }
 

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordComponents.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordComponents.kt
@@ -148,6 +148,52 @@ internal fun TripIconButton(
 }
 
 @Composable
+internal fun TripRecordCreateButton(
+    source: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val palette = TripRecordPalette.current
+    val analytics = LocalMapmoryAnalytics.current
+    Box(
+        modifier = modifier
+            .padding(end = 28.dp, bottom = 33.dp)
+            .size(44.dp)
+            .clip(CircleShape)
+            .background(palette.primary)
+            .clickable {
+                analytics.logEvent(
+                    MapmoryAnalyticsEvent.RECORD_CREATE_STARTED,
+                    mapOf("source" to source),
+                )
+                onClick()
+            }
+            .semantics { contentDescription = "새 기록 작성" },
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(Modifier.size(24.dp)) {
+            val strokeWidth = 2.dp.toPx()
+            val center = Offset(size.width / 2f, size.height / 2f)
+            val armLength = size.minDimension * 0.32f
+            drawLine(
+                color = palette.onPrimary,
+                start = Offset(center.x - armLength, center.y),
+                end = Offset(center.x + armLength, center.y),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round,
+            )
+            drawLine(
+                color = palette.onPrimary,
+                start = Offset(center.x, center.y - armLength),
+                end = Offset(center.x, center.y + armLength),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round,
+            )
+        }
+    }
+}
+
+@Composable
 internal fun TripSectionLabel(
     text: String,
     modifier: Modifier = Modifier,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -74,6 +74,7 @@ import com.mapmory.shared.analytics.LocalMapmoryAnalytics
 import com.mapmory.shared.analytics.MapmoryAnalyticsEvent
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
+import com.mapmory.shared.domain.model.TripRecordPhotoRules
 import com.mapmory.shared.presentation.photo.PhotoLibraryActionsFactory
 import com.mapmory.shared.presentation.photo.PhotoLoadingProgress
 import com.mapmory.shared.presentation.photo.PhotoRecommendationPagingState
@@ -167,6 +168,7 @@ fun TripRecordEditorScreen(
     var showLocationSheet by remember { mutableStateOf(false) }
     var locationSearchQuery by rememberSaveable { mutableStateOf("") }
     var photoMessage by remember { mutableStateOf<String?>(null) }
+    var recommendationSelectionMessage by remember { mutableStateOf<String?>(null) }
     var recommendationPagingState by remember { mutableStateOf(PhotoRecommendationPagingState()) }
     var lastAutoLoadTriggerKey by remember { mutableStateOf<RecommendationLoadKey?>(null) }
     var showRecommendationSheet by remember { mutableStateOf(false) }
@@ -174,6 +176,7 @@ fun TripRecordEditorScreen(
     var isRecommendationLoading by remember { mutableStateOf(false) }
     var photoLoadingProgress by remember { mutableStateOf<PhotoLoadingProgress?>(null) }
     var datePickerTarget by rememberSaveable { mutableStateOf<String?>(null) }
+    val remainingPhotoSlots = TripRecordPhotoRules.remainingSlots(uiState.selectedPhotos.size)
     val dismissKeyboardOnTap = rememberDismissKeyboardOnTapModifier()
     val photoLibrary = photoLibraryActionsFactory(
         { photos ->
@@ -287,8 +290,12 @@ fun TripRecordEditorScreen(
                             locationName = uiState.selectedLocation?.name ?: "여행 장소",
                             photos = uiState.selectedPhotos,
                             onAddClick = {
-                                analytics.logEvent(MapmoryAnalyticsEvent.PHOTO_PICKER_OPENED)
-                                photoLibrary.pickFromGallery()
+                                if (remainingPhotoSlots == 0) {
+                                    photoMessage = TripRecordPhotoRules.LimitMessage
+                                } else {
+                                    analytics.logEvent(MapmoryAnalyticsEvent.PHOTO_PICKER_OPENED)
+                                    photoLibrary.pickFromGallery()
+                                }
                             },
                             onRecommendClick = {
                                 if (isRecommendationLoading) {
@@ -297,7 +304,9 @@ fun TripRecordEditorScreen(
                                     photoMessage = "사진 불러오기를 중단했어요."
                                 } else {
                                     val selectedLocation = uiState.selectedLocation
-                                    if (selectedLocation == null) {
+                                    if (remainingPhotoSlots == 0) {
+                                        photoMessage = TripRecordPhotoRules.LimitMessage
+                                    } else if (selectedLocation == null) {
                                         photoMessage = "사진을 추천받으려면 장소를 먼저 선택해 주세요."
                                     } else {
                                         analytics.logEvent(
@@ -305,7 +314,10 @@ fun TripRecordEditorScreen(
                                             mapOf("location_type" to selectedLocation.type.name.lowercase()),
                                         )
                                         photoMessage = "${selectedLocation.name}에서 촬영된 사진을 찾고 있어요."
-                                        recommendationPagingState = PhotoRecommendationPagingState()
+                                        recommendationPagingState = PhotoRecommendationPagingState(
+                                            maxSelectionCount = remainingPhotoSlots,
+                                        )
+                                        recommendationSelectionMessage = null
                                         lastAutoLoadTriggerKey = null
                                         showRecommendationSheet = false
                                         val parentName = locations
@@ -516,6 +528,18 @@ fun TripRecordEditorScreen(
                     fontSize = 12.sp,
                     modifier = Modifier.padding(top = 6.dp),
                 )
+                Text(
+                    text = recommendationSelectionMessage
+                        ?: "${recommendationPagingState.selectedIds.size}/" +
+                        "${recommendationPagingState.maxSelectionCount}장 선택",
+                    color = if (recommendationSelectionMessage == null) {
+                        TripRecordPalette.current.muted
+                    } else {
+                        TripRecordPalette.current.danger
+                    },
+                    fontSize = 11.sp,
+                    modifier = Modifier.padding(top = 6.dp),
+                )
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(3),
                     state = recommendationGridState,
@@ -536,7 +560,16 @@ fun TripRecordEditorScreen(
                             photo = photo,
                             selected = selected,
                             onClick = {
-                                recommendationPagingState = recommendationPagingState.toggleSelection(photo.id)
+                                val nextState = recommendationPagingState.toggleSelection(photo.id)
+                                recommendationSelectionMessage = if (
+                                    !selected && nextState == recommendationPagingState
+                                ) {
+                                    "이 화면에서는 사진을 최대 " +
+                                        "${recommendationPagingState.maxSelectionCount}장까지 선택할 수 있어요."
+                                } else {
+                                    null
+                                }
+                                recommendationPagingState = nextState
                             },
                         )
                     }
@@ -581,6 +614,7 @@ fun TripRecordEditorScreen(
                                 onPhotosAdded(preparedPhotos)
                                 showRecommendationSheet = false
                                 photoMessage = null
+                                recommendationSelectionMessage = null
                             }
                         }
                     },
@@ -725,7 +759,8 @@ private fun PhotoSection(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "$locationName · 여행 일정과 가까운 사진",
+                text = "$locationName · 여행 일정과 가까운 사진 · " +
+                    "${photos.size}/${TripRecordPhotoRules.MaxPhotosPerRecord}",
                 color = TripRecordPalette.current.text,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.SemiBold,
@@ -780,7 +815,7 @@ private fun PhotoSection(
             photos = photos,
             onAddClick = onAddClick,
             onRemoveClick = onRemoveClick,
-            isAddEnabled = !isLoading,
+            isAddEnabled = !isLoading && photos.size < TripRecordPhotoRules.MaxPhotosPerRecord,
             modifier = Modifier.padding(top = 12.dp, bottom = 16.dp),
         )
     }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -262,6 +262,10 @@ fun TripRecordEditorScreen(
                 isSaving = uiState.isSaving,
                 onSaveClick = onSaveClick,
             )
+            EditorErrorMessage(
+                message = uiState.generalErrorMessage,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+            )
             CompositionLocalProvider(
                 LocalBringIntoViewSpec provides EditorBringIntoViewSpec,
             ) {
@@ -377,26 +381,25 @@ fun TripRecordEditorScreen(
 
                         TagEditor(
                             uiState = uiState,
+                            saveErrorMessage = uiState.errorMessageFor(TripRecordEditorErrorTarget.TAGS),
                             onInputChanged = onTagInputChanged,
                             onTagToggled = onTagToggled,
                             onCreate = onTagCreate,
                             modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
                         )
 
-                        EditorContentField(
-                            value = uiState.content,
-                            onValueChange = onContentChanged,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 20.dp, vertical = 8.dp),
-                        )
-
-                        uiState.generalErrorMessage?.takeIf { uiState.isDirty }?.let { message ->
+                        Column(Modifier.padding(horizontal = 20.dp, vertical = 8.dp)) {
+                            EditorContentField(
+                                value = uiState.content,
+                                onValueChange = onContentChanged,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
                             EditorErrorMessage(
-                                message = message,
-                                modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+                                message = uiState.errorMessageFor(TripRecordEditorErrorTarget.CONTENT),
+                                modifier = Modifier.padding(top = 6.dp),
                             )
                         }
+
                     }
                 }
             }
@@ -926,6 +929,7 @@ private fun TripRecordEditorUiState.errorMessageFor(target: TripRecordEditorErro
 @Composable
 private fun TagEditor(
     uiState: TripRecordEditorUiState,
+    saveErrorMessage: String?,
     onInputChanged: (String) -> Unit,
     onTagToggled: (Long) -> Unit,
     onCreate: () -> Unit,
@@ -1017,9 +1021,10 @@ private fun TagEditor(
             )
         }
 
-        uiState.tagErrorMessage?.let { message ->
-            EditorErrorMessage(message = message, modifier = Modifier.padding(top = 6.dp))
-        }
+        EditorErrorMessage(
+            message = uiState.tagErrorMessage ?: saveErrorMessage,
+            modifier = Modifier.padding(top = 6.dp),
+        )
     }
 }
 

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordListScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordListScreen.kt
@@ -68,72 +68,83 @@ fun TripRecordListScreen(
                 recordCount = (uiState as? TripRecordListUiState.Success)?.records?.size ?: 0,
             )
 
-            Column(
+            Box(
                 modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 18.dp),
+                    .fillMaxWidth()
+                    .weight(1f),
             ) {
-                Spacer(Modifier.height(14.dp))
-                JournalTagFilters(
-                    tags = filter.tags,
-                    selectedTagId = filter.selectedTagId,
-                    onTagClick = onTagClick,
-                )
-                Spacer(Modifier.height(18.dp))
-
-                when (uiState) {
-                    TripRecordListUiState.Idle,
-                    TripRecordListUiState.Loading,
-                    -> CircularProgressIndicator(
-                        color = TripRecordPalette.current.accent,
-                        modifier = Modifier.padding(top = 20.dp),
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 18.dp),
+                ) {
+                    Spacer(Modifier.height(14.dp))
+                    JournalTagFilters(
+                        tags = filter.tags,
+                        selectedTagId = filter.selectedTagId,
+                        onTagClick = onTagClick,
                     )
+                    Spacer(Modifier.height(18.dp))
 
+                    when (uiState) {
+                        TripRecordListUiState.Idle,
+                        TripRecordListUiState.Loading,
+                        -> CircularProgressIndicator(
+                            color = TripRecordPalette.current.accent,
+                            modifier = Modifier.padding(top = 20.dp),
+                        )
 
-                    is TripRecordListUiState.Error -> Text(
-                        text = uiState.message,
-                        color = TripRecordPalette.current.danger,
-                        modifier = Modifier.padding(top = 20.dp),
-                    )
+                        is TripRecordListUiState.Error -> Text(
+                            text = uiState.message,
+                            color = TripRecordPalette.current.danger,
+                            modifier = Modifier.padding(top = 20.dp),
+                        )
 
-                    is TripRecordListUiState.Success -> {
-                        if (uiState.records.isEmpty()) {
-                            EmptyTripRecords(
-                                hasFilter = filter.locationId != null || filter.selectedTagId != null,
-                                modifier = Modifier.weight(1f),
-                            )
-                        } else {
-                            TripRecordList(
-                                records = uiState.records,
-                                onRecordClick = { recordId ->
-                                    analytics.logEvent(MapmoryAnalyticsEvent.JOURNAL_RECORD_OPENED)
-                                    onRecordClick(recordId)
-                                },
-                                modifier = Modifier.weight(1f),
-                            )
-                        }
-                        if (uiState.totalPages > 1) {
-                            PageControls(
-                                page = uiState.page,
-                                totalPages = uiState.totalPages,
-                                onPreviousPageClick = {
-                                    analytics.logEvent(
-                                        MapmoryAnalyticsEvent.JOURNAL_PAGE_CHANGED,
-                                        mapOf("direction" to "previous"),
-                                    )
-                                    onPreviousPageClick()
-                                },
-                                onNextPageClick = {
-                                    analytics.logEvent(
-                                        MapmoryAnalyticsEvent.JOURNAL_PAGE_CHANGED,
-                                        mapOf("direction" to "next"),
-                                    )
-                                    onNextPageClick()
-                                },
-                            )
+                        is TripRecordListUiState.Success -> {
+                            if (uiState.records.isEmpty()) {
+                                EmptyTripRecords(
+                                    hasFilter = filter.locationId != null || filter.selectedTagId != null,
+                                    modifier = Modifier.weight(1f),
+                                )
+                            } else {
+                                TripRecordList(
+                                    records = uiState.records,
+                                    onRecordClick = { recordId ->
+                                        analytics.logEvent(MapmoryAnalyticsEvent.JOURNAL_RECORD_OPENED)
+                                        onRecordClick(recordId)
+                                    },
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
+                            if (uiState.totalPages > 1) {
+                                PageControls(
+                                    page = uiState.page,
+                                    totalPages = uiState.totalPages,
+                                    onPreviousPageClick = {
+                                        analytics.logEvent(
+                                            MapmoryAnalyticsEvent.JOURNAL_PAGE_CHANGED,
+                                            mapOf("direction" to "previous"),
+                                        )
+                                        onPreviousPageClick()
+                                    },
+                                    onNextPageClick = {
+                                        analytics.logEvent(
+                                            MapmoryAnalyticsEvent.JOURNAL_PAGE_CHANGED,
+                                            mapOf("direction" to "next"),
+                                        )
+                                        onNextPageClick()
+                                    },
+                                )
+                            }
                         }
                     }
                 }
+
+                TripRecordCreateButton(
+                    source = "journal_fab",
+                    onClick = onCreateClick,
+                    modifier = Modifier.align(Alignment.BottomEnd),
+                )
             }
 
             TripBottomBar(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordEditorUiState.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordEditorUiState.kt
@@ -48,5 +48,6 @@ enum class TripRecordEditorErrorTarget {
     START_DATE,
     END_DATE,
     CONTENT,
+    TAGS,
     GENERAL,
 }

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordItemUiState.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/state/TripRecordItemUiState.kt
@@ -23,6 +23,7 @@ data class TripRecordPhotoUiState(
     val displayName: String,
     val previewBytes: PhotoPreviewBytes?,
     val sortOrder: Int,
+    val isUploaded: Boolean = false,
     val latitude: Double? = null,
     val longitude: Double? = null,
     val capturedAt: String? = null,
@@ -79,6 +80,7 @@ fun TripRecordData.toTripRecordItemUiState(
                 displayName = media.objectKey.substringAfterLast('/'),
                 previewBytes = PhotoPreviewBytes.from(media.previewBytes ?: media.originalBytes),
                 sortOrder = media.sortOrder,
+                isUploaded = true,
                 latitude = media.latitude,
                 longitude = media.longitude,
                 capturedAt = media.capturedAt,
@@ -118,6 +120,7 @@ fun TripRecordSummary.toTripRecordItemUiState(
                     null
                 },
                 sortOrder = media.sortOrder,
+                isUploaded = true,
                 latitude = media.latitude,
                 longitude = media.longitude,
                 capturedAt = media.capturedAt,

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModel.kt
@@ -10,6 +10,7 @@ import com.mapmory.shared.domain.model.TagRules
 import com.mapmory.shared.domain.model.TripRecordData
 import com.mapmory.shared.domain.model.TripRecordDraft
 import com.mapmory.shared.domain.model.TripRecordMediaDraft
+import com.mapmory.shared.domain.model.TripRecordPhotoRules
 import com.mapmory.shared.domain.model.dateValidationError
 import com.mapmory.shared.domain.region.RegionCatalog
 import com.mapmory.shared.domain.usecase.CreateTripRecordUseCase
@@ -254,25 +255,42 @@ class TripRecordEditorViewModel(
     fun addMediaObjectKey(objectKey: String) {
         val trimmedObjectKey = objectKey.trim()
         if (trimmedObjectKey.isBlank() || trimmedObjectKey in uiState.mediaObjectKeys) return
+        if (uiState.mediaObjectKeys.size >= TripRecordPhotoRules.MaxPhotosPerRecord) {
+            uiState = uiState.withPhotoLimitError()
+            return
+        }
 
         uiState = uiState.copy(
             mediaObjectKeys = uiState.mediaObjectKeys + trimmedObjectKey,
+            fieldErrors = uiState.fieldErrors - TripRecordEditorErrorTarget.PHOTOS,
         ).revalidatedAfterChange()
     }
 
     fun addPhotos(photos: List<SelectedPhoto>) {
+        val existingIds = uiState.selectedPhotos.mapTo(mutableSetOf()) { photo -> photo.id }
+        val newPhotos = photos
+            .filterNot { photo -> photo.id in existingIds }
+            .distinctBy(SelectedPhoto::id)
+        val acceptedPhotos = newPhotos.take(
+            TripRecordPhotoRules.remainingSlots(uiState.selectedPhotos.size),
+        )
         val merged = buildList {
             addAll(uiState.selectedPhotos)
-            photos.forEach { photo ->
-                if (none { existing -> existing.id == photo.id }) {
-                    add(photo.toTripRecordPhotoUiState(sortOrder = size))
-                }
+            acceptedPhotos.forEach { photo ->
+                add(photo.toTripRecordPhotoUiState(sortOrder = size))
             }
+        }
+        val photoErrors = when {
+            acceptedPhotos.size < newPhotos.size -> uiState.fieldErrors + (
+                TripRecordEditorErrorTarget.PHOTOS to TripRecordPhotoRules.LimitMessage
+            )
+            newPhotos.isNotEmpty() -> uiState.fieldErrors - TripRecordEditorErrorTarget.PHOTOS
+            else -> uiState.fieldErrors
         }
         uiState = uiState.copy(
             selectedPhotos = merged,
             mediaObjectKeys = merged.map { it.id },
-            fieldErrors = uiState.fieldErrors - TripRecordEditorErrorTarget.PHOTOS,
+            fieldErrors = photoErrors,
         ).revalidatedAfterChange()
     }
 
@@ -392,12 +410,27 @@ private fun TripRecordEditorUiState.revalidatedAfterChange(
     )
 }
 
+private fun TripRecordEditorUiState.withPhotoLimitError(): TripRecordEditorUiState = copy(
+    isDirty = true,
+    dirtyFields = dirtyFields + TripRecordEditorErrorTarget.PHOTOS,
+    fieldErrors = fieldErrors + (
+        TripRecordEditorErrorTarget.PHOTOS to TripRecordPhotoRules.LimitMessage
+    ),
+    generalErrorMessage = null,
+)
+
 private fun TripRecordEditorErrorTarget.isDateTarget(): Boolean =
     this == TripRecordEditorErrorTarget.START_DATE || this == TripRecordEditorErrorTarget.END_DATE
 
 private fun TripRecordEditorUiState.validationErrors(
     dateRangeErrorTarget: TripRecordEditorErrorTarget = TripRecordEditorErrorTarget.END_DATE,
 ): Map<TripRecordEditorErrorTarget, String> = buildMap {
+    if (
+        mediaObjectKeys.size > TripRecordPhotoRules.MaxPhotosPerRecord ||
+        selectedPhotos.size > TripRecordPhotoRules.MaxPhotosPerRecord
+    ) {
+        put(TripRecordEditorErrorTarget.PHOTOS, TripRecordPhotoRules.LimitMessage)
+    }
     if (selectedLocation == null) {
         put(TripRecordEditorErrorTarget.LOCATION, "장소를 선택해 주세요.")
     } else if (!selectedLocation.isSelectableTripRecordDestination()) {

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.mapmory.shared.data.remote.MapmoryApiException
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.TagRules
 import com.mapmory.shared.domain.model.TripRecordData
@@ -105,6 +106,7 @@ class TripRecordEditorViewModel(
                     longitude = media.longitude,
                     capturedAt = media.capturedAt,
                 ).toTripRecordPhotoUiState(media.sortOrder)
+                    .copy(isUploaded = true)
             },
             availableTags = allTags,
             selectedTagIds = record.tags.mapTo(linkedSetOf()) { it.id },
@@ -134,6 +136,7 @@ class TripRecordEditorViewModel(
         uiState = uiState.copy(
             tagInput = value,
             tagErrorMessage = null,
+            fieldErrors = uiState.fieldErrors - TripRecordEditorErrorTarget.TAGS,
             isDirty = true,
         )
     }
@@ -145,6 +148,7 @@ class TripRecordEditorViewModel(
             tagId in selected -> uiState.copy(
                 selectedTagIds = selected - tagId,
                 tagErrorMessage = null,
+                fieldErrors = uiState.fieldErrors - TripRecordEditorErrorTarget.TAGS,
                 isDirty = true,
             )
             else -> runCatching {
@@ -155,6 +159,7 @@ class TripRecordEditorViewModel(
                     uiState.copy(
                         selectedTagIds = updatedSelection,
                         tagErrorMessage = null,
+                        fieldErrors = uiState.fieldErrors - TripRecordEditorErrorTarget.TAGS,
                         isDirty = true,
                     )
                 },
@@ -178,6 +183,7 @@ class TripRecordEditorViewModel(
                 selectedTagIds = uiState.selectedTagIds + tag.id,
                 tagInput = "",
                 tagErrorMessage = null,
+                fieldErrors = uiState.fieldErrors - TripRecordEditorErrorTarget.TAGS,
                 isDirty = true,
             )
             return
@@ -191,6 +197,7 @@ class TripRecordEditorViewModel(
                     selectedTagIds = uiState.selectedTagIds + tag.id,
                     tagInput = "",
                     isCreatingTag = false,
+                    fieldErrors = uiState.fieldErrors - TripRecordEditorErrorTarget.TAGS,
                     isDirty = true,
                 )
             },
@@ -229,7 +236,7 @@ class TripRecordEditorViewModel(
     fun updateContent(content: String) {
         uiState = uiState.copy(
             content = content,
-        ).revalidatedAfterChange()
+        ).revalidatedAfterChange(TripRecordEditorErrorTarget.CONTENT)
     }
 
     fun updateStartDate(startDate: String) {
@@ -296,6 +303,9 @@ class TripRecordEditorViewModel(
             startDate = state.startDate.ifBlank { null },
             endDate = state.endDate.ifBlank { null },
             mediaObjectKeys = state.mediaObjectKeys,
+            uploadedMediaObjectKeys = state.selectedPhotos
+                .filter { photo -> photo.isUploaded }
+                .mapTo(mutableSetOf()) { photo -> photo.id },
             localMedia = state.selectedPhotos.mapIndexed { index, photo ->
                 TripRecordMediaDraft(
                     objectKey = photo.id,
@@ -324,9 +334,17 @@ class TripRecordEditorViewModel(
                 true
             },
             onFailure = { error ->
+                val fieldErrors = error.toEditorFieldErrors()
                 uiState = uiState.copy(
                     isSaving = false,
-                    generalErrorMessage = error.message ?: "여행 기록을 저장하지 못했습니다.",
+                    isDirty = true,
+                    dirtyFields = uiState.dirtyFields + fieldErrors.keys,
+                    fieldErrors = fieldErrors,
+                    generalErrorMessage = if (fieldErrors.isEmpty()) {
+                        error.message ?: "여행 기록을 저장하지 못했습니다."
+                    } else {
+                        null
+                    },
                 )
                 false
             },
@@ -352,8 +370,9 @@ private fun TripRecordEditorUiState.revalidatedAfterChange(
     }
 
     val updatedDirtyFields = if (dirtyTarget in dirtyFields) dirtyFields else dirtyFields + dirtyTarget
-    val nonValidationErrors = fieldErrors.filterKeys { target ->
-        target == TripRecordEditorErrorTarget.PHOTOS
+    val retainedErrors = fieldErrors.filterKeys { target ->
+        target != dirtyTarget &&
+            !(dirtyTarget.isDateTarget() && target.isDateTarget())
     }
     val dateRangeErrorTarget = when (dirtyTarget) {
         TripRecordEditorErrorTarget.START_DATE,
@@ -367,11 +386,14 @@ private fun TripRecordEditorUiState.revalidatedAfterChange(
     return copy(
         isDirty = true,
         dirtyFields = updatedDirtyFields,
-        fieldErrors = nonValidationErrors + validationErrors(dateRangeErrorTarget)
+        fieldErrors = retainedErrors + validationErrors(dateRangeErrorTarget)
             .filterKeys(updatedDirtyFields::contains),
         generalErrorMessage = null,
     )
 }
+
+private fun TripRecordEditorErrorTarget.isDateTarget(): Boolean =
+    this == TripRecordEditorErrorTarget.START_DATE || this == TripRecordEditorErrorTarget.END_DATE
 
 private fun TripRecordEditorUiState.validationErrors(
     dateRangeErrorTarget: TripRecordEditorErrorTarget = TripRecordEditorErrorTarget.END_DATE,
@@ -407,3 +429,47 @@ private fun TripRecordEditorUiState.validationErrors(
 }
 
 private const val MaxTitleLength = 200
+
+internal fun Throwable.toEditorFieldErrors(): Map<TripRecordEditorErrorTarget, String> {
+    val apiError = this as? MapmoryApiException
+    val errorsByTarget = apiError?.errors.orEmpty()
+        .mapNotNull { error ->
+            error.field.toEditorErrorTarget()?.let { target -> target to error.detail }
+        }
+        .toMap()
+    if (errorsByTarget.isNotEmpty()) return errorsByTarget
+
+    val target = when (apiError?.code) {
+        "INVALID_FILE_TYPE",
+        "FILE_SIZE_EXCEEDED",
+        "TOO_MANY_FILES",
+        "MEDIA_NOT_UPLOADED",
+        "STORAGE_UNAVAILABLE",
+        "INVALID_OBJECT_KEY" -> TripRecordEditorErrorTarget.PHOTOS
+
+        "INVALID_REGION_CODE",
+        "INVALID_REGION_TYPE",
+        "REGION_REQUIRED" -> TripRecordEditorErrorTarget.LOCATION
+
+        "INVALID_TRAVEL_DATE_RANGE" -> TripRecordEditorErrorTarget.END_DATE
+        "TOO_MANY_TAGS", "INVALID_TAG_IDS" -> TripRecordEditorErrorTarget.TAGS
+        else -> when {
+            apiError?.instance.orEmpty().contains("/uploads/") -> TripRecordEditorErrorTarget.PHOTOS
+            message.orEmpty().contains("사진") -> TripRecordEditorErrorTarget.PHOTOS
+            else -> null
+        }
+    } ?: return emptyMap()
+
+    return mapOf(target to (message ?: "입력한 내용을 확인해 주세요."))
+}
+
+private fun String.toEditorErrorTarget(): TripRecordEditorErrorTarget? = when {
+    this in setOf("countryCode", "provinceCode", "districtCode") -> TripRecordEditorErrorTarget.LOCATION
+    this == "title" -> TripRecordEditorErrorTarget.TITLE
+    this == "startDate" -> TripRecordEditorErrorTarget.START_DATE
+    this == "endDate" -> TripRecordEditorErrorTarget.END_DATE
+    this == "content" -> TripRecordEditorErrorTarget.CONTENT
+    startsWith("objectKeys") || startsWith("files") -> TripRecordEditorErrorTarget.PHOTOS
+    startsWith("tagIds") -> TripRecordEditorErrorTarget.TAGS
+    else -> null
+}

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/ApiCallTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/ApiCallTest.kt
@@ -1,11 +1,13 @@
 package com.mapmory.shared.data.remote
 
+import com.mapmory.shared.data.remote.model.ProblemFieldErrorDto
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertSame
 
 class ApiCallTest {
     @Test
@@ -25,5 +27,55 @@ class ApiCallTest {
 
         assertIs<IllegalStateException>(result.exceptionOrNull())
         Unit
+    }
+
+    @Test
+    fun `DNS 오류를 사용자 친화적인 연결 안내로 변환한다`() = runBlocking {
+        val rawError = IllegalStateException(
+            "Unable to resolve host \"api.map-mory.com\": No address associated with hostname",
+        )
+
+        val result = apiCall<Unit> { throw rawError }.exceptionOrNull()
+
+        assertIs<MapmoryConnectionException>(result)
+        assertEquals(
+            "서버에 연결할 수 없습니다. 인터넷 연결을 확인한 뒤 잠시 후 다시 시도해 주세요.",
+            result.message,
+        )
+        assertSame(rawError, result.cause)
+    }
+
+    @Test
+    fun `시간 초과 오류를 재시도 안내로 변환한다`() {
+        val rawError = IllegalStateException("request timed out")
+
+        val result = rawError.toUserFriendlyRemoteFailure()
+
+        assertIs<MapmoryConnectionException>(result)
+        assertEquals(
+            "서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해 주세요.",
+            result.message,
+        )
+    }
+
+    @Test
+    fun `서버가 제공한 API 오류 문구는 유지한다`() {
+        val apiError = MapmoryApiException(
+            statusCode = 400,
+            code = "VALIDATION_ERROR",
+            title = "요청 값이 올바르지 않습니다.",
+            detail = "제목을 확인해 주세요.",
+            instance = "/api/v1/travel-records",
+            errors = listOf(ProblemFieldErrorDto("title", "제목을 확인해 주세요.")),
+        )
+
+        assertSame(apiError, apiError.toUserFriendlyRemoteFailure())
+    }
+
+    @Test
+    fun `알 수 없는 내부 오류는 임의로 네트워크 오류로 바꾸지 않는다`() {
+        val error = IllegalArgumentException("unexpected response shape")
+
+        assertSame(error, error.toUserFriendlyRemoteFailure())
     }
 }

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/ApiCallTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/ApiCallTest.kt
@@ -3,6 +3,7 @@ package com.mapmory.shared.data.remote
 import com.mapmory.shared.data.remote.model.ProblemFieldErrorDto
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerializationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -23,10 +24,13 @@ class ApiCallTest {
 
     @Test
     fun regularExceptionIsReturnedAsFailure() = runBlocking {
-        val result = apiCall<Unit> { throw IllegalStateException("요청 실패") }
+        val rawError = IllegalStateException("internal client state")
 
-        assertIs<IllegalStateException>(result.exceptionOrNull())
-        Unit
+        val result = apiCall<Unit> { throw rawError }.exceptionOrNull()
+
+        assertIs<MapmoryRemoteRequestException>(result)
+        assertEquals("요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.", result.message)
+        assertSame(rawError, result.cause)
     }
 
     @Test
@@ -73,9 +77,51 @@ class ApiCallTest {
     }
 
     @Test
-    fun `알 수 없는 내부 오류는 임의로 네트워크 오류로 바꾸지 않는다`() {
-        val error = IllegalArgumentException("unexpected response shape")
+    fun `사용자에게 안내할 입력 오류는 문구를 유지한다`() {
+        val error = IllegalArgumentException("여행 기록을 찾을 수 없습니다.")
 
         assertSame(error, error.toUserFriendlyRemoteFailure())
+    }
+
+    @Test
+    fun `서버 응답 파싱 오류는 내부 내용을 숨기고 재시도를 안내한다`() {
+        val rawError = SerializationException("Unexpected JSON token at offset 42")
+
+        val result = rawError.toUserFriendlyRemoteFailure()
+
+        assertIs<MapmoryRemoteRequestException>(result)
+        assertEquals("요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.", result.message)
+        assertSame(rawError, result.cause)
+    }
+
+    @Test
+    fun `사진 식별자 오류는 사진 재선택을 안내한다`() {
+        val error = MapmoryApiException(
+            statusCode = 400,
+            code = "INVALID_OBJECT_KEY",
+            title = "Object Key가 올바르지 않습니다.",
+            detail = "다른 기록에서 사용 중인 Object Key입니다.",
+            instance = "/api/v1/travel-records",
+            errors = emptyList(),
+        )
+
+        assertEquals(
+            "사진을 저장하지 못했습니다. 문제가 있는 사진을 삭제한 뒤 다시 추가해 주세요.",
+            error.message,
+        )
+    }
+
+    @Test
+    fun `인증 토큰 오류는 재로그인을 안내한다`() {
+        val error = MapmoryApiException(
+            statusCode = 401,
+            code = "EXPIRED_REFRESH_TOKEN",
+            title = "만료된 refresh 토큰입니다.",
+            detail = "refresh 토큰이 만료되었습니다.",
+            instance = "/api/v1/auth/token/refresh",
+            errors = emptyList(),
+        )
+
+        assertEquals("로그인 정보가 만료되었습니다. 다시 로그인해 주세요.", error.message)
     }
 }

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/ApiCallTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/remote/ApiCallTest.kt
@@ -106,7 +106,7 @@ class ApiCallTest {
         )
 
         assertEquals(
-            "사진을 저장하지 못했습니다. 문제가 있는 사진을 삭제한 뒤 다시 추가해 주세요.",
+            "사진을 저장하지 못했습니다. 잠시 후 다시 저장해 주세요.",
             error.message,
         )
     }

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.mapmory.shared.data.repository
 
+import com.mapmory.shared.data.remote.MapmoryApiException
 import com.mapmory.shared.data.remote.PhotoUploadSource
 import com.mapmory.shared.data.remote.PhotoUploader
 import com.mapmory.shared.data.remote.UploadedPhoto
@@ -135,11 +136,51 @@ class UploadingTripRecordRepositoryTest {
         ).exceptionOrNull()
 
         assertEquals(
-            "사진 원본을 불러오지 못했습니다. 사진을 삭제한 뒤 다시 추가해 주세요.",
+            "사진 원본을 불러오지 못했습니다. 잠시 후 다시 저장해 주세요.",
             error?.message,
         )
         assertFalse(error?.message.orEmpty().contains(internalId))
         assertFalse(error?.message.orEmpty().contains("internal-file-name.jpg"))
+    }
+
+    @Test
+    fun invalidNewObjectKeyIsReissuedAndSavedOnceWithoutReselectingThePhoto() = runBlocking {
+        var uploadAttempt = 0
+        val uploader = PhotoUploader { sources ->
+            uploadAttempt += 1
+            Result.success(
+                sources.map { source ->
+                    UploadedPhoto(source, "travel-records/10/reissued-$uploadAttempt.jpg")
+                },
+            )
+        }
+        val savedDrafts = mutableListOf<TripRecordDraft>()
+        val baseDelegate = CapturingTripRecordRepository()
+        val delegate = object : TripRecordRepository by baseDelegate {
+            override suspend fun updateTripRecord(
+                id: Long,
+                draft: TripRecordDraft,
+            ): Result<TripRecordData> {
+                savedDrafts += draft
+                return if (savedDrafts.size == 1) {
+                    Result.failure(invalidObjectKeyError())
+                } else {
+                    Result.success(draft.toRecord(id))
+                }
+            }
+        }
+        val repository = UploadingTripRecordRepository(uploader, delegate)
+
+        val result = repository.updateTripRecord(
+            id = 101,
+            draft = draftWithPhotos("다시 선택하지 않는 기록", listOf(byteArrayOf(0x01, 0x02))),
+        ).getOrThrow()
+
+        assertEquals(2, uploadAttempt)
+        assertEquals(2, savedDrafts.size)
+        assertEquals("travel-records/10/reissued-1.jpg", savedDrafts[0].mediaObjectKeys.single())
+        assertEquals("travel-records/10/reissued-2.jpg", savedDrafts[1].mediaObjectKeys.single())
+        assertEquals("travel-records/10/reissued-2.jpg", result.media.single().objectKey)
     }
 
     @Test
@@ -247,6 +288,15 @@ private fun indexedUploader(): PhotoUploader = PhotoUploader { sources ->
         },
     )
 }
+
+private fun invalidObjectKeyError(): MapmoryApiException = MapmoryApiException(
+    statusCode = 400,
+    code = "INVALID_OBJECT_KEY",
+    title = "Object Key가 올바르지 않습니다.",
+    detail = "중복되거나 다른 여행 일지에서 사용 중인 Object Key가 포함되어 있습니다.",
+    instance = "/api/v1/travel-records/101",
+    errors = emptyList(),
+)
 
 private fun draftWithPhotos(
     title: String,

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepositoryTest.kt
@@ -106,6 +106,43 @@ class UploadingTripRecordRepositoryTest {
     }
 
     @Test
+    fun missingLocalOriginalDoesNotExposeItsInternalIdentifier() = runBlocking {
+        val internalId = "content://media/external/images/media/12345"
+        val repository = UploadingTripRecordRepository(
+            uploader = indexedUploader(),
+            delegate = CapturingTripRecordRepository(),
+        )
+
+        val error = repository.updateTripRecord(
+            id = 101,
+            draft = TripRecordDraft(
+                locationId = 1,
+                title = "원본 없는 기록",
+                content = "",
+                startDate = "2026-08-26",
+                endDate = null,
+                mediaObjectKeys = listOf(internalId),
+                localMedia = listOf(
+                    TripRecordMediaDraft(
+                        objectKey = internalId,
+                        sortOrder = 0,
+                        previewBytes = byteArrayOf(0x01),
+                        originalBytes = null,
+                        fileName = "internal-file-name.jpg",
+                    ),
+                ),
+            ),
+        ).exceptionOrNull()
+
+        assertEquals(
+            "사진 원본을 불러오지 못했습니다. 사진을 삭제한 뒤 다시 추가해 주세요.",
+            error?.message,
+        )
+        assertFalse(error?.message.orEmpty().contains(internalId))
+        assertFalse(error?.message.orEmpty().contains("internal-file-name.jpg"))
+    }
+
+    @Test
     fun listCacheKeepsOnlyTheFirstPreviewAndNeverKeepsOriginalBytes() = runBlocking {
         val uploader = indexedUploader()
         val delegate = CapturingTripRecordRepository()

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepositoryTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/data/repository/UploadingTripRecordRepositoryTest.kt
@@ -15,12 +15,13 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class UploadingTripRecordRepositoryTest {
     @Test
     fun updateKeepsServerMediaAndUploadsOnlyNewLocalPhotosInOrder() = runBlocking {
-        val existingObjectKey = "travel-records/10/existing.jpg"
+        val existingObjectKey = "mapmory/travel-records/10/existing.jpg"
         val newObjectKey = "travel-records/10/new.jpg"
         val newBytes = byteArrayOf(0x01, 0x02)
         var uploadedSources: List<PhotoUploadSource> = emptyList()
@@ -40,6 +41,7 @@ class UploadingTripRecordRepositoryTest {
                 startDate = "2026-08-26",
                 endDate = null,
                 mediaObjectKeys = listOf(existingObjectKey, "content://photo/new"),
+                uploadedMediaObjectKeys = setOf(existingObjectKey),
                 localMedia = listOf(
                     TripRecordMediaDraft(
                         objectKey = existingObjectKey,
@@ -66,6 +68,41 @@ class UploadingTripRecordRepositoryTest {
         )
         assertContentEquals(byteArrayOf(0x0A), result.media[1].previewBytes)
         assertNull(result.media[1].originalBytes)
+    }
+
+    @Test
+    fun existingServerMediaIsRecognizedWithoutInterpretingItsObjectKey() = runBlocking {
+        val opaqueObjectKey = "production-prefix/member-media/existing.jpg"
+        var uploadCalled = false
+        val uploader = PhotoUploader {
+            uploadCalled = true
+            Result.success(emptyList())
+        }
+        val delegate = CapturingTripRecordRepository()
+        val repository = UploadingTripRecordRepository(uploader, delegate)
+
+        repository.updateTripRecord(
+            id = 101,
+            draft = TripRecordDraft(
+                locationId = 1,
+                title = "기존 사진 기록",
+                content = "",
+                startDate = "2026-08-26",
+                endDate = null,
+                mediaObjectKeys = listOf(opaqueObjectKey),
+                uploadedMediaObjectKeys = setOf(opaqueObjectKey),
+                localMedia = listOf(
+                    TripRecordMediaDraft(
+                        objectKey = opaqueObjectKey,
+                        sortOrder = 0,
+                        previewBytes = null,
+                    ),
+                ),
+            ),
+        ).getOrThrow()
+
+        assertFalse(uploadCalled)
+        assertEquals(listOf(opaqueObjectKey), delegate.updatedDraft?.mediaObjectKeys)
     }
 
     @Test

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationPagingTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/photo/PhotoRecommendationPagingTest.kt
@@ -28,6 +28,28 @@ class PhotoRecommendationPagingTest {
         assertEquals(2, third.pageIndex)
         assertFalse(third.hasMore)
         assertEquals(50, third.photos.map(SelectedPhoto::id).toSet().size)
+        assertEquals(10, third.selectedIds.size)
+    }
+
+    @Test
+    fun `추천_사진은_남은_자리보다_많이_선택할_수_없다`() {
+        val initial = PhotoRecommendationPagingState(maxSelectionCount = 3)
+            .accept(
+                PhotoRecommendationPage(
+                    generation = 1,
+                    photos = (1..5).map(::photo),
+                    hasMore = false,
+                ),
+            )
+
+        assertNotNull(initial)
+        assertEquals(setOf("1", "2", "3"), initial.selectedIds)
+        assertEquals(initial, initial.toggleSelection("4"))
+
+        val replaced = initial
+            .toggleSelection("1")
+            .toggleSelection("4")
+        assertEquals(setOf("2", "3", "4"), replaced.selectedIds)
     }
 
     @Test

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModelTest.kt
@@ -7,6 +7,8 @@ import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.domain.model.TripRecordData
 import com.mapmory.shared.domain.model.TripRecordDraft
+import com.mapmory.shared.domain.model.TripRecordMedia
+import com.mapmory.shared.domain.model.TripRecordPhotoRules
 import com.mapmory.shared.domain.model.TripRecordQuery
 import com.mapmory.shared.domain.repository.TripRecordRepository
 import com.mapmory.shared.domain.usecase.CreateTripRecordUseCase
@@ -14,6 +16,7 @@ import com.mapmory.shared.domain.usecase.CreateTagUseCase
 import com.mapmory.shared.domain.usecase.GetTripRecordsUseCase
 import com.mapmory.shared.domain.usecase.GetTagsUseCase
 import com.mapmory.shared.domain.usecase.UpdateTripRecordUseCase
+import com.mapmory.shared.presentation.photo.SelectedPhoto
 import com.mapmory.shared.presentation.triprecord.state.TripRecordEditorErrorTarget
 import com.mapmory.shared.runSuspend
 import kotlin.test.Test
@@ -240,6 +243,58 @@ class TripRecordEditorViewModelTest {
     }
 
     @Test
+    fun `기록_수정에서는_기존_사진을_포함해_최대_10장만_추가한다`() {
+        val repository = FakeTripRecordRepository { "2026-08-07T00:00:00Z" }
+        val viewModel = TripRecordEditorViewModel(
+            createTripRecord = CreateTripRecordUseCase(repository),
+            updateTripRecord = UpdateTripRecordUseCase(repository),
+        )
+        val location = Location(101, 1, 1, "11680", "강남구", LocationType.DISTRICT)
+        viewModel.startEditing(
+            record = TripRecordData(
+                id = 1,
+                locationId = location.id,
+                title = "서울 여행",
+                content = "",
+                startDate = "2026-08-01",
+                endDate = null,
+                media = (1..9).map { index ->
+                    TripRecordMedia(
+                        id = index.toLong(),
+                        objectKey = "records/1/existing-$index.jpg",
+                        sortOrder = index - 1,
+                        url = null,
+                    )
+                },
+                createdAt = "2026-08-01T00:00:00Z",
+                updatedAt = "2026-08-01T00:00:00Z",
+            ),
+            location = location,
+        )
+
+        viewModel.addPhotos(
+            listOf(
+                selectedPhoto("content://new/1"),
+                selectedPhoto("content://new/2"),
+            ),
+        )
+
+        assertEquals(TripRecordPhotoRules.MaxPhotosPerRecord, viewModel.uiState.selectedPhotos.size)
+        assertEquals(
+            TripRecordPhotoRules.LimitMessage,
+            viewModel.uiState.fieldErrors[TripRecordEditorErrorTarget.PHOTOS],
+        )
+        assertTrue(viewModel.uiState.selectedPhotos.any { photo -> photo.id == "content://new/1" })
+        assertTrue(viewModel.uiState.selectedPhotos.none { photo -> photo.id == "content://new/2" })
+
+        viewModel.removeMediaObjectKey("records/1/existing-1.jpg")
+        viewModel.addPhotos(listOf(selectedPhoto("content://new/2")))
+
+        assertEquals(TripRecordPhotoRules.MaxPhotosPerRecord, viewModel.uiState.selectedPhotos.size)
+        assertNull(viewModel.uiState.fieldErrors[TripRecordEditorErrorTarget.PHOTOS])
+    }
+
+    @Test
     fun `사진_업로드_제한_오류는_사진_컴포넌트의_오류로_분류한다`() {
         val error = MapmoryApiException(
             statusCode = 400,
@@ -317,3 +372,10 @@ class TripRecordEditorViewModelTest {
         )
     }
 }
+
+private fun selectedPhoto(id: String): SelectedPhoto = SelectedPhoto(
+    id = id,
+    displayName = id.substringAfterLast('/'),
+    previewBytes = null,
+    originalBytes = byteArrayOf(0x01),
+)

--- a/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModelTest.kt
+++ b/client/shared/src/commonTest/kotlin/com/mapmory/shared/presentation/triprecord/viewmodel/TripRecordEditorViewModelTest.kt
@@ -1,9 +1,14 @@
 package com.mapmory.shared.presentation.triprecord.viewmodel
 
+import com.mapmory.shared.data.remote.MapmoryApiException
+import com.mapmory.shared.data.remote.model.ProblemFieldErrorDto
 import com.mapmory.shared.data.repository.FakeTripRecordRepository
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
+import com.mapmory.shared.domain.model.TripRecordData
+import com.mapmory.shared.domain.model.TripRecordDraft
 import com.mapmory.shared.domain.model.TripRecordQuery
+import com.mapmory.shared.domain.repository.TripRecordRepository
 import com.mapmory.shared.domain.usecase.CreateTripRecordUseCase
 import com.mapmory.shared.domain.usecase.CreateTagUseCase
 import com.mapmory.shared.domain.usecase.GetTripRecordsUseCase
@@ -232,5 +237,83 @@ class TripRecordEditorViewModelTest {
         viewModel.removeMediaObjectKey("records/1/photo.jpg")
 
         assertTrue(viewModel.uiState.mediaObjectKeys.isEmpty())
+    }
+
+    @Test
+    fun `사진_업로드_제한_오류는_사진_컴포넌트의_오류로_분류한다`() {
+        val error = MapmoryApiException(
+            statusCode = 400,
+            code = "TOO_MANY_FILES",
+            title = "파일 개수가 너무 많습니다.",
+            detail = "한 번에 업로드할 수 있는 최대 파일 개수를 초과했습니다.",
+            instance = "/api/v1/uploads/presigned-urls",
+            errors = emptyList(),
+        )
+
+        assertEquals(
+            mapOf(
+                TripRecordEditorErrorTarget.PHOTOS to
+                    "한 번에 업로드할 수 있는 최대 파일 개수를 초과했습니다.",
+            ),
+            error.toEditorFieldErrors(),
+        )
+    }
+
+    @Test
+    fun `사진_업로드_실패는_폼_하단이_아니라_사진_필드에_저장한다`() = runSuspend {
+        val error = MapmoryApiException(
+            statusCode = 400,
+            code = "TOO_MANY_FILES",
+            title = "파일 개수가 너무 많습니다.",
+            detail = "한 번에 업로드할 수 있는 최대 파일 개수를 초과했습니다.",
+            instance = "/api/v1/uploads/presigned-urls",
+            errors = emptyList(),
+        )
+        val delegate = FakeTripRecordRepository { "2026-08-31T00:00:00Z" }
+        val repository = object : TripRecordRepository by delegate {
+            override suspend fun createTripRecord(draft: TripRecordDraft): Result<TripRecordData> =
+                Result.failure(error)
+        }
+        val viewModel = TripRecordEditorViewModel(
+            createTripRecord = CreateTripRecordUseCase(repository),
+            updateTripRecord = UpdateTripRecordUseCase(repository),
+        )
+        viewModel.selectLocation(Location(101, 1, 1, "11680", "강남구", LocationType.DISTRICT))
+        viewModel.updateTitle("서울 여행")
+        viewModel.updateStartDate("2026-08-31")
+
+        assertFalse(viewModel.save())
+        assertEquals(
+            "한 번에 업로드할 수 있는 최대 파일 개수를 초과했습니다.",
+            viewModel.uiState.fieldErrors[TripRecordEditorErrorTarget.PHOTOS],
+        )
+        assertNull(viewModel.uiState.generalErrorMessage)
+    }
+
+    @Test
+    fun `서버의_필드_오류는_각_입력_컴포넌트의_오류로_분류한다`() {
+        val error = MapmoryApiException(
+            statusCode = 400,
+            code = "VALIDATION_ERROR",
+            title = "요청 값이 올바르지 않습니다.",
+            detail = null,
+            instance = "/api/v1/travel-records",
+            errors = listOf(
+                ProblemFieldErrorDto("title", "제목을 확인해 주세요."),
+                ProblemFieldErrorDto("content", "내용을 확인해 주세요."),
+                ProblemFieldErrorDto("files[0].fileSize", "사진 크기를 확인해 주세요."),
+                ProblemFieldErrorDto("tagIds", "태그를 확인해 주세요."),
+            ),
+        )
+
+        assertEquals(
+            mapOf(
+                TripRecordEditorErrorTarget.TITLE to "제목을 확인해 주세요.",
+                TripRecordEditorErrorTarget.CONTENT to "내용을 확인해 주세요.",
+                TripRecordEditorErrorTarget.PHOTOS to "사진 크기를 확인해 주세요.",
+                TripRecordEditorErrorTarget.TAGS to "태그를 확인해 주세요.",
+            ),
+            error.toEditorFieldErrors(),
+        )
     }
 }


### PR DESCRIPTION
## 요약

- 기록 수정 시 기존 서버 사진을 보존하고 새 사진만 업로드하며, 잘못된 object key는 새 키를 받아 한 번 자동 재시도합니다.
- 네트워크·API 오류를 사용자 안내 문구로 변환하고 각 오류를 해당 입력 컴포넌트 아래에 표시합니다.
- 기록 사진을 기존 사진 포함 최대 10장으로 제한하고, 위치 기반 추천도 남은 자리만큼만 선택할 수 있게 했습니다.
- 지도 태그 간격을 조정하고 지도와 동일한 기록 추가 버튼을 일지 화면에도 배치했습니다.

## 배경

기록 수정 시 서버 사진을 로컬 원본처럼 다시 읽으면서 저장이 막히고, 기술적인 네트워크 오류와 사진 오류가 폼의 서로 다른 위치에 노출되고 있었습니다. 또한 클라이언트에서 사진 10장 제한이 일관되게 적용되지 않았고, 일지 화면에는 빠른 기록 추가 동선이 없었습니다.

## 주요 결정

- 기존 서버 사진은 명시적인 업로드 완료 키 집합으로 구분해 재업로드하지 않습니다.
- 새 사진의 INVALID_OBJECT_KEY 오류에만 로컬 원본으로 새 업로드 키를 발급받아 최대 한 번 재시도합니다.
- 사진 최대 개수 규칙을 공통화하고 편집 병합, 저장 전 검증, 위치 추천 선택에 동일하게 적용합니다.
- 지도 화면의 추가 버튼을 공용 컴포넌트로 추출해 일지 화면과 크기·여백·스타일을 공유합니다.
- 모든 변경은 client 디렉터리에만 포함했습니다.

## 한계

- 로컬 원본 자체를 읽을 수 없는 사진은 자동 재업로드할 수 없어 잠시 후 다시 저장하도록 안내합니다.
- Android 계측 테스트 APK는 빌드했지만 연결된 기기나 에뮬레이터가 없어 실제 계측 실행은 하지 못했습니다.

## 확인

- [x] 로컬에서 실행 확인
- [x] shared 전체 테스트 통과 (Android, iOS Simulator, JVM)
- [x] Android debug 앱 및 UI 테스트 APK 빌드 통과
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 새 환경변수 없음
- [x] DB 스키마 변경 없음
- [x] 실행 방법이나 환경 설정 변경 없음