### PR TITLE
feat(landing): Recap 원본 사진 선택과 운영 측정 보강

### DIFF
--- a/landing/ANALYTICS_MEASUREMENT_PLAN.md
+++ b/landing/ANALYTICS_MEASUREMENT_PLAN.md
@@ -52,9 +52,9 @@
 
 | 이벤트 | 의미 / 추가 속성 |
 | --- | --- |
-| `travel_map_photo_select` / `travel_map_demo_start` | 내 사진 선택 / 샘플 시작; `selected_photos` |
-| `travel_map_processing_complete` | 경로 생성 가능; `selected_photos`, `valid_gps_photos`, `duration_seconds` |
-| `travel_map_photo_analysis_empty` | 분석했으나 GPS 경로 없음; 메타데이터 누락/판독 실패/미지원 개수 |
+| `travel_map_photo_select` / `travel_map_demo_start` | 내 사진 선택 / 샘플 시작; `selected_photos`, 내 사진은 `picker_source=file_system_access|legacy_input` |
+| `travel_map_processing_complete` | 경로 생성 가능; `selected_photos`, `valid_gps_photos`, `duration_seconds`, `picker_source` |
+| `travel_map_photo_analysis_empty` | 분석했으나 GPS 경로 없음; 메타데이터 누락/판독 실패/미지원 개수, `picker_source` |
 | `travel_map_processing_failed` | 분석 예외; `error_type=analysis_failed` |
 | `travel_map_replay_complete` | 경로 재생 종료. 영상 파일 생성 성공을 뜻하지 않음 |
 | `travel_map_recap_view` | 결과 미리보기 표시 |
@@ -99,10 +99,12 @@ Recap 내부 화면을 가짜 `page_view`로 보내지 않고 단계별 이벤�
 - Recap→메인 내부 링크에 UTM을 붙이지 않는다. `travel_map_landing_click`으로 진단한다.
 - 외부 Google Play Install Referrer 표기는 유지. 실제 설치 귀속은 별도 검증 대상이다.
 - 두 앱 모두 `VITE_GA_MEASUREMENT_ID` 명시 필수. CodeBuild에 운영 ID가 전달되는지 배포 전에 확인한다.
+- 두 앱은 같은 `VITE_POSTHOG_KEY`와 `VITE_POSTHOG_HOST`를 사용하지만 각각 SDK를 초기화한다. `/recap/` 직접 진입도 메인 랜딩을 거치지 않고 `$pageview`와 Recap 이벤트를 전송해야 한다.
 - CodeBuild는 측정 ID가 없거나 QA/debug 플래그가 켜진 경우 빌드 전에 실패시켜 추적이 빠진 운영 배포를 방지한다.
 - `map-mory.com`/`www.map-mory.com` 외 기본 비활성. QA만 `VITE_GA_CAPTURE_LOCAL=true`, `VITE_GA_DEBUG=true`와 `?internal=1` 사용.
 - 내부 표시는 같은 출처 저장소 공유. 보고서에서 제외하되 영구 데이터 제외 필터는 임의 활성화하지 않는다.
 - 동의 설정·보존기간·Ads 연동·데이터 삭제 정책은 이번 변경에서 수정하지 않는다.
 - 가짜 측정 ID·네트워크 차단 테스트 통과는 GA4 실수신 증거가 아니다.
+- PostHog 운영 타일과 필터는 [POSTHOG_DASHBOARD_SETUP.md](POSTHOG_DASHBOARD_SETUP.md)를 따르며, 코드 연결과 Live Events 수신·대시보드 저장을 각각 확인한다.
 
 이전 계획과 가설은 [보존 문서](ANALYTICS_MEASUREMENT_HISTORY.md)에 남긴다.

--- a/landing/DEPLOYMENT.md
+++ b/landing/DEPLOYMENT.md
@@ -6,7 +6,7 @@
 - Reuse the institution account and its designated roles. Do not create IAM users, access keys or OIDC roles, modify shared policies, widen SSH/network access, or inspect other teams' resources.
 - Every created resource must carry `Service=techcourse`, `Role=techcourse-etc`, `ProjectTeam=Mapmory`. Apply the common tags in `codedeploy/aws-resources.json` to **each** application, deployment group, build project and pipeline; the JSON is a blueprint, not a CLI request.
 - Monthly team limits provided by the institution: August $50, September $60, October onward $70. EC2 estimates are not the complete team bill. Check the team's usage before provisioning; CodeBuild minutes, CodePipeline and S3 add cost. Do not create budgets, dashboards or alarms with extra costs without discussion.
-- Use `techcourse-project-2026` for frontend source/build/deployment artifacts. CodePipeline generates a Mapmory-identifiable artifact prefix; the live prefix is `mapmory-landing-rele/` (AWS truncates names). Do not change bucket policy, lifecycle or other prefixes. Do not use the backend artifact bucket for frontend serving/deployment.
+- Use `techcourse-project-2026-artifact` for frontend source/build/deployment artifacts. CodePipeline generates a Mapmory-identifiable artifact prefix; the live prefix is `mapmory-landing-rele/` (AWS truncates names). Do not change bucket policy, lifecycle or other prefixes. Do not use `techcourse-project-2026` or the backend artifact bucket for frontend serving/deployment.
 - Permissions or bucket-role mismatches must be raised in the institution's technical-review channel. Never work around them by changing shared IAM policies. Most deletion permissions are absent; avoid speculative resources.
 
 ## Branch, review and approval

--- a/landing/POSTHOG_DASHBOARD_SETUP.md
+++ b/landing/POSTHOG_DASHBOARD_SETUP.md
@@ -1,25 +1,16 @@
-# Mapmory PostHog 대시보드 설정
+# Mapmory PostHog 운영 대시보드 설정
 
-> 아래는 v2 출시 전 대시보드 설정 기록이다. 현재 기준은 [ANALYTICS_MEASUREMENT_PLAN.md](ANALYTICS_MEASUREMENT_PLAN.md)를 따른다. 운영 시 `surface=landing`, `analytics_schema_version=2`, `traffic_type=external`, `landing_version=v3`로 분리하고 최종 전환은 두 스토어의 `download_click`이다. 아래 출시 알림 폼을 현재 퍼널에 다시 넣지 않는다. 이번 코드 변경이 기존 PostHog 대시보드 설정까지 수정한 것은 아니다.
+갱신: 2026-09-05 · 현재 스키마: `analytics_schema_version=2`
 
 ## 목적
 
-GA4에서 여러 탐색 보고서를 반복해서 만들지 않고, 랜딩의 제품 체험 흐름을 한 화면에서 진단한다. GA4는 유입과 최종 전환 판단에 유지하고 PostHog은 체험 퍼널, 활성 시간, 기억 열람 깊이, 단계별 이탈의 운영 화면으로 사용한다.
+PostHog에서는 랜딩의 제품 체험과 Recap의 실제 사진 처리·공유·앱 전환을 한 화면에서 진단한다. GA4는 유입과 전체 스토어 전환의 기준으로 유지한다. PostHog의 비율은 같은 기간의 고유 사용자 기준으로 비교하며 이벤트 수와 혼용하지 않는다.
 
-## 현재 구성 상태
+기존 `Landing · Product Experience v2` 대시보드는 출시 전 기록으로 보존한다. 운영용 새 대시보드는 `Landing + Recap · Growth v3`로 만들고 기본 기간을 최근 14일로 설정한다.
 
-2026-08-28 기준 PostHog 프로젝트에 `Landing · Product Experience v2` 대시보드를 생성했다.
+## 프로젝트 연결과 개인정보 기본값
 
-- 대시보드: `https://us.posthog.com/project/580627/dashboard/2039395`
-- 생성된 첫 차트: `랜딩 체험 핵심 퍼널`
-- 현재 단계: `$pageview → experience_view → experience_start → memory_open`
-- 집계: 고유 사용자, 순차 퍼널, 전환 창 1일
-
-현재 차트의 값에는 초기 연결 QA가 포함되어 있으므로 성과 판정에는 사용하지 않는다. 운영 분석에는 `traffic_type != internal` 공통 필터를 적용하고, 초기 QA 이벤트는 알려진 테스트 시간대·세션으로 별도 제외한다.
-
-## 1. 프로젝트 연결
-
-PostHog 프로젝트 설정 화면에서 Project API key와 Host를 확인하고 배포 환경에 다음 값을 넣는다.
+두 앱 모두 같은 PostHog 프로젝트를 사용한다.
 
 ```text
 VITE_POSTHOG_KEY=<Project API key>
@@ -27,86 +18,105 @@ VITE_POSTHOG_HOST=<프로젝트 설정에 표시된 Host>
 VITE_POSTHOG_CAPTURE_LOCAL=false
 ```
 
-두 값 중 하나라도 없으면 PostHog은 초기화되지 않으며 GA4는 계속 정상 작동한다. 로컬 검증이 꼭 필요할 때만 별도의 테스트 프로젝트에서 `VITE_POSTHOG_CAPTURE_LOCAL=true`를 사용한다.
+메인 랜딩과 `/recap/`은 각각 독립적으로 SDK를 초기화하고 `$pageview`를 한 번 보낸다. 둘 중 한 화면을 먼저 거칠 필요가 없다. 두 값 중 하나라도 비어 있으면 PostHog은 비활성화된다.
 
-현재 구현은 다음 항목을 기본으로 비활성화한다.
+코드 기본값은 자동 클릭·입력 수집과 자동 페이지뷰, 세션 녹화, 설문, 기능 플래그 요청, 개인 프로필, 영구 식별, GeoIP 보강을 비활성화한다. 사진 파일명·좌표·촬영시각·내용, 이메일·전화번호·주소·자유 입력은 이벤트 속성으로 보내지 않는다. PostHog 프로젝트에서도 `Discard client IP data`를 사용한다.
 
-- 자동 클릭·입력 수집
-- 자동 페이지뷰·페이지 이탈 수집
-- 세션 녹화
-- 개인 프로필 생성
-- 쿠키·로컬 스토리지 기반 영구 식별
-- 설문과 기능 플래그 요청
-- IP 기반 도시·위경도 보강
+## 대시보드 공통 필터
 
-페이지 진입은 코드가 `$pageview`를 한 번 명시적으로 전송한다. 모든 이벤트는 GeoIP 보강을 거부한다. PostHog SDK가 브라우저·기기·페이지 같은 표준 진단 속성을 추가할 수 있지만, Mapmory의 커스텀 속성에는 출시 알림 이메일, 개인정보 동의값, 만 14세 확인값을 보내지 않는다. 프로젝트 설정의 `Discard client IP data`도 켜서 서버 측 IP 저장을 막는다.
-
-팀 내부 검수 브라우저는 한 번 `https://map-mory.com/?internal=1`로 접속해 분석 전용 로컬 표시를 저장한다. 이후 모든 이벤트에 `traffic_type=internal`이 붙는다. `?internal=0`으로 해제할 수 있으며, 이 URL은 인증이나 보안 경계가 아니다.
-
-## 2. 대시보드 만들기
-
-대시보드 이름은 `Landing · Product Experience v2`로 한다. 기본 기간은 최근 14일, 운영 공통 필터는 `landing_version = v2`, `traffic_type != internal`로 시작한다.
-
-### 타일 A · 전체 순차 퍼널
-
-순서를 고정한 Funnel 인사이트를 만든다.
+모든 운영 타일에 다음 필터를 적용한다.
 
 ```text
-$pageview
-→ experience_view
-→ experience_start
-→ memory_open (open_index = 1)
-→ waitlist_form_view
-→ waitlist_submit_attempt
-→ waitlist_submit
+analytics_schema_version = 2
+traffic_type = external
 ```
 
-전환 창은 한 세션 안에서 끝나는 랜딩 흐름에 맞게 1일로 설정한다. CTA를 누르지 않고 체험 영역으로 바로 스크롤한 방문자도 포함하기 위해 `experience_cta_click`은 핵심 퍼널 단계에서 제외하고 별도 진단에 사용한다.
+랜딩 타일은 `surface=landing`, Recap 타일은 `surface=recap`을 추가한다. 내부 QA는 `?internal=1`로 표시하고 운영 수치에서 제외하며 `?internal=0`으로 해제한다. 이 표시는 인증 기능이 아니다.
 
-### 타일 B · 정확한 활성 체험시간
+## 운영 타일
 
-`experience_end`만 선택하고 숫자 속성 `active_duration_ms`의 중앙값을 본다. 가능하면 25·75 백분위도 함께 표시한다. 평균은 소수의 장시간 체험에 크게 흔들리므로 보조값으로만 사용한다.
+### 01 · 전체 앱 전환
 
-### 타일 C · 기억 열람 깊이
+Trends에서 `$pageview`와 `download_click`의 고유 사용자를 같은 기간에 표시한다. `download_click`은 `surface`, `store`, `cta_placement`로 나눈다.
 
-`experience_end`의 `unique_memories_opened`를 다음 세 구간으로 나눈다.
+```text
+앱 전환 의도율 = download_click 고유 사용자 / $pageview 고유 사용자
+```
 
-- 0개
-- 1개
-- 2개 이상
+스토어 이동이며 설치 완료가 아니다. 두 스토어 클릭을 합산하지 말고 `download_click` 고유 사용자로 중복을 제거한다.
 
-`experience_type`으로 분리해 지구본과 대한민국 상세지도 중 어느 흐름에서 기억이 더 깊게 열리는지 확인한다.
+### 02 · 랜딩 체험 퍼널
 
-### 타일 D · 첫 가치 도달시간
+순서 고정 Funnel, 전환 창 1일:
 
-`memory_open` 중 `open_index = 1`만 선택하고 `time_since_start_ms` 중앙값을 본다. 시간이 길어지면서 기억 열기 비율이 함께 떨어지면 조작 안내나 전환 모션을 먼저 점검한다.
+```text
+$pageview → experience_view → experience_start
+→ memory_open (open_index = 1) → download_click
+```
 
-### 타일 E · 폼 마찰
+`experience_type`과 기기 유형으로 나눈다. 이 퍼널은 병목 진단용이며 스토어 전환의 필수 경로로 해석하지 않는다.
 
-`waitlist_submit_attempt → waitlist_submit` 퍼널과 `waitlist_submit_error` 추이를 함께 둔다. 오류는 `error_type`과 `validation_field`로 나누며 이메일이나 입력값은 분석 속성으로 추가하지 않는다.
+### 03 · Recap 실제 사진 퍼널
 
-## 3. 공통 분해 기준
+`journey_source=photos`를 고정한 순서 고정 Funnel, 전환 창 1일:
 
-모든 타일에서 필요한 경우에만 다음 기준으로 나눈다.
+```text
+travel_map_photo_select → travel_map_processing_complete
+→ travel_map_recap_view → travel_map_demand_view → download_click
+```
 
-- `landing_version`
-- `traffic_type` (`external`, `internal`)
-- 모바일·데스크톱
-- `experience_type`
-- 유입 소스와 캠페인
+샘플 사용자는 이 타일에서 제외한다. 공유 없이 앱 안내로 이동한 사용자도 정상 흐름이다.
 
-표본이 100세션보다 적을 때는 백분율 변화에 성공·실패 판정을 붙이지 않는다. 초기에는 이벤트가 의도한 시점에 들어오는지와 비정상적인 0값·중복만 확인한다.
+### 04 · Recap 사진 판독 품질
 
-## 4. 출시 전 확인
+한 타일에 `travel_map_photo_select`, `travel_map_processing_complete`, `travel_map_photo_analysis_empty`, `travel_map_processing_failed` 고유 사용자 추이를 표시한다. 먼저 `picker_source=file_system_access|legacy_input`으로 나눠 원본 파일 선택 경로가 GPS 성공률을 개선하는지 확인하고, 빈 결과는 `metadata_missing_photos`, `read_failed_photos`, `unsupported_photos`로 진단한다.
 
-- [ ] Project API key와 Host를 배포 환경에 설정
-- [ ] Project Settings의 IP data capture를 `Discard client IP data`로 설정
-- [ ] 개인정보·쿠키 안내에 실제 사용하는 분석 사업자와 처리 내용을 반영
-- [ ] PostHog Live Events에서 `$pageview`, `experience_start`, `memory_open`, `experience_end` 수신 확인
-- [ ] 이벤트 속성에 이메일·동의값·자유 입력이 없는지 확인
-- [ ] 팀 검수 기기에서 `?internal=1`을 한 번 열고 `traffic_type=internal` 수신 확인
-- [ ] 운영 대시보드에 `traffic_type != internal` 공통 필터 적용
-- [ ] GA4 DebugView와 PostHog Live Events에서 동일 조작의 이벤트 순서 비교
-- [ ] 위 다섯 타일을 만들고 팀 대시보드로 공유
+```text
+경로 생성률 = processing_complete 고유 사용자 / photo_select 고유 사용자
+GPS 유효 비율 = sum(valid_gps_photos) / sum(selected_photos)
+```
 
-세션 녹화가 필요해지면 별도 개인정보 검토와 명시적 결정 후 활성화한다. 현재 설정 변경만으로 자동 활성화하지 않는다.
+GPS 유효 비율은 속성 합계를 지원하는 Trends 또는 HogQL로 만들고 분모가 0인 기간은 제외한다. 사진 수는 입력 호환성 진단에만 사용한다.
+
+### 05 · 공유·저장 결과
+
+`journey_source=photos`를 기본으로 다음을 표시한다.
+
+- `travel_map_share_result`, breakdown `result`
+- `travel_map_video_saved`와 `travel_map_image_saved`, filter `result=download_started`
+- `travel_map_export_failed`, breakdown `format`, `error_type`
+
+`download_started`는 브라우저가 다운로드를 시작했다는 뜻이며 OS 저장 완료로 부르지 않는다. `cancelled`는 기술 실패와 분리한다.
+
+### 06 · Recap 샘플 대비 실제 사진
+
+다음 Funnel을 `journey_source`로 나눈다.
+
+```text
+travel_map_recap_view → travel_map_app_bridge_click
+→ travel_map_demand_view → download_click
+```
+
+`demo`가 높고 `photos`가 낮으면 앱 관심보다 사진 판독·결과 품질 문제를 먼저 본다. 표본이 100명보다 적을 때는 작은 비율 차이에 성공·실패 판정을 붙이지 않는다.
+
+### 07 · 랜딩 체험 깊이
+
+- `experience_end.active_duration_ms`: 중앙값과 25·75 백분위
+- `experience_end.unique_memories_opened`: 0개, 1개, 2개 이상
+- `memory_open(open_index=1).time_since_start_ms`: 중앙값
+
+평균 체류시간 하나만으로 체험 성공을 판단하지 않는다.
+
+## 출시·운영 검증
+
+- [ ] 메인 랜딩과 `/recap/`을 각각 새 탭에서 직접 열어 `$pageview` 수신 확인
+- [ ] 실제 사진 흐름에서 `photo_select → processing_complete|analysis_empty` 중 정확히 한 경로 확인
+- [ ] 실제 사진 이벤트의 `picker_source`가 `file_system_access|legacy_input` 중 하나이며 두 경로의 생성률 비교가 가능한지 확인
+- [ ] 샘플과 실제 사진에 `journey_source=demo|photos`가 구분되는지 확인
+- [ ] 공유 취소·다운로드 폴백·실패가 서로 다른 `result`로 보이는지 확인
+- [ ] `surface`, `analytics_schema_version`, `traffic_type` 공통 속성 확인
+- [ ] 파일명·좌표·촬영시각·이메일 등 개인정보 속성이 없는지 확인
+- [ ] `?internal=1` 이벤트가 운영 타일에서 제외되는지 확인
+- [ ] GA4 DebugView와 PostHog Live Events의 동일 동작 순서 비교
+
+코드 반영, 프로젝트 환경변수 설정, Live Events 실수신, 대시보드 저장은 각각 별도 증거로 확인한다. 어느 하나를 다른 단계의 완료로 보고하지 않는다.

--- a/landing/codedeploy/aws-resources.json
+++ b/landing/codedeploy/aws-resources.json
@@ -43,7 +43,7 @@
     "pipelineType": "V2",
     "executionMode": "SUPERSEDED",
     "serviceRoleName": "codepipeline-project",
-    "artifactStore": { "type": "S3", "location": "techcourse-project-2026" },
+    "artifactStore": { "type": "S3", "location": "techcourse-project-2026-artifact" },
     "stages": [
       {
         "name": "Source",

--- a/landing/tests/analytics-runtime.test.mjs
+++ b/landing/tests/analytics-runtime.test.mjs
@@ -6,18 +6,32 @@ import { build } from "esbuild";
 import { canCaptureGa, resolveMeasurementId } from "../src/analytics-contract.js";
 import { classifyGlobeGesture } from "../src/globe-gesture.js";
 
-async function loadAnalytics(surface, { env = {}, hostname = "map-mory.com", search = "?internal=1" } = {}) {
+async function loadAnalytics(surface, { env = {}, hostname = "map-mory.com", search = "?internal=1", mockPostHog = false } = {}) {
   const entry = surface === "landing" ? "../src/analytics.js" : "../travel-map-campaign/src/analytics.js";
+  const posthogPlugin = {
+    name: "mock-posthog",
+    setup(buildApi) {
+      buildApi.onResolve({ filter: /^posthog-js\/dist\/module\.no-external$/ }, () => ({ path: "posthog", namespace: "mock" }));
+      buildApi.onLoad({ filter: /.*/, namespace: "mock" }, () => ({
+        contents: `export default {
+          init: (...args) => window.__posthogCalls.push(["init", ...args]),
+          register: (...args) => window.__posthogCalls.push(["register", ...args]),
+          capture: (...args) => window.__posthogCalls.push(["capture", ...args]),
+        };`,
+      }));
+    },
+  };
   const result = await build({
     entryPoints: [fileURLToPath(new URL(entry, import.meta.url))], bundle: true,
-    write: false, format: "iife", globalName: "analytics", external: ["posthog-js/*"],
+    write: false, format: "iife", globalName: "analytics",
+    ...(mockPostHog ? { plugins: [posthogPlugin] } : { external: ["posthog-js/*"] }),
     define: { "import.meta.env": JSON.stringify({ VITE_GA_MEASUREMENT_ID: "G-TEST123", ...env }) },
   });
   const scripts = [];
   const storage = new Map();
   const context = vm.createContext({
     URLSearchParams, console,
-    window: { location: { hostname, search }, localStorage: {
+    window: { __posthogCalls: [], location: { hostname, search, pathname: surface === "landing" ? "/" : "/recap/" }, localStorage: {
       getItem: (key) => storage.get(key), setItem: (key, value) => storage.set(key, value), removeItem: (key) => storage.delete(key),
     } },
     document: { createElement: () => ({}), head: { appendChild: (script) => scripts.push(script) } },
@@ -26,6 +40,33 @@ async function loadAnalytics(surface, { env = {}, hostname = "map-mory.com", sea
   return { api: context.analytics, window: context.window, scripts,
     calls: () => JSON.parse(JSON.stringify((context.window.dataLayer ?? []).map((args) => [...args]))) };
 }
+
+test("Recap initializes its own PostHog client and sends scoped explicit events", async () => {
+  const harness = await loadAnalytics("recap", {
+    mockPostHog: true,
+    env: {
+      VITE_POSTHOG_KEY: "phc_test",
+      VITE_POSTHOG_HOST: "https://us.i.posthog.com",
+    },
+  });
+  harness.api.initializeCampaignAnalytics();
+  harness.api.trackCampaignEvent("travel_map_photo_select", {
+    journey_source: "photos", selected_photos: 3, filename: "private.jpg", latitude: 37.5,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const calls = JSON.parse(JSON.stringify(harness.window.__posthogCalls));
+  assert.equal(calls.filter(([name]) => name === "init").length, 1);
+  assert.equal(calls.filter(([name, event]) => name === "capture" && event === "$pageview").length, 1);
+  const event = calls.find(([name, eventName]) => name === "capture" && eventName === "travel_map_photo_select");
+  assert.ok(event);
+  assert.equal(event[2].surface, "recap");
+  assert.equal(event[2].analytics_schema_version, "2");
+  assert.equal(event[2].journey_source, "photos");
+  assert.equal(event[2].selected_photos, 3);
+  assert.equal(event[2].filename, undefined);
+  assert.equal(event[2].latitude, undefined);
+});
 
 test("GA is explicit, and production builds do not opt local/LAN previews in", () => {
   assert.equal(resolveMeasurementId({ PROD: true }), "");

--- a/landing/tests/release-workflow.test.mjs
+++ b/landing/tests/release-workflow.test.mjs
@@ -74,7 +74,7 @@ test("shared-account resources use approved roles, storage, logs, tags and bound
   assert.equal(resources.codeDeploy.serviceRoleName, "codedeploy-project");
   assert.equal(resources.codeBuild.serviceRoleName, "codebuild-project");
   assert.equal(resources.codePipeline.serviceRoleName, "codepipeline-project");
-  assert.equal(resources.codePipeline.artifactStore.location, "techcourse-project-2026");
+  assert.equal(resources.codePipeline.artifactStore.location, "techcourse-project-2026-artifact");
   assert.equal(resources.codeBuild.logsConfig.cloudWatchLogs.groupName, "/aws/codebuild/project-2026");
   assert.equal(resources.codeBuild.concurrentBuildLimit, 1);
   assert.equal(resources.codeBuild.timeoutInMinutes, 15);

--- a/landing/travel-map-campaign/package-lock.json
+++ b/landing/travel-map-campaign/package-lock.json
@@ -13,6 +13,7 @@
         "d3-geo": "3.1.1",
         "exifr": "7.1.3",
         "exifreader": "^4.44.0",
+        "posthog-js": "1.422.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "topojson-client": "3.1.0",
@@ -757,6 +758,31 @@
         "react-dom": ">= 16.8"
       }
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.6.2.tgz",
+      "integrity": "sha512-AZRETXzMXoCqNLGftKN7wtyhI+Da8y3WSYLrVzCyd7CSA2pIas1OjT4wsO3ncvX+Ezg0FJw5iSr84VtyVUcZ0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.49.1",
+        "@posthog/types": "^1.407.1"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.50.5",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.50.5.tgz",
+      "integrity": "sha512-afEchuShDaVIoxAIj76kDZQ1DhfesDmgfVp+mtTzsA3wlc8DF5uoz8YjuTjnxOicWkpP5HCDqYidK/1kT125Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.409.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.409.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.409.0.tgz",
+      "integrity": "sha512-239umoaZVb2GBaXeEyJpwFvjhrrChJH8NHCwiao23EBSu3NA6EN0MTMoaHSmMEf4yjiXEFFoYJA6FjJAXF5HGA==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
@@ -1135,6 +1161,13 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.4.tgz",
@@ -1242,6 +1275,20 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -1281,6 +1328,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1374,6 +1430,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1524,6 +1586,60 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/posthog-js": {
+      "version": "1.422.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.422.0.tgz",
+      "integrity": "sha512-m2mg6SLFZs9L2/L+a8+aeraR0LyijMrXLuwSbgfSeBLjHe99C4IR11Q2DV7R5qktVTwSx0Dg2kdMosx35/FfwQ==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.6.0",
+        "@posthog/core": "^1.49.0",
+        "@posthog/types": "^1.407.0",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.4.13",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0",
+        "web-vitals-soft-navs": "npm:web-vitals@6.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.0",
@@ -1756,6 +1872,19 @@
           "optional": true
         }
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/web-vitals-soft-navs": {
+      "name": "web-vitals",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.0.tgz",
+      "integrity": "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==",
+      "license": "Apache-2.0"
     },
     "node_modules/world-atlas": {
       "version": "2.0.2",

--- a/landing/travel-map-campaign/package.json
+++ b/landing/travel-map-campaign/package.json
@@ -22,6 +22,7 @@
     "d3-geo": "3.1.1",
     "exifr": "7.1.3",
     "exifreader": "^4.44.0",
+    "posthog-js": "1.422.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "topojson-client": "3.1.0",

--- a/landing/travel-map-campaign/src/App.jsx
+++ b/landing/travel-map-campaign/src/App.jsx
@@ -9,6 +9,7 @@ import { APP_ACQUISITION_URL, CAMPAIGN_LANDING_URL } from "./campaignConfig.js";
 import { analyzePhotoFiles, createPlaybackJourney, demoJourney, formatShortDate, getAutoDuration, getJourneyStats, getReplayDuration } from "./journeyData.js";
 import { drawJourneyMap, getActivePoint, loadJourneyImages } from "./mapRenderer.js";
 import { getJourneyProgressState } from "./journeyProgress.js";
+import { pickOriginalPhotoFiles } from "./photoPicker.js";
 import { downloadBlob, drawShareFrame, renderJourneyVideo, renderShareImage } from "./videoRenderer.js";
 import { shareVideo } from "./shareVideo.js";
 
@@ -72,8 +73,7 @@ function StatPills({ journey }) {
   return <div className="stat-pills" aria-label="여행 통계"><span><strong>{stats.trips}</strong> TRIPS</span><span><strong>{stats.cities}</strong> CITIES</span><span><strong>{stats.photos}</strong> PHOTOS</span></div>;
 }
 
-function EntryScreen({ onFiles, onDemo }) {
-  const inputRef = useRef(null);
+function EntryScreen({ onPickFiles, onDemo }) {
   return (
     <section className="screen screen-entry" aria-labelledby="entry-title">
       <CampaignHeader />
@@ -86,8 +86,7 @@ function EntryScreen({ onFiles, onDemo }) {
           <JourneyMap journey={demoJourney} progress={1} />
           <small>Map data · Natural Earth</small>
         </figure>
-        <input ref={inputRef} className="visually-hidden" type="file" accept=".jpg,.jpeg,.heic,.heif,.png,.tif,.tiff,.avif,.webp" multiple onChange={(event) => event.target.files?.length && onFiles(event.target.files)} />
-        <button className="primary-button" type="button" onClick={() => inputRef.current?.click()}><UploadSimple size={20} weight="bold" /> 사진 선택하고 지도 만들기</button>
+        <button className="primary-button" type="button" onClick={onPickFiles}><UploadSimple size={20} weight="bold" /> 원본 사진 선택하고 지도 만들기</button>
         <p className="accuracy-note">최대 200장 · 총 500MB · 사진 한 장 50MB 이하</p>
         <button className="text-button" type="button" onClick={onDemo}>사진 없이 샘플 결과 먼저 보기 <ArrowRight size={16} weight="bold" /></button>
         <aside className="privacy-note"><ShieldCheck size={23} weight="duotone" /><div><strong>원본 사진은 업로드하지 않아요</strong><p>이 브라우저에서 날짜·GPS만 읽고 결과를 만들어요.</p></div></aside>
@@ -119,7 +118,7 @@ function ProcessingScreen({ progress, selectedCount }) {
   );
 }
 
-function EmptyScreen({ analysis, selectedCount, onRetry, onDemo }) {
+function EmptyScreen({ analysis, selectedCount, onRetry, onRetryOriginals, onDemo }) {
   const supportedCount = analysis?.supportedPhotoCount ?? 0;
   const readFailedCount = analysis?.readFailedCount ?? 0;
   const unsupportedCount = analysis?.unsupportedCount ?? 0;
@@ -130,17 +129,17 @@ function EmptyScreen({ analysis, selectedCount, onRetry, onDemo }) {
     ? "선택한 파일을 분석할 수 없어요."
     : parserFailedCompletely
       ? "파일 정보를 읽는 중 문제가 생겼어요."
-      : "웹에서 받은 파일에 GPS 좌표가 없어요.";
+      : "웹에 전달된 사진에서 GPS가 빠졌어요.";
   const description = analysis?.error || (unsupportedCompletely
     ? "JPG, HEIC, HEIF, PNG, TIFF, AVIF, WEBP 형식의 사진을 선택해주세요."
     : parserFailedCompletely
       ? "사진은 정상적으로 선택됐지만 파일 내부 정보를 판독하지 못했습니다."
-      : "사진 앱에 위치가 표시되어도 웹에 전달된 파일에는 좌표가 빠질 수 있어요.");
+      : "Android 사진 선택기는 사진 앱에 위치가 표시되어도 웹에 넘기는 파일에서 좌표를 가릴 수 있어요.");
   const resultMessage = analysis?.error ? "사진 수와 용량을 확인한 뒤 다시 선택해주세요. 선택한 사진은 일부만 처리하지 않아요." : unsupportedCompletely
     ? "선택한 파일 형식을 확인해주세요."
     : parserFailedCompletely
       ? "원본 파일로 다시 시도하면 해결될 수 있어요."
-      : "사진 앱의 위치정보가 없다는 뜻은 아니며, 웹에서 받은 파일 데이터만 기준으로 한 결과예요.";
+      : "사진 앱의 위치정보가 없다는 뜻은 아니에요. ‘내 파일’의 DCIM/Camera 폴더에서 원본을 다시 선택해주세요.";
 
   return (
     <section className="screen screen-empty" aria-labelledby="empty-title">
@@ -163,7 +162,7 @@ function EmptyScreen({ analysis, selectedCount, onRetry, onDemo }) {
           {unsupportedCount > 0 && <p className="is-error"><strong>지원하지 않는 형식</strong> {unsupportedCount}장</p>}
         </div>
         <p className="file-result-note">{resultMessage}</p>
-        <button className="primary-button" type="button" onClick={onRetry}>원본 사진 다시 선택하기</button>
+        <button className="primary-button" type="button" onClick={onRetryOriginals}>내 파일에서 원본 다시 선택하기</button>
         <button className="text-button" type="button" onClick={onDemo}>샘플 지도로 결과 미리보기 <ArrowRight size={16} /></button>
       </div>
     </section>
@@ -376,6 +375,7 @@ export function App() {
   const [selectedCount, setSelectedCount] = useState(0);
   const [processingProgress, setProcessingProgress] = useState(0);
   const objectUrlsRef = useRef([]);
+  const fallbackInputRef = useRef(null);
   useEffect(() => () => objectUrlsRef.current.forEach((url) => URL.revokeObjectURL(url)), []);
 
   const navigate = (nextScreen) => { setScreen(nextScreen); window.scrollTo({ top: 0, behavior: "smooth" }); };
@@ -393,6 +393,7 @@ export function App() {
       if (result.points.length === 0) {
         trackCampaignEvent("travel_map_photo_analysis_empty", {
           journey_source: journeySource,
+          picker_source: result.pickerSource,
           selected_photos: count,
           metadata_missing_photos: result.metadataMissingCount,
           read_failed_photos: result.readFailedCount,
@@ -401,7 +402,7 @@ export function App() {
         navigate("empty");
         return;
       }
-      trackCampaignEvent("travel_map_processing_complete", { journey_source: journeySource, selected_photos: count, valid_gps_photos: result.validPhotoCount, duration_seconds: getAutoDuration(result) });
+      trackCampaignEvent("travel_map_processing_complete", { journey_source: journeySource, picker_source: result.pickerSource, selected_photos: count, valid_gps_photos: result.validPhotoCount, duration_seconds: getAutoDuration(result) });
       navigate("replay");
     } catch (error) {
       window.clearInterval(timer);
@@ -425,15 +426,35 @@ export function App() {
       navigate("empty");
     }
   };
-  const handleFiles = (files) => { trackCampaignEvent("travel_map_photo_select", { journey_source: "photos", selected_photos: files.length }); runProcessing(analyzePhotoFiles(files), files.length, "photos"); };
+  const handleFiles = (files, pickerSource) => {
+    trackCampaignEvent("travel_map_photo_select", { journey_source: "photos", selected_photos: files.length, picker_source: pickerSource });
+    const analysisPromise = analyzePhotoFiles(files).then((result) => ({ ...result, pickerSource }));
+    runProcessing(analysisPromise, files.length, "photos");
+  };
+  const handlePickFiles = async () => {
+    const result = await pickOriginalPhotoFiles(window);
+    if (result.status === "selected" && result.files.length > 0) {
+      handleFiles(result.files, "file_system_access");
+      return;
+    }
+    if (result.status === "unsupported" || result.status === "failed") {
+      fallbackInputRef.current?.click();
+    }
+  };
+  const handleFallbackFiles = (event) => {
+    const files = event.target.files;
+    if (files?.length) handleFiles(files, "legacy_input");
+    event.target.value = "";
+  };
   const handleDemo = () => { trackCampaignEvent("travel_map_demo_start", { journey_source: "demo" }); runProcessing(Promise.resolve(demoJourney), demoJourney.photoCount, "demo", 700); };
 
   return (
     <main className="campaign-page">
+      <input ref={fallbackInputRef} className="visually-hidden" type="file" accept=".jpg,.jpeg,.heic,.heif,.png,.tif,.tiff,.avif,.webp" multiple onChange={handleFallbackFiles} />
       <div className="campaign-stage" data-screen={screen}>
-        {screen === "entry" && <EntryScreen onFiles={handleFiles} onDemo={handleDemo} />}
+        {screen === "entry" && <EntryScreen onPickFiles={handlePickFiles} onDemo={handleDemo} />}
         {screen === "processing" && <ProcessingScreen progress={processingProgress} selectedCount={selectedCount} />}
-        {screen === "empty" && <EmptyScreen analysis={journey} selectedCount={selectedCount} onRetry={() => navigate("entry")} onDemo={handleDemo} />}
+        {screen === "empty" && <EmptyScreen analysis={journey} selectedCount={selectedCount} onRetry={() => navigate("entry")} onRetryOriginals={handlePickFiles} onDemo={handleDemo} />}
         {screen === "replay" && <ReplayScreen journey={journey} onBack={() => navigate("entry")} onNext={() => navigate("recap")} />}
         {screen === "recap" && <RecapScreen journey={journey} onBack={() => navigate("replay")} onNext={() => navigate("demand")} />}
         {screen === "demand" && <DemandScreen journeySource={journey.source} onBack={() => navigate("recap")} />}

--- a/landing/travel-map-campaign/src/analytics.js
+++ b/landing/travel-map-campaign/src/analytics.js
@@ -4,10 +4,16 @@ export { resolveMeasurementId } from "../../src/analytics-contract.js";
 const environment = import.meta.env ?? {};
 const measurementId = resolveMeasurementId(environment);
 const campaignVersion = environment.VITE_CAMPAIGN_VERSION?.trim() || "travel-map-v1";
+const posthogKey = environment.VITE_POSTHOG_KEY?.trim() || "";
+const posthogHost = environment.VITE_POSTHOG_HOST?.trim() || "";
+const capturePosthogLocally = environment.VITE_POSTHOG_CAPTURE_LOCAL === "true";
+const isLocalBrowser = typeof window !== "undefined"
+  && ["localhost", "127.0.0.1"].includes(window.location.hostname);
 const forbiddenParameterPattern = /(email|phone|name|address|message|free.?text)/i;
 const supportedParameters = new Set([
   "journey_source", "selected_photos", "valid_gps_photos", "duration_seconds",
   "metadata_missing_photos", "read_failed_photos", "unsupported_photos",
+  "picker_source",
   "cta_placement", "destination", "store", "format", "result", "error_type",
 ]);
 const supportedEvents = new Set([
@@ -47,15 +53,66 @@ function resolveBrowserTrafficType() {
 
 const trafficType = resolveBrowserTrafficType();
 let gaInitialized = false;
+let posthogInitialization = null;
+
+export const POSTHOG_CAPTURE_CONFIG = Object.freeze({
+  defaults: "2026-05-30",
+  autocapture: false,
+  capture_pageview: false,
+  capture_pageleave: false,
+  disable_session_recording: true,
+  disable_surveys: true,
+  person_profiles: "never",
+  persistence: "memory",
+  advanced_disable_feature_flags: true,
+  advanced_disable_feature_flags_on_first_load: true,
+});
+
+function initializePostHog() {
+  const shouldInitialize = posthogKey
+    && posthogHost
+    && (!isLocalBrowser || capturePosthogLocally)
+    && typeof window !== "undefined";
+
+  if (!shouldInitialize) return null;
+  if (posthogInitialization) return posthogInitialization;
+
+  posthogInitialization = import("posthog-js/dist/module.no-external")
+    .then(({ default: posthog }) => {
+      posthog.init(posthogKey, {
+        ...POSTHOG_CAPTURE_CONFIG,
+        api_host: posthogHost,
+      });
+      posthog.register({
+        ...measurementContext("recap"),
+        campaign_version: campaignVersion,
+        traffic_type: trafficType,
+        $geoip_disable: true,
+      });
+      posthog.capture("$pageview", { $pathname: window.location.pathname });
+      return posthog;
+    })
+    .catch((error) => {
+      if (capturePosthogLocally) {
+        console.warn("PostHog campaign analytics initialization failed.", error);
+      }
+      return null;
+    });
+
+  return posthogInitialization;
+}
 
 export function sanitizeEventProperties(properties = {}) {
   return Object.fromEntries(Object.entries(properties).filter(([key, value]) => (
     supportedParameters.has(key) && !forbiddenParameterPattern.test(key) && isScalar(value)
     && (key !== "journey_source" || ["demo", "photos"].includes(value))
+    && (key !== "picker_source" || ["file_system_access", "legacy_input"].includes(value))
   )));
 }
 
 export function initializeCampaignAnalytics() {
+  void initializePostHog();
+
   if (!measurementId || gaInitialized || typeof window === "undefined"
     || !canCaptureGa(environment, window.location.hostname)) return false;
 
@@ -94,9 +151,12 @@ export function trackCampaignEvent(eventName, properties = {}) {
     window.gtag("event", eventName, eventProperties);
     tracked = true;
   }
-  if (typeof window !== "undefined" && window.posthog?.capture) {
-    window.posthog.capture(eventName, { ...eventProperties, $geoip_disable: true });
+  const posthogClient = initializePostHog();
+  if (posthogClient) {
     tracked = true;
+    void posthogClient.then((posthog) => {
+      posthog?.capture(eventName, { ...eventProperties, $geoip_disable: true });
+    });
   }
   return tracked;
 }

--- a/landing/travel-map-campaign/src/photoPicker.js
+++ b/landing/travel-map-campaign/src/photoPicker.js
@@ -1,0 +1,28 @@
+const PHOTO_EXTENSIONS = [".jpg", ".jpeg", ".heic", ".heif", ".png", ".tif", ".tiff", ".avif", ".webp"];
+
+export function supportsOriginalPhotoPicker(environment = globalThis) {
+  return environment?.isSecureContext === true && typeof environment?.showOpenFilePicker === "function";
+}
+export async function pickOriginalPhotoFiles(environment = globalThis) {
+  if (!supportsOriginalPhotoPicker(environment)) {
+    return { status: "unsupported", files: [] };
+  }
+
+  try {
+    const handles = await environment.showOpenFilePicker({
+      id: "mapmory-recap-original-photos",
+      multiple: true,
+      startIn: "pictures",
+      excludeAcceptAllOption: false,
+      types: [{
+        description: "위치정보가 포함된 원본 사진",
+        accept: { "image/*": PHOTO_EXTENSIONS },
+      }],
+    });
+    const files = await Promise.all(handles.map((handle) => handle.getFile()));
+    return { status: "selected", files };
+  } catch (error) {
+    if (error?.name === "AbortError") return { status: "cancelled", files: [] };
+    return { status: "failed", files: [], error };
+  }
+}

--- a/landing/travel-map-campaign/tests/campaign-config.test.mjs
+++ b/landing/travel-map-campaign/tests/campaign-config.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { APP_ACQUISITION_URL, CAMPAIGN_LANDING_URL, GOOGLE_PLAY_PACKAGE_ID, MAPMORY_DOMAIN_LABEL, MAPMORY_SITE_ORIGIN } from "../src/campaignConfig.js";
-import { initializeCampaignAnalytics, resolveMeasurementId, resolveTrafficType, sanitizeEventProperties, trackCampaignEvent } from "../src/analytics.js";
+import { initializeCampaignAnalytics, POSTHOG_CAPTURE_CONFIG, resolveMeasurementId, resolveTrafficType, sanitizeEventProperties, trackCampaignEvent } from "../src/analytics.js";
 
 test("uses the official Google Play listing for app acquisition", () => {
   const destination = new URL(APP_ACQUISITION_URL);
@@ -51,5 +51,21 @@ test("marks internal campaign traffic without collecting personal fields", () =>
   assert.equal(resolveTrafficType({ search: "?internal=1", storage }), "internal");
   assert.equal(resolveTrafficType({ storage }), "internal");
   assert.equal(resolveTrafficType({ search: "?internal=0", storage }), "external");
-  assert.deepEqual(sanitizeEventProperties({ journey_source: "demo", selected_photos: 5, latitude: 37.5, filename: "private.jpg", email: "private@example.com" }), { journey_source: "demo", selected_photos: 5 });
+  assert.deepEqual(sanitizeEventProperties({ journey_source: "photos", picker_source: "file_system_access", selected_photos: 5, latitude: 37.5, filename: "private.jpg", email: "private@example.com" }), { journey_source: "photos", picker_source: "file_system_access", selected_photos: 5 });
+  assert.deepEqual(sanitizeEventProperties({ journey_source: "photos", picker_source: "unknown" }), { journey_source: "photos" });
+});
+
+test("keeps Recap PostHog anonymous and explicit", () => {
+  assert.deepEqual(POSTHOG_CAPTURE_CONFIG, {
+    defaults: "2026-05-30",
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    disable_session_recording: true,
+    disable_surveys: true,
+    person_profiles: "never",
+    persistence: "memory",
+    advanced_disable_feature_flags: true,
+    advanced_disable_feature_flags_on_first_load: true,
+  });
 });

--- a/landing/travel-map-campaign/tests/journey-data.test.mjs
+++ b/landing/travel-map-campaign/tests/journey-data.test.mjs
@@ -35,6 +35,48 @@ function point({
   };
 }
 
+function createGpsJpeg() {
+  const tiff = Buffer.alloc(128);
+  tiff.write("II", 0, "ascii");
+  tiff.writeUInt16LE(42, 2);
+  tiff.writeUInt32LE(8, 4);
+  tiff.writeUInt16LE(1, 8);
+  tiff.writeUInt16LE(0x8825, 10);
+  tiff.writeUInt16LE(4, 12);
+  tiff.writeUInt32LE(1, 14);
+  tiff.writeUInt32LE(26, 18);
+  tiff.writeUInt32LE(0, 22);
+
+  tiff.writeUInt16LE(4, 26);
+  const writeEntry = (offset, tag, type, count, value) => {
+    tiff.writeUInt16LE(tag, offset);
+    tiff.writeUInt16LE(type, offset + 2);
+    tiff.writeUInt32LE(count, offset + 4);
+    if (type === 2) {
+      tiff.write(value, offset + 8, "ascii");
+    } else {
+      tiff.writeUInt32LE(value, offset + 8);
+    }
+  };
+  writeEntry(28, 1, 2, 2, "N\0");
+  writeEntry(40, 2, 5, 3, 80);
+  writeEntry(52, 3, 2, 2, "E\0");
+  writeEntry(64, 4, 5, 3, 104);
+  tiff.writeUInt32LE(0, 76);
+
+  const writeRationals = (offset, values) => values.forEach(([numerator, denominator], index) => {
+    tiff.writeUInt32LE(numerator, offset + index * 8);
+    tiff.writeUInt32LE(denominator, offset + index * 8 + 4);
+  });
+  writeRationals(80, [[37, 1], [33, 1], [0, 1]]);
+  writeRationals(104, [[126, 1], [58, 1], [0, 1]]);
+
+  const exifPayload = Buffer.concat([Buffer.from("Exif\0\0", "binary"), tiff]);
+  const app1Length = Buffer.alloc(2);
+  app1Length.writeUInt16BE(exifPayload.length + 2);
+  return Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe1]), app1Length, exifPayload, Buffer.from([0xff, 0xd9])]);
+}
+
 test("accepts an image extension even when the browser leaves MIME blank", async () => {
   const bytes = await readFile(fixturePath);
   const file = new File([bytes], "team-jeju-coast.jpg", { type: "" });
@@ -57,6 +99,19 @@ test("normalizes EXIF and XMP GPS coordinate formats", () => {
   assert.equal(normalizeGpsCoordinate("37.5665", "N", "latitude"), 37.5665);
   assert.equal(normalizeGpsCoordinate(122.4194, "W", "longitude"), -122.4194);
   assert.equal(Number.isNaN(normalizeGpsCoordinate("not-a-coordinate", "", "latitude")), true);
+});
+
+test("reads GPS coordinates embedded in an original JPEG", async () => {
+  const file = new File([createGpsJpeg()], "original-with-gps.jpg", { type: "image/jpeg" });
+  const result = await analyzePhotoFiles([file]);
+
+  assert.equal(result.validPhotoCount, 1);
+  assert.equal(result.metadataReadCount, 1);
+  assert.equal(result.missingGpsCount, 0);
+  assert.equal(result.points[0].lat, 37.55);
+  assert.ok(Math.abs(result.points[0].lng - 126.96666666666667) < 1e-10);
+
+  result.objectUrls.forEach((url) => URL.revokeObjectURL(url));
 });
 
 test("keeps the sample and share video short", () => {

--- a/landing/travel-map-campaign/tests/photo-picker.test.mjs
+++ b/landing/travel-map-campaign/tests/photo-picker.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { pickOriginalPhotoFiles, supportsOriginalPhotoPicker } from "../src/photoPicker.js";
+
+test("uses the original file picker only in a secure supported context", () => {
+  assert.equal(supportsOriginalPhotoPicker({ isSecureContext: true, showOpenFilePicker() {} }), true);
+  assert.equal(supportsOriginalPhotoPicker({ isSecureContext: false, showOpenFilePicker() {} }), false);
+  assert.equal(supportsOriginalPhotoPicker({ isSecureContext: true }), false);
+});
+
+test("reads every selected original file from file system handles", async () => {
+  const files = [{ name: "first.jpg" }, { name: "second.heic" }];
+  let pickerOptions;
+  const result = await pickOriginalPhotoFiles({
+    isSecureContext: true,
+    async showOpenFilePicker(options) {
+      pickerOptions = options;
+      return files.map((file) => ({ getFile: async () => file }));
+    },
+  });
+
+  assert.equal(result.status, "selected");
+  assert.deepEqual(result.files, files);
+  assert.equal(pickerOptions.multiple, true);
+  assert.equal(pickerOptions.startIn, "pictures");
+  assert.ok(pickerOptions.types[0].accept["image/*"].includes(".jpg"));
+});
+
+test("treats picker cancellation separately from an unsupported browser", async () => {
+  const result = await pickOriginalPhotoFiles({
+    isSecureContext: true,
+    async showOpenFilePicker() {
+      throw new DOMException("cancelled", "AbortError");
+    },
+  });
+
+  assert.equal(result.status, "cancelled");
+  assert.deepEqual(result.files, []);
+});


### PR DESCRIPTION
Recap에서 Android 사진 선택기가 GPS EXIF를 가리는 문제를 완화하기 위해 HTTPS 원본 파일 선택 API를 우선 사용하고, 미지원 환경에는 기존 입력을 폴백으로 유지합니다. GPS 포함 JPEG 회귀 테스트와 선택기 분기 테스트를 추가했습니다. Recap PostHog를 독립 초기화하고 picker_source 기준 품질 진단을 추가했으며, Landing CodePipeline artifact 버킷을 techcourse-project-2026-artifact로 수정했습니다. 검증: Recap 테스트 73개 통과, landing 분석·배포 테스트 19개 통과(18개 Linux 전용 fixture skip), /recap/ 프로덕션 빌드 성공. 실제 배포 및 PostHog 대시보드 저장은 수행하지 않았습니다.