### PR TITLE
feat(android): 앱 스플래시 화면 추가

### DIFF
--- a/client/androidApp/src/main/res/drawable/splash_transparent.xml
+++ b/client/androidApp/src/main/res/drawable/splash_transparent.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="1dp"
+    android:height="1dp"
+    android:viewportWidth="1"
+    android:viewportHeight="1">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M0,0h1v1h-1z" />
+</vector>

--- a/client/androidApp/src/main/res/values-v31/styles.xml
+++ b/client/androidApp/src/main/res/values-v31/styles.xml
@@ -1,0 +1,11 @@
+<resources>
+    <style name="Theme.Mapmory" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:windowSplashScreenBackground">@color/mapmory_system_bar_light</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/splash_transparent</item>
+        <item name="android:windowSplashScreenIconBackgroundColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@color/mapmory_system_bar_light</item>
+        <item name="android:navigationBarColor">@color/mapmory_system_bar_light</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
+    </style>
+</resources>

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/App.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,7 +22,9 @@ import com.mapmory.shared.navigation.MapmoryBackHandlerRegistry
 import com.mapmory.shared.navigation.MapmoryNavHost
 import com.mapmory.shared.navigation.MapmoryNavigator
 import com.mapmory.shared.preview.PreviewSurface
+import com.mapmory.shared.presentation.splash.MapmorySplashScreen
 import com.mapmory.shared.presentation.triprecord.screen.ProvideTripRecordPalettes
+import kotlinx.coroutines.delay
 
 @Composable
 fun MapmoryApp(
@@ -53,6 +56,12 @@ fun MapmoryApp(
     val latestNavigateBack = rememberUpdatedState {
         backHandlerRegistry.handleBack() || navigator.navigateBack()
     }
+    var showSplash by rememberSaveable { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        delay(SplashDurationMillis)
+        showSplash = false
+    }
 
     DisposableEffect(navigation, navigator, backHandlerRegistry) {
         navigation?.bindBackHandler { latestNavigateBack.value() }
@@ -67,16 +76,22 @@ fun MapmoryApp(
         LocalMapmoryAnalytics provides analytics,
     ) {
         ProvideTripRecordPalettes(isDark = isDarkTheme) {
-            MapmoryNavHost(
-                navController = navController,
-                navigator = navigator,
-                container = appContainer,
-                backHandlerRegistry = backHandlerRegistry,
-                contentWindowInsets = contentWindowInsets,
-            )
+            if (showSplash) {
+                MapmorySplashScreen(contentWindowInsets = contentWindowInsets)
+            } else {
+                MapmoryNavHost(
+                    navController = navController,
+                    navigator = navigator,
+                    container = appContainer,
+                    backHandlerRegistry = backHandlerRegistry,
+                    contentWindowInsets = contentWindowInsets,
+                )
+            }
         }
     }
 }
+
+private const val SplashDurationMillis = 900L
 
 @Preview(
     name = "앱 지도",

--- a/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/splash/SplashScreen.kt
+++ b/client/shared/src/commonMain/kotlin/com/mapmory/shared/presentation/splash/SplashScreen.kt
@@ -1,0 +1,176 @@
+package com.mapmory.shared.presentation.splash
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mapmory.shared.presentation.triprecord.screen.TripMapPalette
+import com.mapmory.shared.presentation.triprecord.screen.TripRecordPalette
+
+@Composable
+internal fun MapmorySplashScreen(
+    contentWindowInsets: WindowInsets,
+    modifier: Modifier = Modifier,
+) {
+    val recordPalette = TripRecordPalette.current
+    val mapPalette = TripMapPalette.current
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(recordPalette.pageBackground),
+    ) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .windowInsetsPadding(contentWindowInsets)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            SplashMark(
+                backgroundColor = recordPalette.primarySoft,
+                borderColor = recordPalette.secondaryAccent.copy(alpha = 0.44f),
+                iconColor = recordPalette.primary,
+            )
+            Spacer(Modifier.size(16.dp))
+            Text(
+                text = buildMapmoryWordmark(
+                    mapColor = mapPalette.logoText,
+                    moryColor = recordPalette.secondaryAccent,
+                ),
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-2.4).sp,
+            )
+            Spacer(Modifier.size(10.dp))
+            Text(
+                text = "여행의 순간을, 지도 위에",
+                color = recordPalette.bodyText,
+                fontSize = 14.sp,
+                lineHeight = 22.sp,
+            )
+        }
+
+        Text(
+            text = "MAP YOUR MEMORIES",
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .windowInsetsPadding(contentWindowInsets)
+                .padding(bottom = 24.dp),
+            color = recordPalette.secondaryText,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.ExtraBold,
+            letterSpacing = 1.6.sp,
+        )
+    }
+}
+
+@Composable
+private fun SplashMark(
+    backgroundColor: Color,
+    borderColor: Color,
+    iconColor: Color,
+) {
+    Box(
+        modifier = Modifier
+            .size(96.dp)
+            .clip(CircleShape)
+            .background(backgroundColor)
+            .border(1.dp, borderColor, CircleShape)
+            .semantics { contentDescription = "Mapmory 로고" },
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(Modifier.size(56.dp)) {
+            val scale = size.minDimension / 48f
+            val center = Offset(size.width / 2f, size.height / 2f)
+            drawCircle(
+                color = iconColor,
+                center = center,
+                radius = 17f * scale,
+                style = Stroke(width = 1.8f * scale),
+            )
+
+            val route = Path().apply {
+                moveTo(14f * scale, 28f * scale)
+                cubicTo(
+                    19f * scale,
+                    21f * scale,
+                    23f * scale,
+                    32f * scale,
+                    28f * scale,
+                    26f * scale,
+                )
+                cubicTo(
+                    32f * scale,
+                    21f * scale,
+                    32f * scale,
+                    16f * scale,
+                    38f * scale,
+                    19f * scale,
+                )
+            }
+            drawPath(
+                path = route,
+                color = iconColor,
+                style = Stroke(
+                    width = 2f * scale,
+                    cap = StrokeCap.Round,
+                    join = StrokeJoin.Round,
+                    pathEffect = PathEffect.dashPathEffect(
+                        intervals = floatArrayOf(1f * scale, 5f * scale),
+                        phase = 0f,
+                    ),
+                ),
+            )
+            drawCircle(
+                color = iconColor,
+                center = Offset(14f * scale, 28f * scale),
+                radius = 3f * scale,
+            )
+            drawCircle(
+                color = iconColor,
+                center = Offset(38f * scale, 19f * scale),
+                radius = 3f * scale,
+            )
+        }
+    }
+}
+
+private fun buildMapmoryWordmark(
+    mapColor: Color,
+    moryColor: Color,
+): AnnotatedString = buildAnnotatedString {
+    withStyle(SpanStyle(color = mapColor)) { append("Map") }
+    withStyle(SpanStyle(color = moryColor)) { append("mory") }
+}


### PR DESCRIPTION
## 변경 내용
- 앱 실행 시 공통 Compose 스플래시 화면을 표시합니다.
- 기존 Mapmory 테마 팔레트를 사용해 라이트·다크 모드에 대응합니다.
- Android 12 이상 시스템 스플래시에서 앱 아이콘이 중복 표시되지 않도록 투명 아이콘 리소스를 적용합니다.
- 시안 확인용 HTML은 포함하지 않았습니다.

## 검증
- `./gradlew :shared:jvmTest`
- `./gradlew :shared:testAndroidHostTest`
- `./gradlew :androidApp:assembleDebug`
- iOS Simulator Debug 빌드 성공
- Android Emulator 설치·실행 확인

## 참고
Android 12 이상에서 OS 시스템 스플래시 자체는 제거할 수 없으므로, 앱 아이콘만 숨기고 커스텀 스플래시와 자연스럽게 연결했습니다.