### PR TITLE
fix: 사진 추천 권한 설정 안내 개선

### DIFF
--- a/client/androidApp/src/androidTest/java/com/mapmory/android/PhotoRecommendationFlowTest.kt
+++ b/client/androidApp/src/androidTest/java/com/mapmory/android/PhotoRecommendationFlowTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.performScrollToIndex
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.photo.PhotoLibraryActions
+import com.mapmory.shared.presentation.photo.PhotoLibraryPermissionIssue
 import com.mapmory.shared.presentation.photo.PhotoRecommendationPage
 import com.mapmory.shared.presentation.photo.SelectedPhoto
 import com.mapmory.shared.presentation.triprecord.screen.TripRecordEditorScreen
@@ -58,7 +59,7 @@ class PhotoRecommendationFlowTest {
                 onPhotosAdded = { photos -> addedPhotos = photos },
                 onSaveClick = {},
                 onBackClick = {},
-                photoLibraryActionsFactory = { _, onRecommended, _, _, _, _ ->
+                photoLibraryActionsFactory = { _, onRecommended, _, _, _, _, _ ->
                     PhotoLibraryActions(
                         pickFromGallery = {},
                         recommendForLocation = { location, parentName ->
@@ -88,7 +89,7 @@ class PhotoRecommendationFlowTest {
             )
         }
 
-        composeRule.onNodeWithText("위치 기반 사진\n불러오기").performClick()
+        composeRule.onNodeWithText("이 장소 사진\n찾기").performClick()
 
         composeRule.onNodeWithText("이 장소에서 찍은 사진").assertIsDisplayed()
         composeRule.runOnIdle {
@@ -127,7 +128,7 @@ class PhotoRecommendationFlowTest {
                 onEndDateChanged = {},
                 onSaveClick = {},
                 onBackClick = {},
-                photoLibraryActionsFactory = { _, onRecommended, _, _, _, _ ->
+                photoLibraryActionsFactory = { _, onRecommended, _, _, _, _, _ ->
                     PhotoLibraryActions(
                         pickFromGallery = {},
                         recommendForLocation = { _, _ ->
@@ -144,7 +145,7 @@ class PhotoRecommendationFlowTest {
             )
         }
 
-        composeRule.onNodeWithText("위치 기반 사진\n불러오기").performClick()
+        composeRule.onNodeWithText("이 장소 사진\n찾기").performClick()
         composeRule.onNodeWithTag("photo-recommendation-grid").assertIsDisplayed()
 
         val first = composeRule
@@ -190,7 +191,7 @@ class PhotoRecommendationFlowTest {
                 onEndDateChanged = {},
                 onSaveClick = {},
                 onBackClick = {},
-                photoLibraryActionsFactory = { _, onRecommended, _, _, _, _ ->
+                photoLibraryActionsFactory = { _, onRecommended, _, _, _, _, _ ->
                     PhotoLibraryActions(
                         pickFromGallery = {},
                         recommendForLocation = { _, _ ->
@@ -217,13 +218,52 @@ class PhotoRecommendationFlowTest {
             )
         }
 
-        composeRule.onNodeWithText("위치 기반 사진\n불러오기").performClick()
+        composeRule.onNodeWithText("이 장소 사진\n찾기").performClick()
         val grid = composeRule.onNodeWithTag("photo-recommendation-grid")
         grid.performScrollToIndex(23)
 
         composeRule.runOnIdle { assertEquals(1, nextPageCalls) }
         grid.performScrollToIndex(24)
         composeRule.onNodeWithTag("photo-recommendation-item-photo-25").assertIsDisplayed()
+    }
+
+    @Test
+    fun `사진_접근이_제한되면_설정_이동과_나가기를_안내한다`() {
+        val seoul = province()
+        val gangnam = district(parentId = seoul.id)
+        var settingsOpenCalls = 0
+
+        composeRule.setContent {
+            TripRecordEditorScreen(
+                uiState = TripRecordEditorUiState(selectedLocation = gangnam),
+                locations = listOf(seoul, gangnam),
+                onLocationSelected = {},
+                onTitleChanged = {},
+                onContentChanged = {},
+                onStartDateChanged = {},
+                onEndDateChanged = {},
+                onSaveClick = {},
+                onBackClick = {},
+                photoLibraryActionsFactory = { _, _, _, _, _, _, onPermissionRequired ->
+                    PhotoLibraryActions(
+                        pickFromGallery = {},
+                        recommendForLocation = { _, _ ->
+                            onPermissionRequired(PhotoLibraryPermissionIssue.LIMITED)
+                        },
+                        openAppSettings = { settingsOpenCalls += 1 },
+                    )
+                },
+            )
+        }
+
+        composeRule.onNodeWithText("이 장소 사진\n찾기").performClick()
+        composeRule.onNodeWithText("사진 전체 접근이 필요해요").assertIsDisplayed()
+        composeRule.onNodeWithText("설정으로 이동").assertIsDisplayed()
+        composeRule.onNodeWithText("나가기").performClick()
+
+        composeRule.onNodeWithText("이 장소 사진\n찾기").performClick()
+        composeRule.onNodeWithText("설정으로 이동").performClick()
+        composeRule.runOnIdle { assertEquals(1, settingsOpenCalls) }
     }
 
     @Test
@@ -241,7 +281,7 @@ class PhotoRecommendationFlowTest {
                 onEndDateChanged = {},
                 onSaveClick = {},
                 onBackClick = {},
-                photoLibraryActionsFactory = { _, _, _, _, _, _ ->
+                photoLibraryActionsFactory = { _, _, _, _, _, _, _ ->
                     PhotoLibraryActions(
                         pickFromGallery = {},
                         recommendForLocation = { _, _ -> recommendationCalls += 1 },
@@ -250,7 +290,7 @@ class PhotoRecommendationFlowTest {
             )
         }
 
-        composeRule.onNodeWithText("위치 기반 사진\n불러오기").performClick()
+        composeRule.onNodeWithText("이 장소 사진\n찾기").performClick()
 
         composeRule.onNodeWithText("사진을 추천받으려면 장소를 먼저 선택해 주세요.")
             .assertIsDisplayed()
@@ -274,7 +314,7 @@ class PhotoRecommendationFlowTest {
                 onEndDateChanged = {},
                 onSaveClick = {},
                 onBackClick = {},
-                photoLibraryActionsFactory = { _, _, _, _, _, _ ->
+                photoLibraryActionsFactory = { _, _, _, _, _, _, _ ->
                     PhotoLibraryActions(
                         pickFromGallery = {},
                         recommendForLocation = { _, _ -> },
@@ -307,7 +347,7 @@ class PhotoRecommendationFlowTest {
                 onEndDateChanged = {},
                 onSaveClick = {},
                 onBackClick = {},
-                photoLibraryActionsFactory = { _, _, _, _, _, _ ->
+                photoLibraryActionsFactory = { _, _, _, _, _, _, _ ->
                     PhotoLibraryActions(
                         pickFromGallery = {},
                         recommendForLocation = { _, _ -> },
@@ -317,7 +357,7 @@ class PhotoRecommendationFlowTest {
         }
 
         composeRule.onNodeWithText("사진첩").assertIsDisplayed()
-        composeRule.onNodeWithText("위치 기반 사진\n불러오기").assertIsDisplayed()
+        composeRule.onNodeWithText("이 장소 사진\n찾기").assertIsDisplayed()
         assertTrue(composeRule.onAllNodesWithText("불러오는 중").fetchSemanticsNodes().isEmpty())
     }
 
@@ -342,7 +382,7 @@ class PhotoRecommendationFlowTest {
                 onEndDateChanged = {},
                 onSaveClick = {},
                 onBackClick = {},
-                photoLibraryActionsFactory = { _, _, _, _, _, recommendationLoadingChanged ->
+                photoLibraryActionsFactory = { _, _, _, _, _, recommendationLoadingChanged, _ ->
                     onRecommendationLoadingChanged = recommendationLoadingChanged
                     PhotoLibraryActions(
                         pickFromGallery = {},

--- a/client/iosApp/Info.plist
+++ b/client/iosApp/Info.plist
@@ -31,7 +31,7 @@
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>촬영한 여행 사진을 사진 보관함에 저장하기 위해 접근합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>여행 기록에 첨부할 사진을 찾기 위해 사진 보관함에 접근합니다.</string>
+	<string>여행 장소에서 찍은 사진을 찾고 기록에 추가하기 위해 사진 보관함에 접근합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
+++ b/client/shared/src/androidMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.android.kt
@@ -3,6 +3,7 @@ package com.mapmory.shared.presentation.photo
 import android.Manifest
 import android.content.ContentUris
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
 import android.graphics.Bitmap
@@ -14,6 +15,7 @@ import android.os.Build
 import android.os.SystemClock
 import android.os.Trace
 import android.provider.MediaStore
+import android.provider.Settings
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -53,6 +55,7 @@ actual fun rememberPhotoLibraryActions(
     onLoadingChanged: (Boolean) -> Unit,
     onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
     onRecommendationLoadingChanged: (Boolean) -> Unit,
+    onPermissionRequired: (PhotoLibraryPermissionIssue) -> Unit,
 ): PhotoLibraryActions {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -62,6 +65,7 @@ actual fun rememberPhotoLibraryActions(
     val latestLoadingChanged by rememberUpdatedState(onLoadingChanged)
     val latestLoadingProgressChanged by rememberUpdatedState(onLoadingProgressChanged)
     val latestRecommendationLoadingChanged by rememberUpdatedState(onRecommendationLoadingChanged)
+    val latestPermissionRequired by rememberUpdatedState(onPermissionRequired)
     var pendingRecommendation by remember { mutableStateOf<Pair<Location, String?>?>(null) }
     val recommendationJob = remember { mutableStateOf<Job?>(null) }
     val recommendationGeneration = remember { mutableStateOf(0) }
@@ -159,14 +163,26 @@ actual fun rememberPhotoLibraryActions(
         val hasGalleryAccess = context.canReadGallery()
         val canRecommend = context.canRecommendPhotos()
         val target = pendingRecommendation
-        pendingRecommendation = null
         when {
             target == null -> Unit
             !context.hasFullGalleryAccess() && hasGalleryAccess -> {
-                latestMessage(FullGalleryAccessMessage)
+                latestPermissionRequired(PhotoLibraryPermissionIssue.LIMITED)
             }
-            canRecommend -> loadRecommendations(target.first, target.second)
-            else -> latestMessage("장소 기반 추천을 사용하려면 사진 접근을 허용해 주세요.")
+            canRecommend -> {
+                pendingRecommendation = null
+                loadRecommendations(target.first, target.second)
+            }
+            else -> latestPermissionRequired(PhotoLibraryPermissionIssue.DENIED)
+        }
+    }
+
+    val settingsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) {
+        val target = pendingRecommendation
+        if (target != null && context.canRecommendPhotos()) {
+            pendingRecommendation = null
+            loadRecommendations(target.first, target.second)
         }
     }
 
@@ -207,7 +223,7 @@ actual fun rememberPhotoLibraryActions(
         }
     }
 
-    return remember(context, galleryPicker, galleryPermissionLauncher) {
+    return remember(context, galleryPicker, galleryPermissionLauncher, settingsLauncher) {
         PhotoLibraryActions(
             pickFromGallery = {
                 latestLoadingChanged(true)
@@ -230,8 +246,10 @@ actual fun rememberPhotoLibraryActions(
             },
             recommendForLocation = { location, parentName ->
                 if (!context.hasFullGalleryAccess() && context.canReadGallery()) {
-                    latestMessage(FullGalleryAccessMessage)
+                    pendingRecommendation = location to parentName
+                    latestPermissionRequired(PhotoLibraryPermissionIssue.LIMITED)
                 } else if (context.canRecommendPhotos()) {
+                    pendingRecommendation = null
                     loadRecommendations(location, parentName)
                 } else {
                     pendingRecommendation = location to parentName
@@ -239,6 +257,14 @@ actual fun rememberPhotoLibraryActions(
                 }
             },
             cancelRecommendation = ::cancelRecommendations,
+            openAppSettings = {
+                settingsLauncher.launch(
+                    Intent(
+                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                        Uri.parse("package:${context.packageName}"),
+                    ),
+                )
+            },
         )
     }
 }
@@ -734,9 +760,6 @@ private const val PreviewSizePx = 1280
 private const val PreviewJpegQuality = 85
 private const val OriginalJpegQuality = 100
 private const val PhotoPerformanceTag = "MapmoryPhotoPerf"
-private const val FullGalleryAccessMessage =
-    "위치 기반 사진 추천을 사용하려면 전체 갤러리 접근 권한을 허용해 주세요."
-
 private object TraceCookie {
     const val Recommend = 1
     const val RoomRead = 2

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.kt
@@ -28,6 +28,12 @@ data class PhotoRecommendationPage(
     val hasMore: Boolean,
 )
 
+enum class PhotoLibraryPermissionIssue {
+    LIMITED,
+    DENIED,
+    RESTRICTED,
+}
+
 data class PhotoLibraryActions(
     val pickFromGallery: () -> Unit,
     val recommendForLocation: (Location, String?) -> Unit,
@@ -38,6 +44,7 @@ data class PhotoLibraryActions(
     ) -> Unit = { photos, onReady -> onReady(photos) },
     val recommendationsAvailable: Boolean = true,
     val cancelRecommendation: () -> Unit = {},
+    val openAppSettings: () -> Unit = {},
 )
 
 typealias PhotoLibraryActionsFactory = @Composable (
@@ -47,6 +54,7 @@ typealias PhotoLibraryActionsFactory = @Composable (
     onLoadingChanged: (Boolean) -> Unit,
     onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
     onRecommendationLoadingChanged: (Boolean) -> Unit,
+    onPermissionRequired: (PhotoLibraryPermissionIssue) -> Unit,
 ) -> PhotoLibraryActions
 
 @Composable
@@ -57,6 +65,7 @@ expect fun rememberPhotoLibraryActions(
     onLoadingChanged: (Boolean) -> Unit,
     onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
     onRecommendationLoadingChanged: (Boolean) -> Unit,
+    onPermissionRequired: (PhotoLibraryPermissionIssue) -> Unit,
 ): PhotoLibraryActions
 
 internal fun mergeSelectedPhotos(

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/triprecord/screen/TripRecordEditorScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -75,6 +76,7 @@ import com.mapmory.shared.analytics.MapmoryAnalyticsEvent
 import com.mapmory.shared.domain.model.Location
 import com.mapmory.shared.domain.model.LocationType
 import com.mapmory.shared.presentation.photo.PhotoLibraryActionsFactory
+import com.mapmory.shared.presentation.photo.PhotoLibraryPermissionIssue
 import com.mapmory.shared.presentation.photo.PhotoLoadingProgress
 import com.mapmory.shared.presentation.photo.PhotoRecommendationPagingState
 import com.mapmory.shared.presentation.photo.RecommendationLoadKey
@@ -148,6 +150,7 @@ fun TripRecordEditorScreen(
             onLoadingChanged,
             onLoadingProgressChanged,
             onRecommendationLoadingChanged,
+            onPermissionRequired,
         ->
             rememberPhotoLibraryActions(
                 onPicked,
@@ -156,6 +159,7 @@ fun TripRecordEditorScreen(
                 onLoadingChanged,
                 onLoadingProgressChanged,
                 onRecommendationLoadingChanged,
+                onPermissionRequired,
             )
         },
     modifier: Modifier = Modifier,
@@ -173,6 +177,7 @@ fun TripRecordEditorScreen(
     var isPreparingRecommendationPhotos by remember { mutableStateOf(false) }
     var isRecommendationLoading by remember { mutableStateOf(false) }
     var photoLoadingProgress by remember { mutableStateOf<PhotoLoadingProgress?>(null) }
+    var photoPermissionIssue by remember { mutableStateOf<PhotoLibraryPermissionIssue?>(null) }
     var datePickerTarget by rememberSaveable { mutableStateOf<String?>(null) }
     val dismissKeyboardOnTap = rememberDismissKeyboardOnTapModifier()
     val photoLibrary = photoLibraryActionsFactory(
@@ -204,6 +209,10 @@ fun TripRecordEditorScreen(
         },
         { progress -> photoLoadingProgress = progress },
         { isLoading -> isRecommendationLoading = isLoading },
+        { issue ->
+            photoMessage = null
+            photoPermissionIssue = issue
+        },
     )
     val locationResultsListState = rememberLazyListState()
     val recommendationGridState = rememberLazyGridState()
@@ -300,7 +309,7 @@ fun TripRecordEditorScreen(
                                             MapmoryAnalyticsEvent.PHOTO_RECOMMENDATION_STARTED,
                                             mapOf("location_type" to selectedLocation.type.name.lowercase()),
                                         )
-                                        photoMessage = "${selectedLocation.name}에서 촬영된 사진을 찾고 있어요."
+                                        photoMessage = "${selectedLocation.name}에서 찍은 사진을 찾고 있어요."
                                         recommendationPagingState = PhotoRecommendationPagingState()
                                         lastAutoLoadTriggerKey = null
                                         showRecommendationSheet = false
@@ -508,7 +517,7 @@ fun TripRecordEditorScreen(
             ) {
                 Text("이 장소에서 찍은 사진", fontSize = 22.sp, fontWeight = FontWeight.Bold)
                 Text(
-                    "사진의 EXIF GPS가 선택한 행정구역과 일치하는 결과예요.",
+                    "사진에 저장된 촬영 위치를 기준으로 찾았어요.",
                     color = TripRecordPalette.current.muted,
                     fontSize = 12.sp,
                     modifier = Modifier.padding(top = 6.dp),
@@ -598,6 +607,17 @@ fun TripRecordEditorScreen(
                 Spacer(Modifier.height(12.dp))
             }
         }
+    }
+
+    photoPermissionIssue?.let { issue ->
+        PhotoPermissionDialog(
+            issue = issue,
+            onOpenSettings = {
+                photoPermissionIssue = null
+                photoLibrary.openAppSettings()
+            },
+            onExit = { photoPermissionIssue = null },
+        )
     }
 
     val activeDatePickerTarget = datePickerTarget
@@ -722,7 +742,7 @@ private fun PhotoSection(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "$locationName · 여행 일정과 가까운 사진",
+                text = "${locationName}에서 찍은 사진을 찾아드려요",
                 color = TripRecordPalette.current.text,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.SemiBold,
@@ -765,7 +785,7 @@ private fun PhotoSection(
                     }
                 } else {
                     Text(
-                        text = "위치 기반 사진\n불러오기",
+                        text = "이 장소 사진\n찾기",
                         color = TripRecordPalette.current.photoRecommendText,
                         fontSize = 9.sp,
                         lineHeight = 11.sp,
@@ -781,6 +801,46 @@ private fun PhotoSection(
             modifier = Modifier.padding(top = 12.dp, bottom = 16.dp),
         )
     }
+}
+
+@Composable
+private fun PhotoPermissionDialog(
+    issue: PhotoLibraryPermissionIssue,
+    onOpenSettings: () -> Unit,
+    onExit: () -> Unit,
+) {
+    val isRestricted = issue == PhotoLibraryPermissionIssue.RESTRICTED
+    AlertDialog(
+        onDismissRequest = onExit,
+        shape = RoundedCornerShape(20.dp),
+        containerColor = TripRecordPalette.current.surface,
+        titleContentColor = TripRecordPalette.current.text,
+        textContentColor = TripRecordPalette.current.bodyText,
+        title = {
+            Text(if (isRestricted) "사진 접근이 제한되어 있어요" else "사진 전체 접근이 필요해요")
+        },
+        text = {
+            Text(
+                if (isRestricted) {
+                    "기기 설정으로 사진 접근이 제한되어 있어요."
+                } else {
+                    "이 장소의 사진을 찾으려면 설정에서 사진 접근을 전체 허용해 주세요."
+                },
+            )
+        },
+        confirmButton = {
+            if (!isRestricted) {
+                TextButton(onClick = onOpenSettings) {
+                    Text("설정으로 이동", color = TripRecordPalette.current.accent)
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onExit) {
+                Text("나가기", color = TripRecordPalette.current.muted)
+            }
+        },
+    )
 }
 
 @Composable

--- a/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
+++ b/client/shared/src/iosMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.ios.kt
@@ -6,6 +6,7 @@
 package com.mapmory.shared.presentation.photo
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.mapmory.shared.domain.model.Location
@@ -21,6 +22,8 @@ import platform.Foundation.NSData
 import platform.Foundation.NSDate
 import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSLog
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSURL
 import platform.Foundation.getBytes
 import platform.Foundation.NSSortDescriptor
 import platform.ImageIO.CGImageSourceCreateThumbnailAtIndex
@@ -51,6 +54,8 @@ import platform.PhotosUI.PHPickerResult
 import platform.PhotosUI.PHPickerViewController
 import platform.PhotosUI.PHPickerViewControllerDelegateProtocol
 import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationDidBecomeActiveNotification
+import platform.UIKit.UIApplicationOpenSettingsURLString
 import platform.UIKit.UIImage
 import platform.UIKit.UIImageJPEGRepresentation
 import platform.UIKit.UIViewController
@@ -74,6 +79,7 @@ actual fun rememberPhotoLibraryActions(
     onLoadingChanged: (Boolean) -> Unit,
     @Suppress("UNUSED_PARAMETER") onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
     onRecommendationLoadingChanged: (Boolean) -> Unit,
+    onPermissionRequired: (PhotoLibraryPermissionIssue) -> Unit,
 ): PhotoLibraryActions {
     val scope = rememberCoroutineScope()
     val controller = remember(scope) { IosPhotoLibraryController(scope) }
@@ -82,6 +88,11 @@ actual fun rememberPhotoLibraryActions(
     controller.onMessage = onMessage
     controller.onLoadingChanged = onLoadingChanged
     controller.onRecommendationLoadingChanged = onRecommendationLoadingChanged
+    controller.onPermissionRequired = onPermissionRequired
+    DisposableEffect(controller) {
+        controller.startObservingAppActivity()
+        onDispose { controller.stopObservingAppActivity() }
+    }
 
     return remember(controller) {
         PhotoLibraryActions(
@@ -90,6 +101,7 @@ actual fun rememberPhotoLibraryActions(
             loadNextRecommendationPage = controller::loadNextRecommendationPage,
             prepareForAdding = controller::prepareForAdding,
             cancelRecommendation = controller::cancelRecommendation,
+            openAppSettings = controller::openAppSettings,
         )
     }
 }
@@ -124,10 +136,13 @@ private class IosPhotoLibraryController(
     var onMessage: (String) -> Unit = {}
     var onLoadingChanged: (Boolean) -> Unit = {}
     var onRecommendationLoadingChanged: (Boolean) -> Unit = {}
+    var onPermissionRequired: (PhotoLibraryPermissionIssue) -> Unit = {}
     private var recommendationJob: Job? = null
     private var recommendationGeneration = 0
     private var recommendationSession: IosRecommendationSession? = null
     private var isRecommendationPageLoading = false
+    private var pendingRecommendation: Location? = null
+    private var appActiveObserver: Any? = null
 
     private var pickerStartedAtMillis: Long? = null
 
@@ -189,22 +204,73 @@ private class IosPhotoLibraryController(
         val status = PHPhotoLibrary.authorizationStatusForAccessLevel(PHAccessLevelReadWrite)
         when (status) {
             PHAuthorizationStatusAuthorized -> {
+                pendingRecommendation = null
                 findRecommendations(location)
             }
-            PHAuthorizationStatusLimited -> onMessage(FullGalleryAccessMessage)
+            PHAuthorizationStatusLimited -> {
+                pendingRecommendation = location
+                onPermissionRequired(PhotoLibraryPermissionIssue.LIMITED)
+            }
             PHAuthorizationStatusNotDetermined -> {
                 PHPhotoLibrary.requestAuthorizationForAccessLevel(PHAccessLevelReadWrite) { newStatus ->
                     onMain {
                         when (newStatus) {
-                            PHAuthorizationStatusAuthorized -> findRecommendations(location)
-                            PHAuthorizationStatusLimited -> onMessage(FullGalleryAccessMessage)
-                            else -> onMessage("장소 기반 추천을 사용하려면 사진 접근을 허용해 주세요.")
+                            PHAuthorizationStatusAuthorized -> {
+                                pendingRecommendation = null
+                                findRecommendations(location)
+                            }
+                            PHAuthorizationStatusLimited -> {
+                                pendingRecommendation = location
+                                onPermissionRequired(PhotoLibraryPermissionIssue.LIMITED)
+                            }
+                            else -> {
+                                pendingRecommendation = location
+                                onPermissionRequired(newStatus.toPermissionIssue())
+                            }
                         }
                     }
                 }
             }
-            else -> onMessage("장소 기반 추천을 사용하려면 설정에서 사진 접근을 허용해 주세요.")
+            else -> {
+                pendingRecommendation = location
+                onPermissionRequired(status.toPermissionIssue())
+            }
         }
+    }
+
+    fun openAppSettings() {
+        val settingsUrl = NSURL.URLWithString(UIApplicationOpenSettingsURLString) ?: return
+        UIApplication.sharedApplication.openURL(
+            url = settingsUrl,
+            options = emptyMap<Any?, Any>(),
+            completionHandler = { opened ->
+                if (!opened) onMessage("설정 화면을 열지 못했어요.")
+            },
+        )
+    }
+
+    fun startObservingAppActivity() {
+        if (appActiveObserver != null) return
+        appActiveObserver = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIApplicationDidBecomeActiveNotification,
+            `object` = null,
+            queue = null,
+        ) {
+            val target = pendingRecommendation
+            if (
+                target != null &&
+                PHPhotoLibrary.authorizationStatusForAccessLevel(PHAccessLevelReadWrite) ==
+                PHAuthorizationStatusAuthorized
+            ) {
+                pendingRecommendation = null
+                findRecommendations(target)
+            }
+        }
+    }
+
+    fun stopObservingAppActivity() {
+        appActiveObserver?.let(NSNotificationCenter.defaultCenter::removeObserver)
+        appActiveObserver = null
     }
 
     private fun findRecommendations(location: Location) {
@@ -581,5 +647,9 @@ private fun logPhotoPerformance(message: String) {
 
 private const val PreviewSizePx = 1280
 private const val PreviewJpegQuality = 0.85
-private const val FullGalleryAccessMessage =
-    "위치 기반 사진 추천을 사용하려면 전체 갤러리 접근 권한을 허용해 주세요."
+private fun Long.toPermissionIssue(): PhotoLibraryPermissionIssue =
+    if (this == platform.Photos.PHAuthorizationStatusRestricted) {
+        PhotoLibraryPermissionIssue.RESTRICTED
+    } else {
+        PhotoLibraryPermissionIssue.DENIED
+    }

--- a/client/shared/src/jvmMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.jvm.kt
+++ b/client/shared/src/jvmMain/kotlin/com/mapmory/shared/presentation/photo/PhotoLibrary.jvm.kt
@@ -11,6 +11,7 @@ actual fun rememberPhotoLibraryActions(
     onLoadingChanged: (Boolean) -> Unit,
     onLoadingProgressChanged: (PhotoLoadingProgress) -> Unit,
     onRecommendationLoadingChanged: (Boolean) -> Unit,
+    onPermissionRequired: (PhotoLibraryPermissionIssue) -> Unit,
 ): PhotoLibraryActions = remember(onMessage, onLoadingChanged, onLoadingProgressChanged) {
     PhotoLibraryActions(
         pickFromGallery = { onMessage("사진 선택은 Android와 iOS 앱에서 사용할 수 있어요.") },


### PR DESCRIPTION
## 요약

사진 전체 접근 권한이 없을 때 설정 이동 안내 팝업을 표시합니다.
Android와 iOS 앱 설정 이동 및 복귀 후 사진 추천 재개 흐름을 추가하고 사용자 문구를 개선했습니다.

Closes #232

## 배경

제한된 사진 접근 또는 접근 거부 상태에서는 위치 정보를 포함한 전체 사진을 검색할 수 없습니다. 기존에는 인라인 문구만 표시되어 사용자가 권한을 변경하는 방법을 알기 어려웠고, iOS에서는 설정 화면 이동도 동작하지 않았습니다.

## 주요 결정

- 일반 오류 문자열과 사진 권한 문제를 구조화된 상태로 분리했습니다.
- 제한 또는 거부 상태에서 사진 전체 접근 안내 팝업을 표시합니다.
- 설정으로 이동과 나가기 버튼을 제공합니다.
- 플랫폼별 앱 설정 화면을 열고, 복귀 시 권한을 다시 확인해 보류한 추천을 재개합니다.
- 위치 기반 사진 불러오기를 이 장소 사진 찾기로 변경했습니다.

## 한계

- iOS 설정 이동 변경은 Kotlin/Native 컴파일까지 확인했으며 실제 아이폰에서 최종 확인이 필요합니다.
- 여행 기록 생성 후 상세 조회 500 오류는 백엔드 문제이므로 이 PR 범위에 포함하지 않았습니다.

## 확인

- [x] 로컬에서 실행 확인
- [x] Android 공유 소스 컴파일 성공
- [x] Android 계측 테스트 소스 컴파일 성공
- [x] iOS 시뮬레이터용 Kotlin 소스 컴파일 성공
- [x] JVM 단위 테스트 성공
- [x] Info.plist 검사 성공
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 새 환경변수 없음
- [x] DB 스키마 변경 없음
- [x] 실행 방법이나 환경 설정 변경 없음