### PR TITLE
ci(landing): protect landing release and use managed CodePipeline/CodeDeploy

### DIFF
--- a/.github/workflows/landing-release.yml
+++ b/.github/workflows/landing-release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
 
+# PR validation only. CodePipeline uses the existing institution-managed AWS roles.
 jobs:
   validate:
     name: Landing release validation
@@ -33,80 +34,5 @@ jobs:
           VITE_POSTHOG_KEY: ${{ vars.VITE_POSTHOG_KEY }}
           VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
       - run: npm test
-      - name: Package tested release
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/landing-release'
-        run: |
-          printf '%s\n' "$GITHUB_SHA" > dist/client/release.txt
-          tar -czf "$RUNNER_TEMP/mapmory-landing.tar.gz" -C dist/client .
-      - uses: actions/upload-artifact@v7
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/landing-release'
-        with:
-          name: mapmory-landing-${{ github.sha }}
-          path: ${{ runner.temp }}/mapmory-landing.tar.gz
-          if-no-files-found: error
-          retention-days: 7
-
-  deploy:
-    name: Deploy landing production
-    if: >-
-      github.repository == 'woowacourse-teams/2026-Mapmory' &&
-      github.event_name != 'pull_request' &&
-      github.ref == 'refs/heads/landing-release'
-    needs: validate
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment:
-      name: landing-production
-      url: https://map-mory.com/
-    concurrency:
-      group: landing-production
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v7
-        with:
-          name: mapmory-landing-${{ github.sha }}
-          path: ${{ runner.temp }}
-      - name: Configure verified landing SSH access
-        env:
-          LANDING_EC2_SSH_KEY: ${{ secrets.LANDING_EC2_SSH_KEY }}
-          LANDING_EC2_KNOWN_HOSTS: ${{ secrets.LANDING_EC2_KNOWN_HOSTS }}
-          LANDING_EC2_HOST: ${{ secrets.LANDING_EC2_HOST }}
-          LANDING_EC2_USER: ${{ secrets.LANDING_EC2_USER }}
-        run: |
-          set -euo pipefail
-          for name in LANDING_EC2_SSH_KEY LANDING_EC2_KNOWN_HOSTS LANDING_EC2_HOST LANDING_EC2_USER; do
-            if [[ -z "${!name}" ]]; then
-              echo "::error::Missing landing-production secret: $name"
-              exit 1
-            fi
-          done
-          [[ "$LANDING_EC2_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]
-          [[ "$LANDING_EC2_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
-          install -d -m 700 "$HOME/.ssh"
-          printf '%s\n' "$LANDING_EC2_SSH_KEY" > "$HOME/.ssh/landing_deploy_key"
-          printf '%s\n' "$LANDING_EC2_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
-          chmod 600 "$HOME/.ssh/landing_deploy_key" "$HOME/.ssh/known_hosts"
-      - name: Upload and activate tested release
-        env:
-          LANDING_EC2_HOST: ${{ secrets.LANDING_EC2_HOST }}
-          LANDING_EC2_USER: ${{ secrets.LANDING_EC2_USER }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          head_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/landing-release" --jq .object.sha)"
-          if [[ "$head_sha" != "$GITHUB_SHA" ]]; then
-            echo '::error::A newer landing release exists. Deploy the latest run instead.'
-            exit 1
-          fi
-          release_id="${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          remote_archive="/tmp/mapmory-landing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.tar.gz"
-          ssh_options=(-i "$HOME/.ssh/landing_deploy_key" -o BatchMode=yes -o ConnectTimeout=15 -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes)
-          scp "${ssh_options[@]}" "$RUNNER_TEMP/mapmory-landing.tar.gz" "$LANDING_EC2_USER@$LANDING_EC2_HOST:$remote_archive"
-          ssh "${ssh_options[@]}" "$LANDING_EC2_USER@$LANDING_EC2_HOST" \
-            "bash -s -- '$release_id' '$remote_archive'" < landing/scripts/deploy-ec2.sh
-      - name: Verify public release identity
-        run: |
-          set -euo pipefail
-          deployed_sha="$(curl --fail --silent --show-error --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 "https://map-mory.com/release.txt?run=$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT")"
-          [[ "$deployed_sha" == "$GITHUB_SHA" ]] || { echo '::error::Public release does not match the tested commit.'; exit 1; }
+      - name: Validate CodeDeploy bundle
+        run: bash scripts/package-codedeploy.sh "$GITHUB_SHA" "$RUNNER_TEMP/mapmory-landing.tar.gz"

--- a/.github/workflows/landing-release.yml
+++ b/.github/workflows/landing-release.yml
@@ -1,0 +1,112 @@
+name: Landing Release
+
+on:
+  pull_request:
+    branches: [landing-release]
+  push:
+    branches: [landing-release]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Landing release validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: landing
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: landing/package-lock.json
+      - run: npm ci
+      - run: npm run build
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ vars.VITE_GA_MEASUREMENT_ID }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          VITE_POSTHOG_KEY: ${{ vars.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
+      - run: npm test
+      - name: Package tested release
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/landing-release'
+        run: |
+          printf '%s\n' "$GITHUB_SHA" > dist/client/release.txt
+          tar -czf "$RUNNER_TEMP/mapmory-landing.tar.gz" -C dist/client .
+      - uses: actions/upload-artifact@v7
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/landing-release'
+        with:
+          name: mapmory-landing-${{ github.sha }}
+          path: ${{ runner.temp }}/mapmory-landing.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  deploy:
+    name: Deploy landing production
+    if: >-
+      github.repository == 'woowacourse-teams/2026-Mapmory' &&
+      github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/landing-release'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: landing-production
+      url: https://map-mory.com/
+    concurrency:
+      group: landing-production
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v7
+        with:
+          name: mapmory-landing-${{ github.sha }}
+          path: ${{ runner.temp }}
+      - name: Configure verified landing SSH access
+        env:
+          LANDING_EC2_SSH_KEY: ${{ secrets.LANDING_EC2_SSH_KEY }}
+          LANDING_EC2_KNOWN_HOSTS: ${{ secrets.LANDING_EC2_KNOWN_HOSTS }}
+          LANDING_EC2_HOST: ${{ secrets.LANDING_EC2_HOST }}
+          LANDING_EC2_USER: ${{ secrets.LANDING_EC2_USER }}
+        run: |
+          set -euo pipefail
+          for name in LANDING_EC2_SSH_KEY LANDING_EC2_KNOWN_HOSTS LANDING_EC2_HOST LANDING_EC2_USER; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::Missing landing-production secret: $name"
+              exit 1
+            fi
+          done
+          [[ "$LANDING_EC2_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]
+          [[ "$LANDING_EC2_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$LANDING_EC2_SSH_KEY" > "$HOME/.ssh/landing_deploy_key"
+          printf '%s\n' "$LANDING_EC2_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/landing_deploy_key" "$HOME/.ssh/known_hosts"
+      - name: Upload and activate tested release
+        env:
+          LANDING_EC2_HOST: ${{ secrets.LANDING_EC2_HOST }}
+          LANDING_EC2_USER: ${{ secrets.LANDING_EC2_USER }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          head_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/landing-release" --jq .object.sha)"
+          if [[ "$head_sha" != "$GITHUB_SHA" ]]; then
+            echo '::error::A newer landing release exists. Deploy the latest run instead.'
+            exit 1
+          fi
+          release_id="${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          remote_archive="/tmp/mapmory-landing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.tar.gz"
+          ssh_options=(-i "$HOME/.ssh/landing_deploy_key" -o BatchMode=yes -o ConnectTimeout=15 -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes)
+          scp "${ssh_options[@]}" "$RUNNER_TEMP/mapmory-landing.tar.gz" "$LANDING_EC2_USER@$LANDING_EC2_HOST:$remote_archive"
+          ssh "${ssh_options[@]}" "$LANDING_EC2_USER@$LANDING_EC2_HOST" \
+            "bash -s -- '$release_id' '$remote_archive'" < landing/scripts/deploy-ec2.sh
+      - name: Verify public release identity
+        run: |
+          set -euo pipefail
+          deployed_sha="$(curl --fail --silent --show-error --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 "https://map-mory.com/release.txt?run=$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT")"
+          [[ "$deployed_sha" == "$GITHUB_SHA" ]] || { echo '::error::Public release does not match the tested commit.'; exit 1; }

--- a/landing/AGENTS.md
+++ b/landing/AGENTS.md
@@ -1,5 +1,10 @@
 # Prototype Instructions
 
+## Shared AWS account operations
+
+- Before any AWS resource creation/change, tell the user the exact targets, steps, cost and operational risks. Afterward report what actually changed.
+- Follow the institution settings and `DEPLOYMENT.md`: existing project roles only, required Service/Role/ProjectTeam tags on every new resource, no changes to other teams, shared IAM/network settings or backend deployment. Do not infer permissions from the EC2 role; use the existing human AWS console login when needed.
+
 Run the local server yourself and open the preview in the browser available to this environment. Do not give the user server-start instructions when you can run it.
 
 Before making substantial visual changes, use the Product Design plugin's `get-context` skill when the visual source is unclear or no longer matches the current goal. When the user gives durable prototype-specific design feedback, preferences, or decisions, record them in `AGENTS.md`.

--- a/landing/DEPLOYMENT.md
+++ b/landing/DEPLOYMENT.md
@@ -1,15 +1,47 @@
-# Landing CI
+# Landing release
 
-`landing-cicd.yml` validates landing-page changes without deploying them. It runs for landing-related pull requests, changes merged into `main`, and manual workflow dispatches.
+## Branch and protection
 
-## CI pipeline
+- Canonical repository: `woowacourse-teams/2026-Mapmory` (`upstream`), not the personal fork.
+- `landing-release` is the long-lived **landing-only production release** branch. Its initial snapshot is `e91d82c727878da8ab05bee1f330f348b3542df3` from `develop`; its landing tree is identical to the tested/reviewed PR #240 head `14219679b59f12526d6abe72c355dda73b46d948`.
+- Subsequent releases go through a PR to `landing-release`. Use a merge commit and keep the source branch. Never force-push or delete the release branch.
+- Active ruleset: [Landing release protection](https://github.com/woowacourse-teams/2026-Mapmory/rules/22160463). It prohibits deletion/force pushes, requires a PR, resolved review threads, and the GitHub Actions check `Landing release validation` against the latest base. No bypass actors are configured. PR approval count follows the existing repository convention (0); the separate deployment approval remains required.
+- Keep app and backend releases separate. This workflow never updates `main`, `develop`, or `backend-release`, builds the backend, or restarts the backend application.
 
-1. Install dependencies with `npm ci`.
-2. Build `dist/client`.
-3. Run the landing-page tests against the built output.
+## Validation and deployment
 
-The workflow does not package a release, access AWS, or connect to EC2. No GitHub environment, AWS credential, or SSH secret is required to run it.
+The existing `landing-cicd.yml` remains validation-only for ordinary landing changes. `landing-release.yml` runs on **every** PR to `landing-release` without a path filter so its required check cannot remain pending for docs-only changes.
 
-## Deployment
+1. Run `npm ci`, `npm run build`, then `npm test` in `landing/`. Build comes before tests because packaging tests inspect generated files.
+2. Request CodeRabbit review and address actionable findings before merging. A skipped/limited bot review is not a completed review.
+3. Merge the validated PR into `landing-release`. Its push rebuilds and tests the exact release SHA, writes `release.txt`, and packages **only** `dist/client`.
+4. The `landing-production` environment requires the existing `bee9827` approval and only permits the `landing-release` branch. PRs and fork workflows cannot deploy. Do not remove the approval gate.
+5. After approval, upload the tested artifact over SSH with pinned host keys and run `landing/scripts/deploy-ec2.sh`. Deployments are serialized, are not interrupted by a newer run, and check that their SHA is still the release branch head before upload.
+6. The script activates `/var/www/mapmory/releases/<sha>-<run-id>-<attempt>` through `/var/www/mapmory/current`. It validates Nginx and checks local HTTPS; Nginx config/local health failures restore the previous symlink when available.
+7. The workflow checks `https://map-mory.com/release.txt` equals the tested SHA. A public/CDN mismatch fails the job and needs operator investigation; that final public check does not automatically roll back the server.
 
-Automatic deployment is intentionally postponed. Production releases must use the separately reviewed manual deployment procedure until the team introduces an AWS-supported deployment pipeline.
+`workflow_dispatch` is provided for retrying the current release, but GitHub only exposes manual dispatch once this workflow also exists on the default branch. Until that reviewed integration happens, merge-to-release push triggers and the Actions **Re-run jobs** control are the supported entry points. Every retry still requires the environment gate and head-SHA check.
+
+## First deployment prerequisites — do not guess these
+
+The historical EC2 script is retained, but its existence does **not** prove the live server has been provisioned. Confirm the landing host/account, Nginx `map-mory.com` virtual host, TLS, and document root `/var/www/mapmory/current` before approving the first run. The account needs the existing script's sudo permissions. Do not provision infrastructure, change DNS, or reuse backend credentials without explicit confirmation.
+
+Register these secrets in **Settings → Environments → landing-production** using a trusted secret-entry method (never commit them or paste private keys in chat):
+
+| Secret | Value |
+| --- | --- |
+| `LANDING_EC2_HOST` | Confirmed landing EC2 hostname or IPv4 address, SSH port 22 |
+| `LANDING_EC2_USER` | Confirmed deployment account |
+| `LANDING_EC2_SSH_KEY` | Deployment account's private SSH key |
+| `LANDING_EC2_KNOWN_HOSTS` | Host key entry independently verified against the server |
+
+As of setup on 2026-09-03 these four secrets are absent. Repository secrets named `EC2_HOST`/`EC2_SSH_KEY` are deliberately **not** used as an implicit fallback.
+
+Optional public build settings belong in **repository variables**, because validation/build happens before the environment approval: `VITE_GA_MEASUREMENT_ID`, `VITE_API_BASE_URL`, `VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`. All `VITE_*` values are bundled into public client JavaScript; never put a private server/API token there. Existing source defaults apply when values are unset.
+
+## Recovery
+
+- Preserve previous release directories; this workflow does not prune them.
+- To restore older content through the normal process, create a revert PR to `landing-release`, validate/review it, merge, and approve its new deployment.
+- If the first deployment has no previous `current` symlink, there is no previous release for the script to restore. First-release server readiness must be verified by the operator before approval.
+- A failed final public check may be caching, routing, or server state. Inspect the recorded release SHA and server symlink before taking recovery action; an HTTP 200 alone is not proof of the deployed version.

--- a/landing/DEPLOYMENT.md
+++ b/landing/DEPLOYMENT.md
@@ -1,47 +1,59 @@
-# Landing release
+# Landing release — institution-managed AWS pipeline
 
-## Branch and protection
+## Shared-account safety (mandatory)
 
-- Canonical repository: `woowacourse-teams/2026-Mapmory` (`upstream`), not the personal fork.
-- `landing-release` is the long-lived **landing-only production release** branch. Its initial snapshot is `e91d82c727878da8ab05bee1f330f348b3542df3` from `develop`; its landing tree is identical to the tested/reviewed PR #240 head `14219679b59f12526d6abe72c355dda73b46d948`.
-- Subsequent releases go through a PR to `landing-release`. Use a merge commit and keep the source branch. Never force-push or delete the release branch.
-- Active ruleset: [Landing release protection](https://github.com/woowacourse-teams/2026-Mapmory/rules/22160463). It prohibits deletion/force pushes, requires a PR, resolved review threads, and the GitHub Actions check `Landing release validation` against the latest base. No bypass actors are configured. PR approval count follows the existing repository convention (0); the separate deployment approval remains required.
-- Keep app and backend releases separate. This workflow never updates `main`, `develop`, or `backend-release`, builds the backend, or restarts the backend application.
+- Before creating or changing any AWS resource, announce the exact targets, sequence, expected cost and operational risks to the user. Report what actually changed afterward. Read-only inspection must stay within Mapmory resources.
+- Reuse the institution account and its designated roles. Do not create IAM users, access keys or OIDC roles, modify shared policies, widen SSH/network access, or inspect other teams' resources.
+- Every created resource must carry `Service=techcourse`, `Role=techcourse-etc`, `ProjectTeam=Mapmory`. Apply the common tags in `codedeploy/aws-resources.json` to **each** application, deployment group, build project and pipeline; the JSON is a blueprint, not a CLI request.
+- Monthly team limits provided by the institution: August $50, September $60, October onward $70. EC2 estimates are not the complete team bill. Check the team's usage before provisioning; CodeBuild minutes, CodePipeline and S3 add cost. Do not create budgets, dashboards or alarms with extra costs without discussion.
+- Use `techcourse-project-2026` for frontend source/build/deployment artifacts. CodePipeline creates the Mapmory-identifiable `mapmory-landing-release/` artifact prefix automatically. Do not change bucket policy, lifecycle or other prefixes. Do not use the backend artifact bucket for frontend serving/deployment.
+- Permissions or bucket-role mismatches must be raised in the institution's technical-review channel. Never work around them by changing shared IAM policies. Most deletion permissions are absent; avoid speculative resources.
 
-## Validation and deployment
+## Branch, review and approval
 
-The existing `landing-cicd.yml` remains validation-only for ordinary landing changes. `landing-release.yml` runs on **every** PR to `landing-release` without a path filter so its required check cannot remain pending for docs-only changes.
+Canonical repository is `woowacourse-teams/2026-Mapmory` (`upstream`). `landing-release` is the landing-only production branch. Its initial SHA is `e91d82c727878da8ab05bee1f330f348b3542df3`, with the same landing tree as merged/reviewed PR #240.
 
-1. Run `npm ci`, `npm run build`, then `npm test` in `landing/`. Build comes before tests because packaging tests inspect generated files.
-2. Request CodeRabbit review and address actionable findings before merging. A skipped/limited bot review is not a completed review.
-3. Merge the validated PR into `landing-release`. Its push rebuilds and tests the exact release SHA, writes `release.txt`, and packages **only** `dist/client`.
-4. The `landing-production` environment requires the existing `bee9827` approval and only permits the `landing-release` branch. PRs and fork workflows cannot deploy. Do not remove the approval gate.
-5. After approval, upload the tested artifact over SSH with pinned host keys and run `landing/scripts/deploy-ec2.sh`. Deployments are serialized, are not interrupted by a newer run, and check that their SHA is still the release branch head before upload.
-6. The script activates `/var/www/mapmory/releases/<sha>-<run-id>-<attempt>` through `/var/www/mapmory/current`. It validates Nginx and checks local HTTPS; Nginx config/local health failures restore the previous symlink when available.
-7. The workflow checks `https://map-mory.com/release.txt` equals the tested SHA. A public/CDN mismatch fails the job and needs operator investigation; that final public check does not automatically roll back the server.
+All updates go through a PR to `landing-release`, CodeRabbit review and all required/path-relevant checks. Rate-limited or skipped bot reviews are not completed reviews. Use a merge commit and retain the source branch. Never push directly, force-push or delete the release branch. The existing [Landing release ruleset](https://github.com/woowacourse-teams/2026-Mapmory/rules/22160463) requires `Landing release validation`, resolved conversations and the latest base.
 
-`workflow_dispatch` is provided for retrying the current release, but GitHub only exposes manual dispatch once this workflow also exists on the default branch. Until that reviewed integration happens, merge-to-release push triggers and the Actions **Re-run jobs** control are the supported entry points. Every retry still requires the environment gate and head-SHA check.
+GitHub Actions now performs **PR validation only**. The institution-approved deployment path is:
 
-## First deployment prerequisites — do not guess these
+`landing-release → GitHub (version 1) source → CodeBuild → manual approval → CodeDeploy`
 
-The historical EC2 script is retained, but its existence does **not** prove the live server has been provisioned. Confirm the landing host/account, Nginx `map-mory.com` virtual host, TLS, and document root `/var/www/mapmory/current` before approving the first run. The account needs the existing script's sudo permissions. Do not provision infrastructure, change DNS, or reuse backend credentials without explicit confirmation.
+The deployment approval lives in CodePipeline's `ApproveLandingProduction` action. This is a deliberate migration of the proposed GitHub deployment job's approval checkpoint, **not approval-free deployment**. Announce/confirm that checkpoint when provisioning. Leave the existing GitHub `landing-production` environment and its protection unchanged; no workflow uses it to deploy in this design. The Mapmory release owner must check CodeRabbit, CI, the source SHA and the latest branch head before approving the AWS action. Never approve a stale execution.
 
-Register these secrets in **Settings → Environments → landing-production** using a trusted secret-entry method (never commit them or paste private keys in chat):
+## Configuration and provisioning order
 
-| Secret | Value |
-| --- | --- |
-| `LANDING_EC2_HOST` | Confirmed landing EC2 hostname or IPv4 address, SSH port 22 |
-| `LANDING_EC2_USER` | Confirmed deployment account |
-| `LANDING_EC2_SSH_KEY` | Deployment account's private SSH key |
-| `LANDING_EC2_KNOWN_HOSTS` | Host key entry independently verified against the server |
+`codedeploy/aws-resources.json` records the desired settings without account credentials. It omits the source OAuth token on purpose. Do not feed it directly to AWS CLI.
 
-As of setup on 2026-09-03 these four secrets are absent. Repository secrets named `EC2_HOST`/`EC2_SSH_KEY` are deliberately **not** used as an implicit fallback.
+1. Inspect existing Mapmory resources and confirm this account/region, the current landing symlink/TLS, the active CodeDeploy agent and the existing backend baseline. Announce the change/risk plan before creating anything.
+2. Create **only** the `mapmory-landing` CodeDeploy application and `mapmory-landing-production` deployment group, with all three tags. Use existing `codedeploy-project`; select instances matching both `Name=ec2-mapmory` and `ProjectTeam=Mapmory`. Use in-place, no traffic control, `CodeDeployDefault.AllAtOnce`, rollback on deployment failure. Do not run a deployment yet.
+3. Create `mapmory-landing-build` with all three tags and existing `codebuild-project`. Use `aws/codebuild/standard:7.0`, Node 24, small Linux build, no privileged mode/VPC, concurrency 1 and timeout 15 minutes. Source/artifacts are CodePipeline. Buildspec is `landing/buildspec.yml`. Logs use only `/aws/codebuild/project-2026` and a `mapmory-landing` stream prefix. Creating the project alone should not start a build.
+4. Preserve the live public `VITE_GA_MEASUREMENT_ID`, `VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`, and optional `VITE_API_BASE_URL` as CodeBuild project environment variables. They are public client build settings, never private tokens. Check against the current live bundle; do not silently drop analytics because the GitHub repository variables are unset. Set `VITE_LANDING_VERSION=v3`.
+5. Only after this PR's files exist on the reviewed `landing-release` head, create `mapmory-landing-release` using existing `codepipeline-project` and all three tags. Choose V1 / SUPERSEDED to avoid parallel deployments. Select the frontend bucket explicitly, not a new default bucket. Connect **GitHub (version 1)** to the canonical repository's `landing-release` branch using the AWS console authorization flow. Let the user complete OAuth if required; never collect tokens/passwords/MFA in chat or copy another pipeline's masked token. The console-created webhook should detect this branch, with polling disabled; verify both to avoid duplicate or missing runs.
+6. Configure source namespace `SourceVariables`. Pass `SOURCE_COMMIT_ID=#{SourceVariables.CommitId}` to CodeBuild as shown in the blueprint. Add the **manual approval action before CodeDeploy**. The creation wizard may not offer approval: do not create an immediately deployable pipeline in that case. Initially omit/disable Deploy, add approval, then enable Deploy only after inspection.
+7. Pipeline creation can automatically start its first execution and incur build charges. Announce this before creation. Do not approve production until local/CI tests pass and the exact tested source revision is verified. Backend pipeline `mapmory-backend-pipeline` and group `mapmory-prod` remain untouched.
 
-Optional public build settings belong in **repository variables**, because validation/build happens before the environment approval: `VITE_GA_MEASUREMENT_ID`, `VITE_API_BASE_URL`, `VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`. All `VITE_*` values are bundled into public client JavaScript; never put a private server/API token there. Existing source defaults apply when values are unset.
+The EC2 `ec2-project` role is an instance role, not the human console user. It may lack CodePipeline/CodeBuild creation permission even though the signed-in institution user can provision those services. Use the existing console login; do not request a new administrator account or broaden the instance role.
 
-## Recovery
+## Build, deploy and verification
 
-- Preserve previous release directories; this workflow does not prune them.
-- To restore older content through the normal process, create a revert PR to `landing-release`, validate/review it, merge, and approve its new deployment.
-- If the first deployment has no previous `current` symlink, there is no previous release for the script to restore. First-release server readiness must be verified by the operator before approval.
-- A failed final public check may be caching, routing, or server state. Inspect the recorded release SHA and server symlink before taking recovery action; an HTTP 200 alone is not proof of the deployed version.
+Local validation in `landing/`: `npm ci`, `npm run build`, `npm test`. Linux CI and CodeBuild additionally execute the real filesystem activation/rollback fixtures (service/network calls are mocked); Windows skips only those Linux-specific fixtures.
+
+CodeBuild validates that `CODEBUILD_RESOLVED_SOURCE_VERSION` equals the source action's full `SOURCE_COMMIT_ID`, builds and tests before packaging, and refuses to publish a failed build. The bundle root contains only `appspec.yml`, `scripts/activate.sh`, and `client/` (static files including `release.txt`). It never includes backend JARs, `.env` files or server code. CodePipeline retains and passes that exact build artifact to approval and deployment.
+
+The CodeDeploy hook:
+
+- Rejects the wrong application/group, invalid deployment IDs/SHAs, symlinked content and out-of-root previous releases.
+- Requires an existing known-good landing release for first-run recovery and serializes activations with `flock`.
+- Creates a fresh `/var/www/mapmory/releases/<sha>-<deployment-id>` directory, preserving previous releases.
+- Atomically replaces only `/var/www/mapmory/current`, reloads Nginx and verifies local HTTPS **and exact release SHA**.
+- Restores the prior symlink on activation/reload/health failures. CodeDeploy also has rollback enabled; a later CodeDeploy rollback gets a new deployment ID, so reusing an old SHA does not collide.
+- Never uses an ApplicationStop hook, changes Nginx config, or stops/restarts the backend.
+
+After first approval, verify public `https://map-mory.com/release.txt` against the source SHA, homepage/assets, mobile navigation, Nginx and the unchanged backend PID/health. Public/CDN mismatch needs operator investigation; a successful CodeDeploy local check alone is not a public end-to-end check.
+
+The old `scripts/deploy-ec2.sh` remains available for the already-established manual route. It is not used by CodePipeline. Do not remove SSH secrets or change server access as part of this migration.
+
+## Current rollout state
+
+The live site remains the manually deployed `e91d82c` release. Pipeline code/blueprints do not prove AWS provisioning or a successful automated deployment. Record actual resource IDs, checks and rollout status privately after setup; never claim success until the entire pipeline is observed. Keep PR #243 unmerged while first-deployment prerequisites or CodeRabbit review remain incomplete.

--- a/landing/buildspec.yml
+++ b/landing/buildspec.yml
@@ -1,0 +1,34 @@
+version: 0.2
+
+env:
+  shell: bash
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 24
+    commands:
+      - cd "$CODEBUILD_SRC_DIR/landing"
+      - npm ci
+  pre_build:
+    commands:
+      - test "$CODEBUILD_RESOLVED_SOURCE_VERSION" = "$SOURCE_COMMIT_ID"
+      - '[[ "$SOURCE_COMMIT_ID" =~ ^[0-9a-f]{40}$ ]]'
+  build:
+    commands:
+      - npm run build
+      - npm test
+  post_build:
+    commands:
+      - |
+        set -Eeuo pipefail
+        [[ "$CODEBUILD_BUILD_SUCCEEDING" == 1 ]] || exit 1
+        bash scripts/package-codedeploy.sh "$SOURCE_COMMIT_ID" /tmp/mapmory-landing-codedeploy.tar.gz
+        mkdir -p deploy
+        tar -xzf /tmp/mapmory-landing-codedeploy.tar.gz -C deploy
+
+artifacts:
+  base-directory: landing/deploy
+  files:
+    - '**/*'
+  discard-paths: no

--- a/landing/codedeploy/activate.sh
+++ b/landing/codedeploy/activate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Root/bundle arguments make the same activation logic testable in an isolated fixture.
+# The CodeDeploy entry point below always pins the production root and application.
+activate_release() (
+  set -Eeuo pipefail
+  local root="$1" bundle="$2" deployment_id="$3" sha release previous link staged switched=0
+  [[ "$deployment_id" =~ ^d-[A-Za-z0-9]+$ ]] || { echo 'Invalid deployment id' >&2; exit 2; }
+  [[ -f "$bundle/client/index.html" && -f "$bundle/client/release.txt" ]] || {
+    echo 'Missing static landing files' >&2; exit 2;
+  }
+  sha="$(cat -- "$bundle/client/release.txt")"
+  [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || { echo 'Invalid release marker' >&2; exit 2; }
+  [[ -z "$(find "$bundle/client" -type l -print -quit)" ]] || {
+    echo 'Symlinks are not allowed in the static bundle' >&2; exit 2;
+  }
+  root="$(realpath -e -- "$root")"
+  [[ -d "$root/releases" && ! -L "$root/releases" ]] || {
+    echo 'Provision the landing release directory first' >&2; exit 2;
+  }
+  link="$root/current"
+  # Acquire the lock before reading the previous target, so rollback cannot be stale.
+  exec 9>"$root/.codedeploy.lock"
+  flock -n 9 || { echo 'Another landing activation is running' >&2; exit 1; }
+  # Production is already provisioned; require a known-good first-deploy rollback target.
+  [[ -L "$link" ]] || { echo 'Missing previous landing release' >&2; exit 2; }
+  previous="$(readlink -f -- "$link")"
+  [[ "$previous" == "$root/releases/"* && -f "$previous/index.html" ]] || {
+    echo 'Previous release is outside the landing release directory' >&2; exit 2;
+  }
+  release="$root/releases/$sha-$deployment_id"
+  staged="$root/.current-$deployment_id"
+  [[ ! -e "$release" && ! -L "$release" && ! -e "$staged" && ! -L "$staged" ]] || {
+    echo 'Release or staging link already exists' >&2; exit 2;
+  }
+  restore_previous() {
+    local status="$1"
+    trap - ERR INT TERM
+    if [[ "$switched" == 1 ]]; then
+      echo 'Activation failed; restoring previous landing release' >&2
+      ln -sfnT -- "$previous" "$staged" && mv -Tf -- "$staged" "$link"
+      nginx -t && systemctl reload nginx
+    fi
+    exit "$status"
+  }
+  trap 'restore_previous $?' ERR
+  trap 'restore_previous 130' INT
+  trap 'restore_previous 143' TERM
+
+  nginx -t
+  mkdir -- "$release"
+  cp -R -- "$bundle/client/." "$release/"
+  chown -R root:root "$release"
+  chmod -R a+rX "$release"
+  ln -s -- "$release" "$staged"
+  # rename(2) replaces the link atomically: there is no missing-current interval.
+  switched=1
+  mv -Tf -- "$staged" "$link"
+  systemctl reload nginx
+  local served_sha
+  if ! served_sha="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
+    --retry 2 --retry-delay 1 --resolve map-mory.com:443:127.0.0.1 \
+    "https://map-mory.com/release.txt?deployment=$deployment_id")"; then
+    echo 'Local release request failed' >&2
+    false
+  fi
+  [[ "$served_sha" == "$sha" ]] || { echo 'Release identity check failed' >&2; false; }
+  curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
+    --resolve map-mory.com:443:127.0.0.1 https://map-mory.com/ --output /dev/null
+  trap - ERR INT TERM
+  echo "Activated landing release: $sha ($deployment_id)"
+)
+
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
+  [[ "${APPLICATION_NAME:-}" == mapmory-landing && \
+     "${DEPLOYMENT_GROUP_NAME:-}" == mapmory-landing-production ]] || {
+    echo 'This hook may run only in the landing CodeDeploy application/group' >&2; exit 2;
+  }
+  bundle="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+  activate_release /var/www/mapmory "$bundle" "${DEPLOYMENT_ID:?deployment id is required}"
+fi

--- a/landing/codedeploy/appspec.yml
+++ b/landing/codedeploy/appspec.yml
@@ -1,0 +1,10 @@
+version: 0.0
+os: linux
+
+# No files/ApplicationStop hooks: never overwrite backend files or stop its service.
+# Operate on the extracted bundle, then switch only the landing symlink.
+hooks:
+  ApplicationStart:
+    - location: scripts/activate.sh
+      timeout: 180
+      runas: root

--- a/landing/codedeploy/aws-resources.json
+++ b/landing/codedeploy/aws-resources.json
@@ -1,0 +1,97 @@
+{
+  "region": "ap-northeast-2",
+  "tags": [
+    { "key": "Service", "value": "techcourse" },
+    { "key": "Role", "value": "techcourse-etc" },
+    { "key": "ProjectTeam", "value": "Mapmory" }
+  ],
+  "codeDeploy": {
+    "applicationName": "mapmory-landing",
+    "computePlatform": "Server",
+    "deploymentGroupName": "mapmory-landing-production",
+    "serviceRoleName": "codedeploy-project",
+    "deploymentConfigName": "CodeDeployDefault.AllAtOnce",
+    "ec2TagSet": {
+      "ec2TagSetList": [
+        [{ "Key": "Name", "Value": "ec2-mapmory", "Type": "KEY_AND_VALUE" }],
+        [{ "Key": "ProjectTeam", "Value": "Mapmory", "Type": "KEY_AND_VALUE" }]
+      ]
+    },
+    "deploymentStyle": { "deploymentType": "IN_PLACE", "deploymentOption": "WITHOUT_TRAFFIC_CONTROL" },
+    "autoRollbackConfiguration": { "enabled": true, "events": ["DEPLOYMENT_FAILURE"] }
+  },
+  "codeBuild": {
+    "name": "mapmory-landing-build",
+    "serviceRoleName": "codebuild-project",
+    "source": { "type": "CODEPIPELINE", "buildspec": "landing/buildspec.yml" },
+    "artifacts": { "type": "CODEPIPELINE" },
+    "environment": {
+      "type": "LINUX_CONTAINER",
+      "computeType": "BUILD_GENERAL1_SMALL",
+      "image": "aws/codebuild/standard:7.0",
+      "privilegedMode": false,
+      "imagePullCredentialsType": "CODEBUILD"
+    },
+    "timeoutInMinutes": 15,
+    "concurrentBuildLimit": 1,
+    "logsConfig": {
+      "cloudWatchLogs": { "status": "ENABLED", "groupName": "/aws/codebuild/project-2026", "streamName": "mapmory-landing" }
+    }
+  },
+  "codePipeline": {
+    "name": "mapmory-landing-release",
+    "pipelineType": "V1",
+    "executionMode": "SUPERSEDED",
+    "serviceRoleName": "codepipeline-project",
+    "artifactStore": { "type": "S3", "location": "techcourse-project-2026" },
+    "stages": [
+      {
+        "name": "Source",
+        "actions": [{
+          "name": "GitHubSource",
+          "namespace": "SourceVariables",
+          "actionTypeId": { "category": "Source", "owner": "ThirdParty", "provider": "GitHub", "version": "1" },
+          "configuration": { "Owner": "woowacourse-teams", "Repo": "2026-Mapmory", "Branch": "landing-release", "PollForSourceChanges": "false" },
+          "outputArtifacts": [{ "name": "SourceArtifact" }],
+          "runOrder": 1
+        }]
+      },
+      {
+        "name": "Build",
+        "actions": [{
+          "name": "BuildAndTestLanding",
+          "actionTypeId": { "category": "Build", "owner": "AWS", "provider": "CodeBuild", "version": "1" },
+          "configuration": {
+            "ProjectName": "mapmory-landing-build",
+            "EnvironmentVariables": "[{\"name\":\"SOURCE_COMMIT_ID\",\"value\":\"#{SourceVariables.CommitId}\",\"type\":\"PLAINTEXT\"}]"
+          },
+          "inputArtifacts": [{ "name": "SourceArtifact" }],
+          "outputArtifacts": [{ "name": "LandingBundle" }],
+          "runOrder": 1
+        }]
+      },
+      {
+        "name": "Approve",
+        "actions": [{
+          "name": "ApproveLandingProduction",
+          "actionTypeId": { "category": "Approval", "owner": "AWS", "provider": "Manual", "version": "1" },
+          "configuration": {
+            "CustomData": "Mapmory release owner: approve only after CodeRabbit/required checks pass and this SHA is the latest landing-release head: #{SourceVariables.CommitId}. Never approve a backend deployment here.",
+            "ExternalEntityLink": "https://github.com/woowacourse-teams/2026-Mapmory/commit/#{SourceVariables.CommitId}"
+          },
+          "runOrder": 1
+        }]
+      },
+      {
+        "name": "Deploy",
+        "actions": [{
+          "name": "DeployLandingOnly",
+          "actionTypeId": { "category": "Deploy", "owner": "AWS", "provider": "CodeDeploy", "version": "1" },
+          "configuration": { "ApplicationName": "mapmory-landing", "DeploymentGroupName": "mapmory-landing-production" },
+          "inputArtifacts": [{ "name": "LandingBundle" }],
+          "runOrder": 1
+        }]
+      }
+    ]
+  }
+}

--- a/landing/scripts/deploy-ec2.sh
+++ b/landing/scripts/deploy-ec2.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 release_id="${1:?release id is required}"
 archive_path="${2:?archive path is required}"
 
-if [[ ! "$release_id" =~ ^[0-9a-f]{40}-[0-9]+$ ]]; then
+if [[ ! "$release_id" =~ ^[0-9a-f]{40}-[0-9]+(-[0-9]+)?$ ]]; then
   echo "Invalid release id: $release_id" >&2
   exit 2
 fi

--- a/landing/scripts/package-codedeploy.sh
+++ b/landing/scripts/package-codedeploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+sha="${1:?commit SHA is required}"
+output="${2:?output archive is required}"
+[[ "$sha" =~ ^[0-9a-f]{40}$ ]] || { echo 'Invalid commit SHA' >&2; exit 2; }
+landing_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+[[ -f "$landing_root/dist/client/index.html" ]] || { echo 'Build the landing first' >&2; exit 1; }
+
+# The archive contains only static client files and landing-specific deployment hooks.
+bundle="$(mktemp -d)"
+trap 'rm -rf -- "$bundle"' EXIT
+cp -R -- "$landing_root/dist/client" "$bundle/client"
+printf '%s\n' "$sha" > "$bundle/client/release.txt"
+cp -- "$landing_root/codedeploy/appspec.yml" "$bundle/appspec.yml"
+mkdir -- "$bundle/scripts"
+cp -- "$landing_root/codedeploy/activate.sh" "$bundle/scripts/activate.sh"
+chmod 755 "$bundle/scripts/activate.sh"
+tar -czf "$output" -C "$bundle" appspec.yml scripts client

--- a/landing/tests/fixtures/codedeploy-activation.sh
+++ b/landing/tests/fixtures/codedeploy-activation.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+source "$(dirname -- "${BASH_SOURCE[0]}")/../../codedeploy/activate.sh"
+scenario="${1:?scenario}"
+fixture="$(mktemp -d)"
+trap 'rm -rf -- "$fixture"' EXIT
+root="$fixture/landing"
+bundle="$fixture/bundle"
+mkdir -p "$root/releases/old" "$bundle/client" "$fixture/outside"
+printf old > "$root/releases/old/index.html"
+printf external > "$fixture/outside/index.html"
+ln -s "$root/releases/old" "$root/current"
+sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+printf new > "$bundle/client/index.html"
+printf '%s\n' "$sha" > "$bundle/client/release.txt"
+deployment_id=d-TEST123
+
+# Never call host services or the network. Filesystem operations stay under mktemp.
+chown() { return 0; }
+nginx() { [[ "$scenario" != nginx-failure ]]; }
+systemctl() {
+  [[ "$*" == 'reload nginx' ]] || return 99
+  if [[ "$scenario" == reload-failure && ! -f "$fixture/reload-failed" ]]; then
+    touch "$fixture/reload-failed"
+    return 1
+  fi
+}
+curl() {
+  [[ "$scenario" != http-failure ]] || return 22
+  if [[ "$*" == *release.txt* ]]; then
+    if [[ "$scenario" == identity-failure ]]; then printf wrong; else printf '%s' "$sha"; fi
+  fi
+}
+case "$scenario" in
+  bad-marker) printf '../bad' > "$bundle/client/release.txt" ;;
+  bad-id) deployment_id=../bad ;;
+  missing-previous) unlink "$root/current" ;;
+  outside-previous) ln -sfnT "$fixture/outside" "$root/current" ;;
+  duplicate) mkdir "$root/releases/$sha-$deployment_id" ;;
+  symlink-bundle) ln -s "$fixture/outside/index.html" "$bundle/client/escape" ;;
+  locked) flock() { return 1; } ;;
+esac
+set +e
+( set -e; activate_release "$root" "$bundle" "$deployment_id" )
+status=$?
+set -e
+if [[ "$scenario" == success ]]; then
+  [[ "$status" == 0 ]]
+  [[ "$(readlink -f "$root/current")" == "$root/releases/$sha-$deployment_id" ]]
+  [[ "$(cat "$root/current/release.txt")" == "$sha" ]]
+else
+  [[ "$status" != 0 ]]
+  case "$scenario" in
+    missing-previous) [[ ! -L "$root/current" ]] ;;
+    outside-previous) [[ "$(readlink -f "$root/current")" == "$fixture/outside" ]] ;;
+    *) [[ "$(readlink -f "$root/current")" == "$root/releases/old" ]] ;;
+  esac
+fi
+[[ "$(cat "$root/releases/old/index.html")" == old ]]
+[[ "$(cat "$fixture/outside/index.html")" == external ]]
+echo "PASS $scenario"

--- a/landing/tests/release-workflow.test.mjs
+++ b/landing/tests/release-workflow.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const workflow = readFileSync(new URL("../../.github/workflows/landing-release.yml", import.meta.url), "utf8");
+const script = readFileSync(new URL("../scripts/deploy-ec2.sh", import.meta.url), "utf8").replace(/\r\n/g, "\n");
+const bash = process.platform === "win32" ? "C:/Program Files/Git/bin/bash.exe" : "/bin/bash";
+
+test("release validation runs for every release PR with the ruleset's unique check name", () => {
+  assert.match(workflow, /pull_request:\s+branches: \[landing-release\]/);
+  assert.match(workflow, /push:\s+branches: \[landing-release\]/);
+  assert.doesNotMatch(workflow, /paths(?:-ignore)?:/);
+  assert.match(workflow, /name: Landing release validation/);
+  assert.ok(workflow.indexOf("run: npm run build") < workflow.indexOf("run: npm test"));
+});
+
+test("production deploy is gated by repository, release branch, tests, and environment", () => {
+  const deploy = workflow.split("  deploy:\n")[1];
+  assert.ok(deploy);
+  assert.match(deploy, /github\.repository == 'woowacourse-teams\/2026-Mapmory'/);
+  assert.match(deploy, /github\.event_name != 'pull_request'/);
+  assert.match(deploy, /github\.ref == 'refs\/heads\/landing-release'/);
+  assert.match(deploy, /needs: validate/);
+  assert.match(deploy, /environment:\s+name: landing-production/);
+  assert.match(deploy, /cancel-in-progress: false/);
+  assert.match(deploy, /head_sha.*!=.*GITHUB_SHA/);
+});
+
+test("deployment packages static assets and checks the public commit identity", () => {
+  assert.match(workflow, /tar -czf.*-C dist\/client \./);
+  assert.match(workflow, /GITHUB_SHA.*> dist\/client\/release\.txt/);
+  assert.match(workflow, /deployed_sha.*==.*GITHUB_SHA/);
+  assert.match(workflow, /StrictHostKeyChecking=yes/);
+  assert.doesNotMatch(workflow, /secrets\.EC2_|backend-release|pull_request_target/);
+});
+
+test("deployment shell syntax is valid", { skip: !existsSync(bash) }, () => {
+  const result = spawnSync(bash, ["-n"], { input: script, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr || String(result.error));
+});
+
+test("deployment rejects invalid paths before running remote mutations", { skip: !existsSync(bash) }, () => {
+  const sha = "a".repeat(40);
+  for (const release of [sha + "-42", sha + "-12345-2"]) {
+    const result = spawnSync(bash, ["-s", "--", release, "/tmp/not-a-landing-archive.tar.gz"], {
+      input: script, encoding: "utf8",
+    });
+    assert.equal(result.status, 2, result.stderr || String(result.error));
+    assert.match(result.stderr, /Invalid archive path/);
+  }
+  for (const release of ["../outside", sha + "-12;echo unsafe", sha + "-12-3-4"]) {
+    const result = spawnSync(bash, ["-s", "--", release, "/tmp/mapmory-landing-12345-2.tar.gz"], {
+      input: script, encoding: "utf8",
+    });
+    assert.equal(result.status, 2, result.stderr || String(result.error));
+    assert.match(result.stderr, /Invalid release id/);
+  }
+});

--- a/landing/tests/release-workflow.test.mjs
+++ b/landing/tests/release-workflow.test.mjs
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 const workflow = readFileSync(new URL("../../.github/workflows/landing-release.yml", import.meta.url), "utf8");
 const script = readFileSync(new URL("../scripts/deploy-ec2.sh", import.meta.url), "utf8").replace(/\r\n/g, "\n");
 const bash = process.platform === "win32" ? "C:/Program Files/Git/bin/bash.exe" : "/bin/bash";
+const buildspec = readFileSync(new URL("../buildspec.yml", import.meta.url), "utf8");
+const resources = JSON.parse(readFileSync(new URL("../codedeploy/aws-resources.json", import.meta.url), "utf8"));
+const hook = readFileSync(new URL("../codedeploy/activate.sh", import.meta.url), "utf8");
+const packager = readFileSync(new URL("../scripts/package-codedeploy.sh", import.meta.url), "utf8");
 
 test("release validation runs for every release PR with the ruleset's unique check name", () => {
   assert.match(workflow, /pull_request:\s+branches: \[landing-release\]/);
@@ -15,30 +20,82 @@ test("release validation runs for every release PR with the ruleset's unique che
   assert.ok(workflow.indexOf("run: npm run build") < workflow.indexOf("run: npm test"));
 });
 
-test("production deploy is gated by repository, release branch, tests, and environment", () => {
-  const deploy = workflow.split("  deploy:\n")[1];
-  assert.ok(deploy);
-  assert.match(deploy, /github\.repository == 'woowacourse-teams\/2026-Mapmory'/);
-  assert.match(deploy, /github\.event_name != 'pull_request'/);
-  assert.match(deploy, /github\.ref == 'refs\/heads\/landing-release'/);
-  assert.match(deploy, /needs: validate/);
-  assert.match(deploy, /environment:\s+name: landing-production/);
-  assert.match(deploy, /cancel-in-progress: false/);
-  assert.match(deploy, /head_sha.*!=.*GITHUB_SHA/);
+test("CodePipeline preserves landing-only source, build, approval, and deployment order", () => {
+  const pipeline = resources.codePipeline;
+  assert.deepEqual(pipeline.stages.map(stage => stage.name), ["Source", "Build", "Approve", "Deploy"]);
+  const [source, build, approve, deploy] = pipeline.stages.map(stage => stage.actions[0]);
+  assert.equal(source.actionTypeId.provider, "GitHub");
+  assert.equal(source.actionTypeId.version, "1");
+  assert.equal(source.configuration.Owner, "woowacourse-teams");
+  assert.equal(source.configuration.Branch, "landing-release");
+  assert.equal(build.configuration.ProjectName, "mapmory-landing-build");
+  assert.equal(approve.actionTypeId.provider, "Manual");
+  assert.match(approve.configuration.CustomData, /CodeRabbit.*latest landing-release head/);
+  assert.equal(deploy.configuration.ApplicationName, "mapmory-landing");
+  assert.equal(deploy.configuration.DeploymentGroupName, "mapmory-landing-production");
+  assert.equal(pipeline.executionMode, "SUPERSEDED");
+  assert.doesNotMatch(workflow, /id-token:|configure-aws-credentials|secrets\.|\bssh\b.*-|\bscp\b/);
 });
 
-test("deployment packages static assets and checks the public commit identity", () => {
-  assert.match(workflow, /tar -czf.*-C dist\/client \./);
-  assert.match(workflow, /GITHUB_SHA.*> dist\/client\/release\.txt/);
-  assert.match(workflow, /deployed_sha.*==.*GITHUB_SHA/);
-  assert.match(workflow, /StrictHostKeyChecking=yes/);
-  assert.doesNotMatch(workflow, /secrets\.EC2_|backend-release|pull_request_target/);
+test("CodeBuild binds the tested source SHA to a static-only CodeDeploy bundle", () => {
+  assert.match(buildspec, /CODEBUILD_RESOLVED_SOURCE_VERSION.*SOURCE_COMMIT_ID/);
+  assert.ok(buildspec.indexOf("npm run build") < buildspec.indexOf("npm test"));
+  assert.match(buildspec, /CODEBUILD_BUILD_SUCCEEDING/);
+  assert.match(packager, /dist\/client/);
+  assert.match(packager, /sha.*>.*client\/release\.txt/);
+  assert.match(packager, /tar -czf.*appspec\.yml scripts client/);
+  assert.match(hook, /served_sha.*==.*sha/);
+  assert.doesNotMatch(buildspec, /gradlew|backend\/|npm run dev/);
+});
+
+test("shared-account resources use approved roles, storage, logs, tags and bounded builds", () => {
+  assert.deepEqual(Object.fromEntries(resources.tags.map(({key, value}) => [key, value])), {
+    Service: "techcourse", Role: "techcourse-etc", ProjectTeam: "Mapmory",
+  });
+  assert.equal(resources.codeDeploy.serviceRoleName, "codedeploy-project");
+  assert.equal(resources.codeBuild.serviceRoleName, "codebuild-project");
+  assert.equal(resources.codePipeline.serviceRoleName, "codepipeline-project");
+  assert.equal(resources.codePipeline.artifactStore.location, "techcourse-project-2026");
+  assert.equal(resources.codeBuild.logsConfig.cloudWatchLogs.groupName, "/aws/codebuild/project-2026");
+  assert.equal(resources.codeBuild.concurrentBuildLimit, 1);
+  assert.equal(resources.codeBuild.timeoutInMinutes, 15);
+  assert.equal(resources.codeBuild.environment.privilegedMode, false);
+  assert.equal(resources.codeDeploy.ec2TagSet.ec2TagSetList.length, 2);
+  assert.equal(resources.codeDeploy.autoRollbackConfiguration.enabled, true);
+});
+
+test("CodeDeploy hook is confined to the landing and does not stop backend services", () => {
+  assert.match(hook, /APPLICATION_NAME.*mapmory-landing/);
+  assert.match(hook, /DEPLOYMENT_GROUP_NAME.*mapmory-landing-production/);
+  assert.match(hook, /activate_release \/var\/www\/mapmory/);
+  assert.match(hook, /mv -Tf/);
+  assert.match(hook, /restore_previous/);
+  assert.doesNotMatch(hook, /systemctl (?:restart|stop)|backend|\/opt\/mapmory|rm -rf/);
 });
 
 test("deployment shell syntax is valid", { skip: !existsSync(bash) }, () => {
-  const result = spawnSync(bash, ["-n"], { input: script, encoding: "utf8" });
-  assert.equal(result.status, 0, result.stderr || String(result.error));
+  for (const input of [script, hook, packager]) {
+    const result = spawnSync(bash, ["-n"], { input, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr || String(result.error));
+  }
 });
+
+test("CodeDeploy rejects use from the backend group before filesystem access", () => {
+  const result = spawnSync(bash, ["-s"], {
+    input: hook, encoding: "utf8",
+    env: {...process.env, APPLICATION_NAME: "mapmory-backend", DEPLOYMENT_GROUP_NAME: "mapmory-prod"},
+  });
+  assert.equal(result.status, 2, result.stderr);
+  assert.match(result.stderr, /only in the landing/);
+});
+
+for (const scenario of ["success", "reload-failure", "identity-failure", "http-failure", "nginx-failure", "bad-marker", "bad-id", "missing-previous", "outside-previous", "duplicate", "symlink-bundle", "locked"]) {
+  test(`CodeDeploy activation fixture: ${scenario}`, { skip: process.platform === "win32" ? "Linux filesystem/flock fixture runs in CI and CodeBuild" : false }, () => {
+    const fixture = fileURLToPath(new URL("./fixtures/codedeploy-activation.sh", import.meta.url));
+    const result = spawnSync(bash, [fixture, scenario], {encoding: "utf8", timeout: 15000});
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  });
+}
 
 test("deployment rejects invalid paths before running remote mutations", { skip: !existsSync(bash) }, () => {
   const sha = "a".repeat(40);


### PR DESCRIPTION
## 변경 내용
- landing-release 필수 PR 검증 유지
- SSH 배포 대신 교육기관 지정 CodePipeline → CodeBuild → 수동 승인 → CodeDeploy 구성
- 기존 서비스 역할 재사용, 필수 태그와 프론트엔드 전용 아티팩트 저장소 규칙 반영
- 랜딩 전용 AppSpec, 원자적 릴리스 전환, 실패 시 이전 버전 복구
- 백엔드 배포·공용 IAM·네트워크 설정 변경 없음

## 검증
- 로컬 프로덕션 빌드 성공
- Windows 테스트 55개 통과; Linux 전용 활성화/복구 12개는 CI에서 실행
- CodeDeploy 묶음 패키징과 잘못된 경로/대상 차단 검증 추가

## 운영 상태
- 현재 운영 사이트는 기존 수동 배포 버전 그대로입니다.
- AWS 설정 파일은 구성 명세이며, 파이프라인 생성/첫 배포 성공을 의미하지 않습니다.
- CodeRabbit 리뷰와 CI 확인 후에만 병합합니다.
- AWS 리소스 생성 전 대상·절차·비용·위험을 사용자에게 공지하며, 배포 전 수동 승인 단계를 유지합니다.