### PR TITLE
fix: 여행 일지 상세 조회의 지역 지연 로딩 예외 수정

### DIFF
--- a/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordRepository.java
+++ b/backend/src/main/java/com/mapmory/backend/travelrecord/TravelRecordRepository.java
@@ -5,12 +5,19 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TravelRecordRepository extends JpaRepository<TravelRecord, Long> {
 
+    /**
+     * 상세 응답은 지역을 국가·시도·시군구로 펼쳐 보여주므로 Region의 parent·root까지 필요하다.
+     * 둘 다 지연 로딩이고 open-in-view가 꺼져 있어, 여기서 함께 읽어두지 않으면
+     * 웹 계층의 DTO 변환에서 LazyInitializationException이 난다.
+     */
+    @EntityGraph(attributePaths = {"region", "region.parent", "region.root"})
     Optional<TravelRecord> findByIdAndMemberId(Long id, Long memberId);
 
     /**

--- a/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordDetailAcceptanceTest.java
+++ b/backend/src/test/java/com/mapmory/backend/travelrecord/TravelRecordDetailAcceptanceTest.java
@@ -1,0 +1,96 @@
+package com.mapmory.backend.travelrecord;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import com.mapmory.backend.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * 상세 응답의 지역 계층이 트랜잭션 밖에서도 채워지는지 확인한다.
+ *
+ * <p>open-in-view가 꺼져 있어 컨트롤러 시점에는 영속성 컨텍스트가 닫혀 있다.
+ * RegionDetailResponse는 시·군·구 기록에서 Region의 parent·root를 읽는데, 이 둘은 지연 로딩이라
+ * 서비스가 미리 초기화해 두지 않으면 LazyInitializationException이 난다.
+ * 기존 인수 테스트는 모두 국가 단위(JP) 기록만 다뤄 이 경로를 지나지 않았다.
+ */
+@AutoConfigureMockMvc
+class TravelRecordDetailAcceptanceTest extends IntegrationTest {
+
+    private static final String SEOUL_PROVINCE_CODE = "11";
+    private static final String JONGNO_DISTRICT_CODE = "11110";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void 시군구_기록의_상세_조회는_국가_시도_시군구를_모두_응답한다() throws Exception {
+        String accessToken = guestAccessToken();
+        long recordId = createDistrictRecord(accessToken);
+
+        mockMvc.perform(get("/api/v1/travel-records/" + recordId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.region.country.code").value("KR"))
+                .andExpect(jsonPath("$.data.region.province.code").value(SEOUL_PROVINCE_CODE))
+                .andExpect(jsonPath("$.data.region.district.code").value(JONGNO_DISTRICT_CODE));
+    }
+
+    @Test
+    void 시군구_기록의_수정_응답도_국가_시도_시군구를_모두_담는다() throws Exception {
+        String accessToken = guestAccessToken();
+        long recordId = createDistrictRecord(accessToken);
+
+        mockMvc.perform(put("/api/v1/travel-records/" + recordId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(districtRecordBody("수정한 종로 여행")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정한 종로 여행"))
+                .andExpect(jsonPath("$.data.region.country.code").value("KR"))
+                .andExpect(jsonPath("$.data.region.province.code").value(SEOUL_PROVINCE_CODE))
+                .andExpect(jsonPath("$.data.region.district.code").value(JONGNO_DISTRICT_CODE));
+    }
+
+    private long createDistrictRecord(String accessToken) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/travel-records")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(districtRecordBody("종로 여행")))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Integer id = JsonPath.read(result.getResponse().getContentAsString(), "$.data.id");
+        return id.longValue();
+    }
+
+    private String districtRecordBody(String title) {
+        return """
+                {
+                  "countryCode": "KR",
+                  "provinceCode": "%s",
+                  "districtCode": "%s",
+                  "title": "%s",
+                  "content": "기록 본문",
+                  "startDate": "2026-08-01",
+                  "objectKeys": []
+                }
+                """.formatted(SEOUL_PROVINCE_CODE, JONGNO_DISTRICT_CODE, title);
+    }
+
+    private String guestAccessToken() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/auth/login/guest"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return JsonPath.read(result.getResponse().getContentAsString(), "$.data.accessToken");
+    }
+}


### PR DESCRIPTION
## 요약

국내 여행 일지 상세 조회(`GET /api/v1/travel-records/{id}`)가 `LazyInitializationException`으로
500을 응답하던 문제를 고칩니다. `findByIdAndMemberId`에 `@EntityGraph`를 걸어 지역 계층을
트랜잭션 안에서 함께 읽습니다.

컨트롤러부터 실제 JPA까지 관통하는 시·군·구 인수 테스트를 추가합니다.

## 배경

`open-in-view: false`(`application.yaml:17`)라 컨트롤러 시점에는 영속성 컨텍스트가 닫혀 있습니다.

그런데 `TravelRecordDetail`은 `TravelRecord` **엔티티를 그대로** 웹 계층으로 내보내고,
`RegionDetailResponse.from()`이 그 안의 지역을 국가·시도·시군구로 펼치며 지연 로딩 필드를 읽습니다.

```java
// RegionDetailResponse.java
case DISTRICT -> new RegionDetailResponse(
        RegionItemResponse.from(region.getRoot()),    // Region.root  → LAZY
        RegionItemResponse.from(region.getParent()),  // Region.parent → LAZY
        RegionItemResponse.from(region)
);
```

`TravelRecord.region`은 `@ManyToOne` 기본값이라 EAGER로 딸려오지만, **그 안의 `parent`·`root`는 프록시**입니다.

```
LazyInitializationException: Could not initialize proxy [Region#122] - no session
```

`validateTravelRecordRegion()` 상 `KR` 기록은 항상 시·군·구까지 받으므로,
**국내 일지 상세 조회는 예외 없이 전부 500**이었습니다.

## 주요 결정

### 1. 리포지토리 fetch join으로 고칩니다

```java
@EntityGraph(attributePaths = {"region", "region.parent", "region.root"})
Optional<TravelRecord> findByIdAndMemberId(Long id, Long memberId);
```

`TravelRecordDetail`이 엔티티 대신 값 레코드를 담도록 평탄화하는 방법도 있지만,
그건 ADR 0016·0017의 "응답 DTO 변환은 웹 계층이 맡는다"를 다시 해석해야 하는 큰 변경입니다.
지금은 **DTO 변환 위치를 그대로 두고**, 필요한 데이터를 트랜잭션 안에서 채워 보내는 쪽을 택했습니다.

상세 조회와 수정 모두 `findByIdAndMemberId` 하나를 지나므로 두 경로가 함께 해결됩니다.

### 2. 왜 지금까지 아무도 못 잡았나

버그 자체보다 이쪽이 더 중요해 보여서 적습니다. 세 겹으로 가려져 있었습니다.

- **`TravelRecordControllerTest`** — 서비스를 목으로 두고 `Region.of(...)`로 만든 **생 객체**를 넘깁니다.
  프록시가 아니라 실제 인스턴스라 `getParent()`가 그냥 동작합니다.
- **`TravelRecordServiceTest`** — 전부 목이고, DTO 변환은 컨트롤러에 있어 아예 타지 않습니다.
- **`UploadedObjectVerificationAcceptanceTest`** — 유일하게 실제 JPA를 관통하지만
  `"countryCode": "JP"`, 즉 **국가 단위 기록만** 다룹니다. `COUNTRY` 분기는 `getRoot()`·`getParent()`를
  건드리지 않아 통과합니다.

즉 **트랜잭션 경계를 넘는 시·군·구 경로를 지나는 테스트가 하나도 없었습니다.**
`GET /travel-records/{id}`는 인수 테스트가 아예 없었고요.

그래서 `TravelRecordDetailAcceptanceTest`를 추가했습니다. `KR/11/11110`(서울 종로구)로 기록을 만들고
상세 조회·수정 응답에 국가·시도·시군구가 모두 담기는지 확인합니다.
수정 전 커밋에 이 테스트를 얹으면 상세 조회가 500으로 **실패하는 것을 확인했습니다.**

### 3. 수정(`PUT`)은 왜 멀쩡했나

`update()`가 같은 트랜잭션에서 `RegionResolver`로 상위 지역을 이미 조회해 둡니다.
영속성 컨텍스트에 실제 엔티티가 올라와 있으면 연관 필드가 프록시가 아니라 그 엔티티를 가리키므로
세션이 닫힌 뒤에도 읽힙니다. **우연히 통과하던 것**이라 이번 인수 테스트로 함께 고정했습니다.

## 한계

`TravelRecordDetail`·`TravelRecordSummaries`가 JPA 엔티티를 웹 계층까지 내보내는 구조 자체는 남습니다.
`mapsummary`·`statistics`는 순수 프로젝션 레코드만 내보내서 이 문제에서 자유롭습니다.

앞으로 응답 DTO가 새로운 지연 로딩 필드를 건드리면 같은 방식으로 다시 터집니다.
도메인 값 레코드로 평탄화하는 리팩터링은 #236 으로 분리했습니다.

## 확인

- [x] 로컬에서 실행 확인 (`./gradlew test` 전체 통과, 수정 전에는 신규 테스트 실패 확인)
- [x] 비밀 정보(비밀번호·키·토큰)를 커밋하지 않았음
- [x] 새 환경변수 없음
- [x] DB 스키마 변경 없음
- [x] 실행 방법·환경 설정 변경 없음